### PR TITLE
Call postprocess_text_node regardless of whether node has next_sibling

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1103,10 +1103,12 @@ impl<'a, 'o> Parser<'a, 'o> {
             loop {
                 match n.data.borrow_mut().value {
                     NodeValue::Text(ref mut root) => {
-                        self.postprocess_text_node(n, root);
                         let ns = match n.next_sibling() {
                             Some(ns) => ns,
-                            _ => break
+                            _ => {
+                                self.postprocess_text_node(n, root);
+                                break;
+                            }
                         };
 
                         match ns.data.borrow().value {
@@ -1114,7 +1116,10 @@ impl<'a, 'o> Parser<'a, 'o> {
                                 *root += adj;
                                 ns.detach();
                             }
-                            _ => break,
+                            _ => {
+                                self.postprocess_text_node(n, root);
+                                break;
+                            }
                         }
                     }
                     NodeValue::Link(..) |

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1103,12 +1103,10 @@ impl<'a, 'o> Parser<'a, 'o> {
             loop {
                 match n.data.borrow_mut().value {
                     NodeValue::Text(ref mut root) => {
+                        self.postprocess_text_node(n, root);
                         let ns = match n.next_sibling() {
                             Some(ns) => ns,
-                            _ => {
-                                self.postprocess_text_node(n, root);
-                                break;
-                            }
+                            _ => break
                         };
 
                         match ns.data.borrow().value {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -423,6 +423,19 @@ fn autolink_scheme() {
 }
 
 #[test]
+fn autolink_scheme_multiline() {
+    html_opts(
+        concat!("https://google.com/search\nhttps://www.google.com/maps"),
+        concat!(
+            "<p><a href=\"https://google.com/search\">https://google.\
+                       com/search</a>\n<a href=\"https://www.google.com/maps\">\
+                       https://www.google.com/maps</a></p>\n"
+        ),
+        |opts| opts.ext_autolink = true,
+    );
+}
+
+#[test]
 fn tagfilter() {
     html_opts(concat!("hi <xmp> ok\n", "\n", "<xmp>\n"),
               concat!("<p>hi &lt;xmp> ok</p>\n", "&lt;xmp>\n"),


### PR DESCRIPTION
@kivikakk I'm encountering some unusual behavior with autolinking URLs wherein – in a container node containing _multiple_ lines – only the links on the final line are autolinked.

To demonstrate, I've added [a test](https://github.com/kivikakk/comrak/compare/master...zeantsoi:autolink-multiline?expand=1#diff-94ae0e030d77f337226703a7b6631921R426) which fails with the following:

    failures:

    ---- tests::autolink_scheme_multiline stdout ----
    Running regular test
    Got:
    ==============================
    <p>https://google.com/search
    <a href="https://www.google.com/maps">https://www.google.com/maps</a></p>

    ==============================

    Expected:
    ==============================
    <p><a href="https://google.com/search">https://google.com/search</a>
    <a href="https://www.google.com/maps">https://www.google.com/maps</a></p>

    ==============================

    thread 'tests::autolink_scheme_multiline' panicked at 'assertion failed: `(left == right)` (left: `"<p>https://google.com/search\n<a href=\"https://www.google.com/maps\">https://www.google.com/maps</a></p>\n"`, right: `"<p><a href=\"https://google.com/search\">https://google.com/search</a>\n<a href=\"https://www.google.com/maps\">https://www.google.com/maps</a></p>\n"`)', src/tests.rs:19
    note: Run with `RUST_BACKTRACE=1` for a backtrace.


    failures:
        tests::autolink_scheme_multiline

    test result: FAILED. 28 passed; 1 failed; 0 ignored; 0 measured

I've isolated where I think the issue is stemming from and validated that the added test passes *without* breaking any existing tests.

cc: @SSJohns