### PR TITLE
Fix for inter-unicode slices and indexing

### DIFF
--- a/src/parser/autolink.rs
+++ b/src/parser/autolink.rs
@@ -75,7 +75,7 @@ fn www_match<'a>(
         return None;
     }
 
-    if contents.len() - i < 4 || &contents[i..i + 4] != "www." {
+    if !contents[i..].starts_with("www.") {
         return None;
     }
 

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -720,7 +720,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
             };
             let endall = endtitle + scanners::spacechars(&self.input[endtitle..]).unwrap_or(0);
 
-            if self.input.as_bytes()[endall] == b')' {
+            if endall < self.input.len() && self.input.as_bytes()[endall] == b')' {
                 self.pos = endall + 1;
                 let url = strings::clean_url(&self.input[starturl..endurl]);
                 let title = strings::clean_title(&self.input[starttitle..endtitle]);


### PR DESCRIPTION
There was an error with slices in autolink where a unicode character would cause the parser to panic when it was a multi-character entity. For instance `[ww𨭎` covers 4 spaces and the line in autolink would try to slice into that. 

The change in inlines.rs is just a bounds check. All test still pass.