### PR TITLE
Make clippy happy

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -4,12 +4,12 @@ use ctype::isdigit;
 use entity_data;
 
 fn isxdigit(ch: &u8) -> bool {
-    (*ch >= '0' as u8 && *ch <= '9' as u8) || (*ch >= 'a' as u8 && *ch <= 'f' as u8) ||
-    (*ch >= 'A' as u8 && *ch <= 'F' as u8)
+    (*ch >= b'0' && *ch <= b'9') || (*ch >= b'a' && *ch <= b'f') ||
+    (*ch >= b'A' && *ch <= b'F')
 }
 
 pub fn unescape(text: &str) -> Option<(String, usize)> {
-    if text.len() >= 3 && text.as_bytes()[0] == '#' as u8 {
+    if text.len() >= 3 && text.as_bytes()[0] == b'#' {
         let mut codepoint: u32 = 0;
         let mut i = 0;
 
@@ -21,8 +21,8 @@ pub fn unescape(text: &str) -> Option<(String, usize)> {
                 i += 1;
             }
             i - 1
-        } else if text.as_bytes()[1] == 'x' as u8 ||
-                                   text.as_bytes()[1] == 'X' as u8 {
+        } else if text.as_bytes()[1] == b'x' ||
+                                   text.as_bytes()[1] == b'X' {
             i = 2;
             while i < text.len() && isxdigit(&text.as_bytes()[i]) {
                 codepoint = (codepoint * 16) + ((text.as_bytes()[i] as u32 | 32) % 39 - 9);
@@ -34,7 +34,7 @@ pub fn unescape(text: &str) -> Option<(String, usize)> {
             0
         };
 
-        if num_digits >= 1 && num_digits <= 8 && i < text.len() && text.as_bytes()[i] == ';' as u8 {
+        if num_digits >= 1 && num_digits <= 8 && i < text.len() && text.as_bytes()[i] == b';' {
             if codepoint == 0 || (codepoint >= 0xD800 && codepoint <= 0xE000) ||
                codepoint >= 0x110000 {
                 codepoint = 0xFFFD;
@@ -45,11 +45,11 @@ pub fn unescape(text: &str) -> Option<(String, usize)> {
 
     let size = min(text.len(), entity_data::MAX_LENGTH);
     for i in entity_data::MIN_LENGTH..size {
-        if text.as_bytes()[i] == ' ' as u8 {
+        if text.as_bytes()[i] == b' ' {
             return None;
         }
 
-        if text.as_bytes()[i] == ';' as u8 {
+        if text.as_bytes()[i] == b';' {
             return lookup(&text[..i]).map(|e| (e.to_string(), i + 1));
         }
     }
@@ -93,7 +93,7 @@ pub fn unescape_html(src: &str) -> String {
 
     while i < size {
         let org = i;
-        while i < size && src.as_bytes()[i] != '&' as u8 {
+        while i < size && src.as_bytes()[i] != b'&' {
             i += 1;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ fn main() {
         ext_superscript: exts.remove("superscript"),
     };
 
-    assert!(exts.len() == 0);
+    assert!(exts.is_empty());
 
     let mut buf = vec![];
 

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -242,39 +242,39 @@ pub struct NodeHtmlBlock {
 impl NodeValue {
     /// Indicates whether this node is a block node or inline node.
     pub fn block(&self) -> bool {
-        match self {
-            &NodeValue::Document |
-            &NodeValue::BlockQuote |
-            &NodeValue::List(..) |
-            &NodeValue::Item(..) |
-            &NodeValue::CodeBlock(..) |
-            &NodeValue::HtmlBlock(..) |
-            &NodeValue::Paragraph |
-            &NodeValue::Heading(..) |
-            &NodeValue::ThematicBreak |
-            &NodeValue::Table(..) |
-            &NodeValue::TableRow(..) |
-            &NodeValue::TableCell => true,
+        match *self {
+            NodeValue::Document |
+            NodeValue::BlockQuote |
+            NodeValue::List(..) |
+            NodeValue::Item(..) |
+            NodeValue::CodeBlock(..) |
+            NodeValue::HtmlBlock(..) |
+            NodeValue::Paragraph |
+            NodeValue::Heading(..) |
+            NodeValue::ThematicBreak |
+            NodeValue::Table(..) |
+            NodeValue::TableRow(..) |
+            NodeValue::TableCell => true,
             _ => false,
         }
     }
 
     #[doc(hidden)]
     pub fn accepts_lines(&self) -> bool {
-        match self {
-            &NodeValue::Paragraph |
-            &NodeValue::Heading(..) |
-            &NodeValue::CodeBlock(..) => true,
+        match *self {
+            NodeValue::Paragraph |
+            NodeValue::Heading(..) |
+            NodeValue::CodeBlock(..) => true,
             _ => false,
         }
     }
 
     /// Indicates whether this node may contain inlines.
     pub fn contains_inlines(&self) -> bool {
-        match self {
-            &NodeValue::Paragraph |
-            &NodeValue::Heading(..) |
-            &NodeValue::TableCell => true,
+        match *self {
+            NodeValue::Paragraph |
+            NodeValue::Heading(..) |
+            NodeValue::TableCell => true,
             _ => false,
         }
     }
@@ -283,8 +283,8 @@ impl NodeValue {
     ///
     /// Convenience method.
     pub fn text(&mut self) -> Option<&mut String> {
-        match self {
-            &mut NodeValue::Text(ref mut t) => Some(t),
+        match *self {
+            NodeValue::Text(ref mut t) => Some(t),
             _ => None,
         }
     }
@@ -347,7 +347,7 @@ pub fn last_child_is_open<'a>(node: &'a AstNode<'a>) -> bool {
 
 #[doc(hidden)]
 pub fn can_contain_type<'a>(node: &'a AstNode<'a>, child: &NodeValue) -> bool {
-    if let &NodeValue::Document = child {
+    if let NodeValue::Document = *child {
         return false;
     }
 
@@ -356,15 +356,15 @@ pub fn can_contain_type<'a>(node: &'a AstNode<'a>, child: &NodeValue) -> bool {
         NodeValue::BlockQuote |
         NodeValue::Item(..) => {
             child.block() &&
-            match child {
-                &NodeValue::Item(..) => false,
+            match *child {
+                NodeValue::Item(..) => false,
                 _ => true,
             }
         }
 
         NodeValue::List(..) => {
-            match child {
-                &NodeValue::Item(..) => true,
+            match *child {
+                NodeValue::Item(..) => true,
                 _ => false,
             }
         }
@@ -377,29 +377,29 @@ pub fn can_contain_type<'a>(node: &'a AstNode<'a>, child: &NodeValue) -> bool {
         NodeValue::Image(..) => !child.block(),
 
         NodeValue::Table(..) => {
-            match child {
-                &NodeValue::TableRow(..) => true,
+            match *child {
+                NodeValue::TableRow(..) => true,
                 _ => false,
             }
         }
 
         NodeValue::TableRow(..) => {
-            match child {
-                &NodeValue::TableCell => true,
+            match *child {
+                NodeValue::TableCell => true,
                 _ => false,
             }
         }
 
         NodeValue::TableCell => {
-            match child {
-                &NodeValue::Text(..) |
-                &NodeValue::Code(..) |
-                &NodeValue::Emph |
-                &NodeValue::Strong |
-                &NodeValue::Link(..) |
-                &NodeValue::Image(..) |
-                &NodeValue::Strikethrough |
-                &NodeValue::HtmlInline(..) => true,
+            match *child {
+                NodeValue::Text(..) |
+                NodeValue::Code(..) |
+                NodeValue::Emph |
+                NodeValue::Strong |
+                NodeValue::Link(..) |
+                NodeValue::Image(..) |
+                NodeValue::Strikethrough |
+                NodeValue::HtmlInline(..) => true,
                 _ => false,
             }
         }
@@ -415,9 +415,9 @@ pub fn ends_with_blank_line<'a>(node: &'a AstNode<'a>) -> bool {
         if cur.data.borrow().last_line_blank {
             return true;
         }
-        match &cur.data.borrow().value {
-            &NodeValue::List(..) |
-            &NodeValue::Item(..) => it = cur.last_child(),
+        match cur.data.borrow().value {
+            NodeValue::List(..) |
+            NodeValue::Item(..) => it = cur.last_child(),
             _ => it = None,
         };
     }

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -8,9 +8,9 @@ pub fn try_opening_block<'a, 'o>(parser: &mut Parser<'a, 'o>,
                                  container: &'a AstNode<'a>,
                                  line: &str)
                                  -> Option<(&'a AstNode<'a>, bool)> {
-    let aligns = match &container.data.borrow().value {
-        &NodeValue::Paragraph => None,
-        &NodeValue::Table(ref aligns) => Some(aligns.clone()),
+    let aligns = match container.data.borrow().value {
+        NodeValue::Paragraph => None,
+        NodeValue::Table(ref aligns) => Some(aligns.clone()),
         _ => return None,
     };
 
@@ -41,8 +41,8 @@ pub fn try_opening_header<'a, 'o>(parser: &mut Parser<'a, 'o>,
 
     let mut alignments = vec![];
     for cell in marker_row {
-        let left = cell.len() > 0 && cell.as_bytes()[0] == ':' as u8;
-        let right = cell.len() > 0 && cell.as_bytes()[cell.len() - 1] == ':' as u8;
+        let left = !cell.is_empty() && cell.as_bytes()[0] == b':';
+        let right = !cell.is_empty() && cell.as_bytes()[cell.len() - 1] == b':';
         alignments.push(if left && right {
             TableAlignment::Center
         } else if left {
@@ -72,7 +72,7 @@ pub fn try_opening_header<'a, 'o>(parser: &mut Parser<'a, 'o>,
 
 pub fn try_opening_row<'a, 'o>(parser: &mut Parser<'a, 'o>,
                                container: &'a AstNode<'a>,
-                               alignments: &Vec<TableAlignment>,
+                               alignments: &[TableAlignment],
                                line: &str)
                                -> Option<(&'a AstNode<'a>, bool)> {
     if parser.blank {
@@ -110,7 +110,7 @@ fn row(string: &str) -> Option<Vec<String>> {
     let mut v = vec![];
     let mut offset = 0;
 
-    if len > 0 && string.as_bytes()[0] == '|' as u8 {
+    if len > 0 && string.as_bytes()[0] == b'|' {
         offset += 1;
     }
 
@@ -137,7 +137,7 @@ fn row(string: &str) -> Option<Vec<String>> {
         }
     }
 
-    if offset != len || v.len() == 0 {
+    if offset != len || v.is_empty() {
         None
     } else {
         Some(v)

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -155,7 +155,7 @@ pub fn setext_heading_line(line: &str) -> Option<SetextChar> {
     }
 
     if is_match(&RE, line) {
-        if line.as_bytes()[0] == '=' as u8 {
+        if line.as_bytes()[0] == b'=' {
             Some(SetextChar::Equals)
         } else {
             Some(SetextChar::Hyphen)

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -7,7 +7,7 @@ pub fn unescape(v: &mut String) {
     let mut sz = v.len();
 
     while r < sz {
-        if v.as_bytes()[r] == '\\' as u8 && r + 1 < sz && ispunct(&v.as_bytes()[r + 1]) {
+        if v.as_bytes()[r] == b'\\' && r + 1 < sz && ispunct(&v.as_bytes()[r + 1]) {
             v.remove(r);
             sz -= 1;
         }
@@ -22,7 +22,7 @@ pub fn clean_autolink(url: &str, kind: AutolinkType) -> String {
     let mut url_string = url.to_string();
     trim(&mut url_string);
 
-    if url_string.len() == 0 {
+    if url_string.is_empty() {
         return url_string;
     }
 
@@ -59,7 +59,7 @@ pub fn remove_trailing_blank_lines(line: &mut String) {
     loop {
         let c = line.as_bytes()[i];
 
-        if c != ' ' as u8 && c != '\t' as u8 && !is_line_end_char(&c) {
+        if c != b' ' && c != b'\t' && !is_line_end_char(&c) {
             break;
         }
 
@@ -84,15 +84,15 @@ pub fn remove_trailing_blank_lines(line: &mut String) {
 }
 
 pub fn is_line_end_char(ch: &u8) -> bool {
-    match ch {
-        &10 | &13 => true,
+    match *ch {
+        10 | 13 => true,
         _ => false,
     }
 }
 
 pub fn is_space_or_tab(ch: &u8) -> bool {
-    match ch {
-        &9 | &32 => true,
+    match *ch {
+        9 | 32 => true,
         _ => false,
     }
 }
@@ -103,7 +103,7 @@ pub fn chop_trailing_hashtags(line: &mut String) {
     let orig_n = line.len() - 1;
     let mut n = orig_n;
 
-    while line.as_bytes()[n] == '#' as u8 {
+    while line.as_bytes()[n] == b'#' {
         if n == 0 {
             return;
         }
@@ -158,7 +158,7 @@ pub fn clean_url(url: &str) -> String {
         return String::new();
     }
 
-    let mut b = if url.as_bytes()[0] == '<' as u8 && url.as_bytes()[url_len - 1] == '>' as u8 {
+    let mut b = if url.as_bytes()[0] == b'<' && url.as_bytes()[url_len - 1] == b'>' {
         entity::unescape_html(&url[1..url_len - 1])
     } else {
         entity::unescape_html(url)
@@ -177,9 +177,9 @@ pub fn clean_title(title: &str) -> String {
     let first = title.as_bytes()[0];
     let last = title.as_bytes()[title_len - 1];
 
-    let mut b = if (first == '\'' as u8 && last == '\'' as u8) ||
-                   (first == '(' as u8 && last == ')' as u8) ||
-                   (first == '"' as u8 && last == '"' as u8) {
+    let mut b = if (first == b'\'' && last == b'\'') ||
+                   (first == b'(' && last == b')') ||
+                   (first == b'"' && last == b'"') {
         entity::unescape_html(&title[1..title_len - 1])
     } else {
         entity::unescape_html(title)


### PR DESCRIPTION
This resolves all the important stuff clippy complained about. A few minor lint suggestions are not addressed (combining match arms with the same right side for examples). A lot of diff churn because I ran `s/'(.+?) as u8/b'$1'` without making a separate commit. Sorry.