### PR TITLE
String->Vec<u8> optimisations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ entities = "1.0.0"
 unicode_categories = "0.1.1"
 clap = { version = "2.22.2", optional = true }
 clippy = { version = "~0.0.123", optional = true }
+twoway = "0.1.3"
 
 [features]
 default = ["clap"]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ let arena = Arena::new();
 
 let root = parse_document(
     &arena,
-    b"This is my input.\n\n1. Also my input.\n2. Certainly my input.\n",
+    "This is my input.\n\n1. Also my input.\n2. Certainly my input.\n",
     &ComrakOptions::default());
 
 fn iter_nodes<'a, F>(node: &'a AstNode<'a>, f: &F)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ let arena = Arena::new();
 
 let root = parse_document(
     &arena,
-    "This is my input.\n\n1. Also my input.\n2. Certainly my input.\n",
+    b"This is my input.\n\n1. Also my input.\n2. Certainly my input.\n",
     &ComrakOptions::default());
 
 fn iter_nodes<'a, F>(node: &'a AstNode<'a>, f: &F)
@@ -74,7 +74,8 @@ fn iter_nodes<'a, F>(node: &'a AstNode<'a>, f: &F)
 iter_nodes(root, &|node| {
     match &mut node.data.borrow_mut().value {
         &mut NodeValue::Text(ref mut text) => {
-            *text = text.replace("my", "your");
+            let orig = std::mem::replace(text, vec![]);
+            *text = String::from_utf8(orig).unwrap().replace("my", "your").as_bytes().to_vec();
         }
         _ => (),
     }

--- a/src/arena_tree.rs
+++ b/src/arena_tree.rs
@@ -1,5 +1,6 @@
-/*! 
-  Included from https://github.com/SimonSapin/rust-forest/blob/5783c8be8680b84c0438638bdee07d4e4aca40ac/arena-tree/lib.rs.
+/*!
+  Included from https://github.com/SimonSapin/rust-forest/blob/
+  5783c8be8680b84c0438638bdee07d4e4aca40ac/arena-tree/lib.rs.
   MIT license (per Cargo.toml).
 
 A DOM-like tree data structure based on `&Node` references.
@@ -282,7 +283,7 @@ impl<'a, T> Iterator for Descendants<'a, T> {
             match self.0.next() {
                 Some(NodeEdge::Start(node)) => return Some(node),
                 Some(NodeEdge::End(_)) => {}
-                None => return None
+                None => return None,
             }
         }
     }
@@ -353,12 +354,14 @@ macro_rules! traverse_iterator {
 }
 
 traverse_iterator! {
-    #[doc = "An iterator of the start and end edges of a given node and its descendants, in tree order."]
+    #[doc = "An iterator of the start and end edges of a given
+    node and its descendants, in tree order."]
     Traverse: first_child, next_sibling
 }
 
 traverse_iterator! {
-    #[doc = "An iterator of the start and end edges of a given node and its descendants, in reverse tree order."]
+    #[doc = "An iterator of the start and end edges of a given
+    node and its descendants, in reverse tree order."]
     ReverseTraverse: last_child, previous_sibling
 }
 
@@ -384,26 +387,27 @@ fn it_works() {
             arena.alloc(Node::new((new_counter, DropTracker(&drop_counter))))
         };
 
-        let a = new();  // 1
-        a.append(new());  // 2
-        a.append(new());  // 3
-        a.prepend(new());  // 4
-        let b = new();  // 5
+        let a = new(); // 1
+        a.append(new()); // 2
+        a.append(new()); // 3
+        a.prepend(new()); // 4
+        let b = new(); // 5
         b.append(a);
-        a.insert_before(new());  // 6
-        a.insert_before(new());  // 7
-        a.insert_after(new());  // 8
-        a.insert_after(new());  // 9
-        let c = new();  // 10
+        a.insert_before(new()); // 6
+        a.insert_before(new()); // 7
+        a.insert_after(new()); // 8
+        a.insert_after(new()); // 9
+        let c = new(); // 10
         b.append(c);
 
         assert_eq!(drop_counter.get(), 0);
         c.previous_sibling.get().unwrap().detach();
         assert_eq!(drop_counter.get(), 0);
 
-        assert_eq!(b.descendants().map(|node| node.data.0).collect::<Vec<_>>(), [
-            5, 6, 7, 1, 4, 2, 3, 9, 10
-        ]);
+        assert_eq!(
+            b.descendants().map(|node| node.data.0).collect::<Vec<_>>(),
+            [5, 6, 7, 1, 4, 2, 3, 9, 10]
+        );
     }
 
     assert_eq!(drop_counter.get(), 10);

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -3,6 +3,7 @@ use ctype::isdigit;
 use entities::ENTITIES;
 use std::char;
 use std::cmp::min;
+use std::str;
 
 pub const ENTITY_MIN_LENGTH: usize = 2;
 pub const ENTITY_MAX_LENGTH: usize = 31;
@@ -11,24 +12,24 @@ fn isxdigit(ch: &u8) -> bool {
     (*ch >= b'0' && *ch <= b'9') || (*ch >= b'a' && *ch <= b'f') || (*ch >= b'A' && *ch <= b'F')
 }
 
-pub fn unescape(text: &str) -> Option<(String, usize)> {
-    if text.len() >= 3 && text.as_bytes()[0] == b'#' {
+pub fn unescape(text: &[u8]) -> Option<(Vec<u8>, usize)> {
+    if text.len() >= 3 && text[0] == b'#' {
         let mut codepoint: u32 = 0;
         let mut i = 0;
 
-        let num_digits = if isdigit(text.as_bytes()[1]) {
+        let num_digits = if isdigit(text[1]) {
             i = 1;
-            while i < text.len() && isdigit(text.as_bytes()[i]) {
-                codepoint = (codepoint * 10) + (text.as_bytes()[i] as u32 - '0' as u32);
-                codepoint = min(codepoint, 0x110000);
+            while i < text.len() && isdigit(text[i]) {
+                codepoint = (codepoint * 10) + (text[i] as u32 - '0' as u32);
+                codepoint = min(codepoint, 0x11_0000);
                 i += 1;
             }
             i - 1
-        } else if text.as_bytes()[1] == b'x' || text.as_bytes()[1] == b'X' {
+        } else if text[1] == b'x' || text[1] == b'X' {
             i = 2;
-            while i < text.len() && isxdigit(&text.as_bytes()[i]) {
-                codepoint = (codepoint * 16) + ((text.as_bytes()[i] as u32 | 32) % 39 - 9);
-                codepoint = min(codepoint, 0x110000);
+            while i < text.len() && isxdigit(&text[i]) {
+                codepoint = (codepoint * 16) + ((text[i] as u32 | 32) % 39 - 9);
+                codepoint = min(codepoint, 0x11_0000);
                 i += 1;
             }
             i - 2
@@ -36,14 +37,14 @@ pub fn unescape(text: &str) -> Option<(String, usize)> {
             0
         };
 
-        if num_digits >= 1 && num_digits <= 8 && i < text.len() && text.as_bytes()[i] == b';' {
+        if num_digits >= 1 && num_digits <= 8 && i < text.len() && text[i] == b';' {
             if codepoint == 0 || (codepoint >= 0xD800 && codepoint <= 0xE000) ||
                 codepoint >= 0x110000
             {
                 codepoint = 0xFFFD;
             }
             return Some((
-                char::from_u32(codepoint).unwrap_or('\u{FFFD}').to_string(),
+                char::from_u32(codepoint).unwrap_or('\u{FFFD}').to_string().into_bytes(),
                 i + 1,
             ));
         }
@@ -51,46 +52,46 @@ pub fn unescape(text: &str) -> Option<(String, usize)> {
 
     let size = min(text.len(), ENTITY_MAX_LENGTH);
     for i in ENTITY_MIN_LENGTH..size {
-        if text.as_bytes()[i] == b' ' {
+        if text[i] == b' ' {
             return None;
         }
 
-        if text.as_bytes()[i] == b';' {
-            return lookup(&text[..i]).map(|e| (e.to_string(), i + 1));
+        if text[i] == b';' {
+            return lookup(&text[..i]).map(|e| (e.to_vec(), i + 1));
         }
     }
 
     None
 }
 
-fn lookup(text: &str) -> Option<&str> {
-    let entity_str = format!("&{};", text);
+fn lookup(text: &[u8]) -> Option<&[u8]> {
+    let entity_str = format!("&{};", unsafe {str::from_utf8_unchecked(text) });
 
     let entity = ENTITIES.iter().find(|e| e.entity == entity_str);
 
     match entity {
-        Some(e) => Some(e.characters),
+        Some(e) => Some(e.characters.as_bytes()),
         None => None,
     }
 }
 
-pub fn unescape_html(src: &str) -> String {
+pub fn unescape_html(src: &[u8]) -> Vec<u8> {
     let size = src.len();
     let mut i = 0;
-    let mut v = String::with_capacity(size);
+    let mut v = Vec::with_capacity(size);
 
     while i < size {
         let org = i;
-        while i < size && src.as_bytes()[i] != b'&' {
+        while i < size && src[i] != b'&' {
             i += 1;
         }
 
         if i > org {
             if org == 0 && i >= size {
-                return src.to_string();
+                return src.to_vec();
             }
 
-            v += &src[org..i];
+            v.extend_from_slice(&src[org..i]);
         }
 
         if i >= size {
@@ -100,10 +101,10 @@ pub fn unescape_html(src: &str) -> String {
         i += 1;
         match unescape(&src[i..]) {
             Some((chs, size)) => {
-                v += &chs;
+                v.extend_from_slice(&chs);
                 i += size;
             }
-            None => v.push('&'),
+            None => v.push(b'&'),
         }
     }
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -108,18 +108,17 @@ fn tagfilter(literal: &[u8]) -> bool {
 }
 
 fn tagfilter_block(input: &[u8], o: &mut Write) -> io::Result<()> {
-    let src = input;
-    let size = src.len();
+    let size = input.len();
     let mut i = 0;
 
     while i < size {
         let org = i;
-        while i < size && src[i] != b'<' {
+        while i < size && input[i] != b'<' {
             i += 1;
         }
 
         if i > org {
-            try!(o.write_all(&src[org..i]));
+            try!(o.write_all(&input[org..i]));
         }
 
         if i >= size {
@@ -154,25 +153,24 @@ impl<'o> HtmlFormatter<'o> {
     }
 
     fn escape(&mut self, buffer: &[u8]) -> io::Result<()> {
-        let src = buffer;
-        let size = src.len();
+        let size = buffer.len();
         let mut i = 0;
 
         while i < size {
             let org = i;
-            while i < size && !NEEDS_ESCAPED[src[i] as usize] {
+            while i < size && !NEEDS_ESCAPED[buffer[i] as usize] {
                 i += 1;
             }
 
             if i > org {
-                try!(self.output.write_all(&src[org..i]));
+                try!(self.output.write_all(&buffer[org..i]));
             }
 
             if i >= size {
                 break;
             }
 
-            match src[i] as char {
+            match buffer[i] as char {
                 '"' => {
                     try!(self.output.write_all(b"&quot;"));
                 }
@@ -208,32 +206,31 @@ impl<'o> HtmlFormatter<'o> {
             };
         }
 
-        let src = buffer;
-        let size = src.len();
+        let size = buffer.len();
         let mut i = 0;
 
         while i < size {
             let org = i;
-            while i < size && HREF_SAFE[src[i] as usize] {
+            while i < size && HREF_SAFE[buffer[i] as usize] {
                 i += 1;
             }
 
             if i > org {
-                try!(self.output.write_all(&src[org..i]));
+                try!(self.output.write_all(&buffer[org..i]));
             }
 
             if i >= size {
                 break;
             }
 
-            match src[i] as char {
+            match buffer[i] as char {
                 '&' => {
                     try!(self.output.write_all(b"&amp;"));
                 }
                 '\'' => {
                     try!(self.output.write_all(b"&#x27;"));
                 }
-                _ => try!(write!(self.output, "%{:02X}", src[i])),
+                _ => try!(write!(self.output, "%{:02X}", buffer[i])),
             }
 
             i += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! let root = parse_document(
 //!     &arena,
-//!     b"This is my input.\n\n1. Also my input.\n2. Certainly my input.\n",
+//!     "This is my input.\n\n1. Also my input.\n2. Certainly my input.\n",
 //!     &ComrakOptions::default());
 //!
 //! fn iter_nodes<'a, F>(node: &'a AstNode<'a>, f: &F)
@@ -107,7 +107,7 @@ use typed_arena::Arena;
 /// See the documentation of the crate root for an example.
 pub fn markdown_to_html(md: &str, options: &ComrakOptions) -> String {
     let arena = Arena::new();
-    let root = parse_document(&arena, md.as_bytes(), options);
+    let root = parse_document(&arena, md, options);
     let mut s = Vec::new();
     format_html(root, options, &mut s).unwrap();
     String::from_utf8(s).unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! let root = parse_document(
 //!     &arena,
-//!     "This is my input.\n\n1. Also my input.\n2. Certainly my input.\n",
+//!     b"This is my input.\n\n1. Also my input.\n2. Certainly my input.\n",
 //!     &ComrakOptions::default());
 //!
 //! fn iter_nodes<'a, F>(node: &'a AstNode<'a>, f: &F)
@@ -42,7 +42,8 @@
 //! iter_nodes(root, &|node| {
 //!     match &mut node.data.borrow_mut().value {
 //!         &mut NodeValue::Text(ref mut text) => {
-//!             *text = text.replace("my", "your");
+//!             let orig = std::mem::replace(text, vec![]);
+//!             *text = String::from_utf8(orig).unwrap().replace("my", "your").as_bytes().to_vec();
 //!         }
 //!         _ => (),
 //!     }
@@ -81,6 +82,7 @@ extern crate regex;
 extern crate entities;
 #[macro_use]
 extern crate lazy_static;
+extern crate twoway;
 
 mod arena_tree;
 mod parser;
@@ -105,7 +107,7 @@ use typed_arena::Arena;
 /// See the documentation of the crate root for an example.
 pub fn markdown_to_html(md: &str, options: &ComrakOptions) -> String {
     let arena = Arena::new();
-    let root = parse_document(&arena, md, options);
+    let root = parse_document(&arena, md.as_bytes(), options);
     let mut s = Vec::new();
     format_html(root, options, &mut s).unwrap();
     String::from_utf8(s).unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ fn main() {
     }
 
     let arena = Arena::new();
-    let root = parser::parse_document(&arena, &s, &options);
+    let root = parser::parse_document(&arena, &String::from_utf8(s).unwrap(), &options);
 
     let formatter = match matches.value_of("format") {
         Some("html") => html::format_document,

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ extern crate typed_arena;
 extern crate regex;
 #[macro_use]
 extern crate lazy_static;
+extern crate twoway;
 
 mod arena_tree;
 mod html;
@@ -125,16 +126,16 @@ fn main() {
 
     assert!(exts.is_empty());
 
-    let mut s = String::with_capacity(2048);
+    let mut s: Vec<u8> = Vec::with_capacity(2048);
 
     match matches.values_of("file") {
         None => {
-            std::io::stdin().read_to_string(&mut s).unwrap();
+            std::io::stdin().read_to_end(&mut s).unwrap();
         }
         Some(fs) => {
             for f in fs {
                 let mut io = std::fs::File::open(f).unwrap();
-                io.read_to_string(&mut s).unwrap();
+                io.read_to_end(&mut s).unwrap();
             }
         }
     };
@@ -158,22 +159,22 @@ fn main() {
 }
 
 fn init_scanners() {
-    scanners::atx_heading_start("");
-    scanners::html_block_end_1("");
-    scanners::open_code_fence("");
-    scanners::close_code_fence("");
-    scanners::html_block_start("");
-    scanners::html_block_start_7("");
-    scanners::setext_heading_line("");
-    scanners::thematic_break("");
-    scanners::scheme("");
-    scanners::autolink_uri("");
-    scanners::autolink_email("");
-    scanners::html_tag("");
-    scanners::spacechars("");
-    scanners::link_title("");
-    scanners::table_start("");
-    scanners::table_cell("");
-    scanners::table_cell_end("");
-    scanners::table_row_end("");
+    scanners::atx_heading_start(b"");
+    scanners::html_block_end_1(b"");
+    scanners::open_code_fence(b"");
+    scanners::close_code_fence(b"");
+    scanners::html_block_start(b"");
+    scanners::html_block_start_7(b"");
+    scanners::setext_heading_line(b"");
+    scanners::thematic_break(b"");
+    scanners::scheme(b"");
+    scanners::autolink_uri(b"");
+    scanners::autolink_email(b"");
+    scanners::html_tag(b"");
+    scanners::spacechars(b"");
+    scanners::link_title(b"");
+    scanners::table_start(b"");
+    scanners::table_cell(b"");
+    scanners::table_cell_end(b"");
+    scanners::table_row_end(b"");
 }

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -67,7 +67,7 @@ pub enum NodeValue {
 
     /// **Inline**.  [Textual content](https://github.github.com/gfm/#textual-content).  All text
     /// in a document will be contained in a `Text` node.
-    Text(String),
+    Text(Vec<u8>),
 
     /// **Inline**.  A [soft line break](https://github.github.com/gfm/#soft-line-breaks).  If
     /// the `hardbreaks` option is set in `ComrakOptions` during formatting, it will be formatted
@@ -78,10 +78,10 @@ pub enum NodeValue {
     LineBreak,
 
     /// **Inline**.  A [code span](https://github.github.com/gfm/#code-spans).
-    Code(String),
+    Code(Vec<u8>),
 
     /// **Inline**.  [Raw HTML](https://github.github.com/gfm/#raw-html) contained inline.
-    HtmlInline(String),
+    HtmlInline(Vec<u8>),
 
     /// **Inline**.  [Emphasised](https://github.github.com/gfm/#emphasis-and-strong-emphasis)
     /// text.
@@ -125,13 +125,13 @@ pub enum TableAlignment {
 #[derive(Debug, Clone)]
 pub struct NodeLink {
     /// The URL for the link destination or image source.
-    pub url: String,
+    pub url: Vec<u8>,
 
     /// The title for the link or image.
     ///
     /// Note this field is used for the `title` attribute by the HTML formatter even for images;
     /// `alt` text is supplied in the image inline text.
-    pub title: String,
+    pub title: Vec<u8>,
 }
 
 /// The metadata of a list; the kind of list, the delimiter used and so on.
@@ -209,12 +209,12 @@ pub struct NodeCodeBlock {
 
     /// For fenced code blocks, the [info string](https://github.github.com/gfm/#info-string) after
     /// the opening fence, if any.
-    pub info: String,
+    pub info: Vec<u8>,
 
     /// The literal contents of the code block.  As the contents are not interpreted as Markdown at
     /// all, they are contained within this structure, rather than inserted into a child inline of
     /// any kind.
-    pub literal: String,
+    pub literal: Vec<u8>,
 }
 
 /// The metadata of a heading.
@@ -235,7 +235,7 @@ pub struct NodeHtmlBlock {
 
     /// The literal contents of the HTML block.  Per NodeCodeBlock, the content is included here
     /// rather than in any inline.
-    pub literal: String,
+    pub literal: Vec<u8>,
 }
 
 
@@ -282,7 +282,7 @@ impl NodeValue {
     /// Return a reference to the text of a `Text` inline, if this node is one.
     ///
     /// Convenience method.
-    pub fn text(&self) -> Option<&String> {
+    pub fn text(&self) -> Option<&Vec<u8>> {
         match *self {
             NodeValue::Text(ref t) => Some(t),
             _ => None,
@@ -292,7 +292,7 @@ impl NodeValue {
     /// Return a mutable reference to the text of a `Text` inline, if this node is one.
     ///
     /// Convenience method.
-    pub fn text_mut(&mut self) -> Option<&mut String> {
+    pub fn text_mut(&mut self) -> Option<&mut Vec<u8>> {
         match *self {
             NodeValue::Text(ref mut t) => Some(t),
             _ => None,
@@ -322,7 +322,7 @@ pub struct Ast {
     pub end_column: usize,
 
     #[doc(hidden)]
-    pub content: String,
+    pub content: Vec<u8>,
     #[doc(hidden)]
     pub open: bool,
     #[doc(hidden)]
@@ -333,7 +333,7 @@ pub struct Ast {
 pub fn make_block(value: NodeValue, start_line: u32, start_column: usize) -> Ast {
     Ast {
         value: value,
-        content: String::new(),
+        content: vec![],
         start_line: start_line,
         start_column: start_column,
         end_line: start_line,

--- a/src/parser/autolink.rs
+++ b/src/parser/autolink.rs
@@ -3,11 +3,12 @@ use nodes::{NodeValue, NodeLink, AstNode};
 use parser::inlines::make_inline;
 use typed_arena::Arena;
 use unicode_categories::UnicodeCategories;
+use std::str;
 
 pub fn process_autolinks<'a>(
     arena: &'a Arena<AstNode<'a>>,
     node: &'a AstNode<'a>,
-    contents: &mut String,
+    contents: &mut Vec<u8>,
 ) {
     let len = contents.len();
     let mut i = 0;
@@ -16,7 +17,7 @@ pub fn process_autolinks<'a>(
         let mut post_org = None;
 
         while i < len {
-            match contents.as_bytes()[i] {
+            match contents[i] {
                 b':' => {
                     post_org = url_match(arena, contents, i);
                     if post_org.is_some() {
@@ -44,7 +45,7 @@ pub fn process_autolinks<'a>(
             i -= reverse;
             node.insert_after(post);
             if i + skip < len {
-                let remain = contents[i + skip..].to_string();
+                let remain = contents[i + skip..].to_vec();
                 assert!(!remain.is_empty());
                 post.insert_after(make_inline(arena, NodeValue::Text(remain)));
             }
@@ -56,7 +57,7 @@ pub fn process_autolinks<'a>(
 
 fn www_match<'a>(
     arena: &'a Arena<AstNode<'a>>,
-    contents: &str,
+    contents: &[u8],
     i: usize,
 ) -> Option<(&'a AstNode<'a>, usize, usize)> {
     lazy_static! {
@@ -69,13 +70,12 @@ fn www_match<'a>(
         };
     }
 
-    if i > 0 && !isspace(contents.as_bytes()[i - 1]) &&
-        !WWW_DELIMS[contents.as_bytes()[i - 1] as usize]
+    if i > 0 && !isspace(contents[i - 1]) && !WWW_DELIMS[contents[i - 1] as usize]
     {
         return None;
     }
 
-    if !contents[i..].starts_with("www.") {
+    if !contents[i..].starts_with(b"www.") {
         return None;
     }
 
@@ -84,36 +84,36 @@ fn www_match<'a>(
         Some(link_end) => link_end,
     };
 
-    while i + link_end < contents.len() && !isspace(contents.as_bytes()[i + link_end]) {
+    while i + link_end < contents.len() && !isspace(contents[i + link_end]) {
         link_end += 1;
     }
 
     link_end = autolink_delim(&contents[i..], link_end);
 
-    let mut url = "http://".to_string();
-    url += &contents[i..link_end + i];
+    let mut url = b"http://".to_vec();
+    url.extend_from_slice(&contents[i..link_end + i]);
 
     let inl = make_inline(
         arena,
         NodeValue::Link(NodeLink {
             url: url,
-            title: String::new(),
+            title: vec![],
         }),
     );
 
     inl.append(make_inline(
         arena,
-        NodeValue::Text(contents[i..link_end + i].to_string()),
+        NodeValue::Text(contents[i..link_end + i].to_vec()),
     ));
     Some((inl, 0, link_end))
 }
 
-fn check_domain(data: &str) -> Option<usize> {
+fn check_domain(data: &[u8]) -> Option<usize> {
     let mut np = 0;
     let mut uscore1 = 0;
     let mut uscore2 = 0;
 
-    for (i, c) in data.char_indices() {
+    for (i, c) in unsafe { str::from_utf8_unchecked(data) }.char_indices() {
         if c == '_' {
             uscore2 += 1;
         } else if c == '.' {
@@ -139,7 +139,7 @@ fn is_valid_hostchar(ch: char) -> bool {
     !ch.is_whitespace() && !ch.is_punctuation()
 }
 
-fn autolink_delim(data: &str, mut link_end: usize) -> usize {
+fn autolink_delim(data: &[u8], mut link_end: usize) -> usize {
     lazy_static! {
         static ref LINK_END_ASSORTMENT: [bool; 256] = {
             let mut sc = [false; 256];
@@ -150,15 +150,15 @@ fn autolink_delim(data: &str, mut link_end: usize) -> usize {
         };
     }
 
-    for i in 0..link_end {
-        if data.as_bytes()[i] == b'<' {
+    for (i, &b) in data.iter().enumerate().take(link_end) {
+        if b == b'<' {
             link_end = i;
             break;
         }
     }
 
     while link_end > 0 {
-        let cclose = data.as_bytes()[link_end - 1];
+        let cclose = data[link_end - 1];
 
         let copen = if cclose == b')' { Some(b'(') } else { None };
 
@@ -167,11 +167,11 @@ fn autolink_delim(data: &str, mut link_end: usize) -> usize {
         } else if cclose == b';' {
             let mut new_end = link_end - 2;
 
-            while new_end > 0 && isalpha(data.as_bytes()[new_end]) {
+            while new_end > 0 && isalpha(data[new_end]) {
                 new_end -= 1;
             }
 
-            if new_end < link_end - 2 && data.as_bytes()[new_end] == b'&' {
+            if new_end < link_end - 2 && data[new_end] == b'&' {
                 link_end = new_end;
             } else {
                 link_end -= 1;
@@ -179,10 +179,10 @@ fn autolink_delim(data: &str, mut link_end: usize) -> usize {
         } else if let Some(copen) = copen {
             let mut opening = 0;
             let mut closing = 0;
-            for i in 0..link_end {
-                if data.as_bytes()[i] == copen {
+            for &b in data.iter().take(link_end) {
+                if b == copen {
                     opening += 1;
-                } else if data.as_bytes()[i] == cclose {
+                } else if b == cclose {
                     closing += 1;
                 }
             }
@@ -202,26 +202,26 @@ fn autolink_delim(data: &str, mut link_end: usize) -> usize {
 
 fn url_match<'a>(
     arena: &'a Arena<AstNode<'a>>,
-    contents: &str,
+    contents: &[u8],
     i: usize,
 ) -> Option<(&'a AstNode<'a>, usize, usize)> {
     lazy_static! {
-        static ref SCHEMES: Vec<&'static str> =
-            vec!["http", "https", "ftp"];
+        static ref SCHEMES: Vec<&'static [u8]> =
+            vec![b"http", b"https", b"ftp"];
     }
 
     let size = contents.len();
 
-    if size - i < 4 || contents.as_bytes()[i + 1] != b'/' || contents.as_bytes()[i + 2] != b'/' {
+    if size - i < 4 || contents[i + 1] != b'/' || contents[i + 2] != b'/' {
         return None;
     }
 
     let mut rewind = 0;
-    while rewind < i && isalpha(contents.as_bytes()[i - rewind - 1]) {
+    while rewind < i && isalpha(contents[i - rewind - 1]) {
         rewind += 1;
     }
 
-    let cond = |s: &&str| size - i + rewind >= s.len() && &&contents[i - rewind..i] == s;
+    let cond = |s: &&[u8]| size - i + rewind >= s.len() && &&contents[i - rewind..i] == s;
     if !SCHEMES.iter().any(cond) {
         return None;
     }
@@ -231,18 +231,18 @@ fn url_match<'a>(
         Some(link_end) => link_end,
     };
 
-    while link_end < size - i && !isspace(contents.as_bytes()[i + link_end]) {
+    while link_end < size - i && !isspace(contents[i + link_end]) {
         link_end += 1;
     }
 
     link_end = autolink_delim(&contents[i..], link_end);
 
-    let url = contents[i - rewind..i + link_end].to_string();
+    let url = contents[i - rewind..i + link_end].to_vec();
     let inl = make_inline(
         arena,
         NodeValue::Link(NodeLink {
             url: url.clone(),
-            title: String::new(),
+            title: vec![],
         }),
     );
 
@@ -252,7 +252,7 @@ fn url_match<'a>(
 
 fn email_match<'a>(
     arena: &'a Arena<AstNode<'a>>,
-    contents: &str,
+    contents: &[u8],
     i: usize,
 ) -> Option<(&'a AstNode<'a>, usize, usize)> {
     lazy_static! {
@@ -271,7 +271,7 @@ fn email_match<'a>(
     let mut ns = 0;
 
     while rewind < i {
-        let c = contents.as_bytes()[i - rewind - 1];
+        let c = contents[i - rewind - 1];
 
         if isalnum(c) || EMAIL_OK_SET[c as usize] {
             rewind += 1;
@@ -294,7 +294,7 @@ fn email_match<'a>(
     let mut np = 0;
 
     while link_end < size - i {
-        let c = contents.as_bytes()[i + link_end];
+        let c = contents[i + link_end];
 
         if isalnum(c) {
             // empty
@@ -310,29 +310,29 @@ fn email_match<'a>(
     }
 
     if link_end < 2 || nb != 1 || np == 0 ||
-        (!isalpha(contents.as_bytes()[i + link_end - 1]) &&
-             contents.as_bytes()[i + link_end - 1] != b'.')
+        (!isalpha(contents[i + link_end - 1]) &&
+             contents[i + link_end - 1] != b'.')
     {
         return None;
     }
 
     link_end = autolink_delim(&contents[i..], link_end);
 
-    let mut url = "mailto:".to_string();
-    url += &contents[i - rewind..link_end + i];
+    let mut url = b"mailto:".to_vec();
+    url.extend_from_slice(&contents[i - rewind..link_end + i]);
 
     let inl = make_inline(
         arena,
         NodeValue::Link(NodeLink {
             url: url,
-            title: String::new(),
+            title: vec![],
         }),
     );
 
     inl.append(make_inline(
         arena,
         NodeValue::Text(
-            contents[i - rewind..link_end + i].to_string(),
+            contents[i - rewind..link_end + i].to_vec(),
         ),
     ));
     Some((inl, rewind, rewind + link_end))

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -8,6 +8,7 @@ use scanners;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::ptr;
+use std::str;
 use strings;
 use typed_arena::Arena;
 use unicode_categories::UnicodeCategories;
@@ -18,9 +19,9 @@ const MAX_LINK_LABEL_LENGTH: usize = 1000;
 pub struct Subject<'a: 'd, 'r, 'o, 'd, 'i> {
     pub arena: &'a Arena<AstNode<'a>>,
     options: &'o ComrakOptions,
-    pub input: &'i str,
+    pub input: &'i [u8],
     pub pos: usize,
-    pub refmap: &'r mut HashMap<String, Reference>,
+    pub refmap: &'r mut HashMap<Vec<u8>, Reference>,
     delimiter_arena: &'d Arena<Delimiter<'a, 'd>>,
     last_delimiter: Option<&'d Delimiter<'a, 'd>>,
     brackets: Vec<Bracket<'a, 'd>>,
@@ -51,8 +52,8 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
     pub fn new(
         arena: &'a Arena<AstNode<'a>>,
         options: &'o ComrakOptions,
-        input: &'i str,
-        refmap: &'r mut HashMap<String, Reference>,
+        input: &'i [u8],
+        refmap: &'r mut HashMap<Vec<u8>, Reference>,
         delimiter_arena: &'d Arena<Delimiter<'a, 'd>>,
     ) -> Self {
         let mut s = Subject {
@@ -119,7 +120,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
             //'.' => new_inl => Some(self.handle_period()),
             '[' => {
                 self.pos += 1;
-                let inl = make_inline(self.arena, NodeValue::Text("[".to_string()));
+                let inl = make_inline(self.arena, NodeValue::Text(b"[".to_vec()));
                 new_inl = Some(inl);
                 self.push_bracket(false, inl);
             }
@@ -128,11 +129,11 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
                 self.pos += 1;
                 if self.peek_char() == Some(&(b'[')) {
                     self.pos += 1;
-                    let inl = make_inline(self.arena, NodeValue::Text("![".to_string()));
+                    let inl = make_inline(self.arena, NodeValue::Text(b"![".to_vec()));
                     new_inl = Some(inl);
                     self.push_bracket(true, inl);
                 } else {
-                    new_inl = Some(make_inline(self.arena, NodeValue::Text("!".to_string())));
+                    new_inl = Some(make_inline(self.arena, NodeValue::Text(b"!".to_vec())));
                 }
             }
             _ => {
@@ -142,7 +143,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
                     new_inl = Some(self.handle_delim(b'^'));
                 } else {
                     let endpos = self.find_special_char();
-                    let mut contents = self.input[self.pos..endpos].to_string();
+                    let mut contents = self.input[self.pos..endpos].to_vec();
                     self.pos = endpos;
 
                     if self.peek_char().map_or(
@@ -256,7 +257,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
                         .borrow_mut()
                         .value
                         .text_mut()
-                        .unwrap() = "’".to_string();
+                        .unwrap() = "’".to_string().into_bytes();
                     if opener_found {
                         *opener
                             .unwrap()
@@ -265,7 +266,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
                             .borrow_mut()
                             .value
                             .text_mut()
-                            .unwrap() = "‘".to_string();
+                            .unwrap() = "‘".to_string().into_bytes();
                     }
                     closer = closer.unwrap().next.get();
                 } else if closer.unwrap().delim_char == b'"' {
@@ -276,7 +277,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
                         .borrow_mut()
                         .value
                         .text_mut()
-                        .unwrap() = "”".to_string();
+                        .unwrap() = "”".to_string().into_bytes();
                     if opener_found {
                         *opener
                             .unwrap()
@@ -285,7 +286,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
                             .borrow_mut()
                             .value
                             .text_mut()
-                            .unwrap() = "“".to_string();
+                            .unwrap() = "“".to_string().into_bytes();
                     }
                     closer = closer.unwrap().next.get();
                 }
@@ -338,7 +339,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
         if self.eof() {
             None
         } else {
-            let c = &self.input.as_bytes()[self.pos];
+            let c = &self.input[self.pos];
             assert!(*c > 0);
             Some(c)
         }
@@ -346,7 +347,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
 
     pub fn find_special_char(&self) -> usize {
         for n in self.pos..self.input.len() {
-            if self.special_chars[self.input.as_bytes()[n] as usize] {
+            if self.special_chars[self.input[n] as usize] {
                 return n;
             }
         }
@@ -356,15 +357,15 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
 
     pub fn handle_newline(&mut self) -> &'a AstNode<'a> {
         let nlpos = self.pos;
-        if self.input.as_bytes()[self.pos] == b'\r' {
+        if self.input[self.pos] == b'\r' {
             self.pos += 1;
         }
-        if self.input.as_bytes()[self.pos] == b'\n' {
+        if self.input[self.pos] == b'\n' {
             self.pos += 1;
         }
         self.skip_spaces();
-        if nlpos > 1 && self.input.as_bytes()[nlpos - 1] == b' ' &&
-            self.input.as_bytes()[nlpos - 2] == b' '
+        if nlpos > 1 && self.input[nlpos - 1] == b' ' &&
+            self.input[nlpos - 2] == b' '
         {
             make_inline(self.arena, NodeValue::LineBreak)
         } else {
@@ -372,10 +373,11 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
         }
     }
 
-    pub fn take_while(&mut self, c: u8) -> String {
-        let mut v = String::with_capacity(10);
+    pub fn take_while(&mut self, c: u8) -> Vec<u8> {
+        let mut v = Vec::with_capacity(10);
+        // TODO
         while self.peek_char() == Some(&c) {
-            v.push(self.input.as_bytes()[self.pos] as char);
+            v.push(self.input[self.pos]);
             self.pos += 1;
         }
         v
@@ -439,7 +441,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
     pub fn handle_delim(&mut self, c: u8) -> &'a AstNode<'a> {
         let (numdelims, can_open, can_close) = self.scan_delims(c);
 
-        let contents = self.input[self.pos - numdelims..self.pos].to_string();
+        let contents = self.input[self.pos - numdelims..self.pos].to_vec();
         let inl = make_inline(self.arena, NodeValue::Text(contents));
 
         if (can_open || can_close) && c != b'\'' && c != b'"' {
@@ -454,10 +456,10 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
             '\n'
         } else {
             let mut before_char_pos = self.pos - 1;
-            while before_char_pos > 0 && self.input.as_bytes()[before_char_pos] >> 6 == 2 {
+            while before_char_pos > 0 && self.input[before_char_pos] >> 6 == 2 {
                 before_char_pos -= 1;
             }
-            self.input[before_char_pos..].chars().next().unwrap()
+            unsafe {str::from_utf8_unchecked(&self.input[before_char_pos..self.pos]) }.chars().next().unwrap()
         };
 
         let mut numdelims = 0;
@@ -474,7 +476,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
         let after_char = if self.eof() {
             '\n'
         } else {
-            self.input[self.pos..].chars().next().unwrap()
+            unsafe {str::from_utf8_unchecked(&self.input[self.pos..]) }.chars().next().unwrap()
         };
 
         let left_flanking = numdelims > 0 && !after_char.is_whitespace() &&
@@ -517,7 +519,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
         opener: &'d Delimiter<'a, 'd>,
         closer: &'d Delimiter<'a, 'd>,
     ) -> Option<&'d Delimiter<'a, 'd>> {
-        let opener_char = opener.inl.data.borrow().value.text().unwrap().as_bytes()[0];
+        let opener_char = opener.inl.data.borrow().value.text().unwrap()[0];
         let mut opener_num_chars = opener.inl.data.borrow().value.text().unwrap().len();
         let mut closer_num_chars = closer.inl.data.borrow().value.text().unwrap().len();
         let use_delims = if closer_num_chars >= 2 && opener_num_chars >= 2 {
@@ -600,14 +602,15 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
         self.pos += 1;
         if self.peek_char().map_or(false, |&c| ispunct(c)) {
             self.pos += 1;
+            // TODO
             make_inline(
                 self.arena,
-                NodeValue::Text((self.input.as_bytes()[self.pos - 1] as char).to_string()),
+                NodeValue::Text(vec![self.input[self.pos - 1]]),
             )
         } else if !self.eof() && self.skip_line_end() {
             make_inline(self.arena, NodeValue::LineBreak)
         } else {
-            make_inline(self.arena, NodeValue::Text("\\".to_string()))
+            make_inline(self.arena, NodeValue::Text(b"\\".to_vec()))
         }
     }
 
@@ -626,7 +629,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
         self.pos += 1;
 
         match entity::unescape(&self.input[self.pos..]) {
-            None => make_inline(self.arena, NodeValue::Text("&".to_string())),
+            None => make_inline(self.arena, NodeValue::Text(b"&".to_vec())),
             Some((entity, len)) => {
                 self.pos += len;
                 make_inline(self.arena, NodeValue::Text(entity))
@@ -659,12 +662,12 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
 
         if let Some(matchlen) = scanners::html_tag(&self.input[self.pos..]) {
             let contents = &self.input[self.pos - 1..self.pos + matchlen];
-            let inl = make_inline(self.arena, NodeValue::HtmlInline(contents.to_string()));
+            let inl = make_inline(self.arena, NodeValue::HtmlInline(contents.to_vec()));
             self.pos += matchlen;
             return inl;
         }
 
-        make_inline(self.arena, NodeValue::Text("<".to_string()))
+        make_inline(self.arena, NodeValue::Text(b"<".to_vec()))
     }
 
     pub fn push_bracket(&mut self, image: bool, inl_text: &'a AstNode<'a>) {
@@ -688,12 +691,12 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
 
         let brackets_len = self.brackets.len();
         if brackets_len == 0 {
-            return Some(make_inline(self.arena, NodeValue::Text("]".to_string())));
+            return Some(make_inline(self.arena, NodeValue::Text(b"]".to_vec())));
         }
 
         if !self.brackets[brackets_len - 1].active {
             self.brackets.pop();
-            return Some(make_inline(self.arena, NodeValue::Text("]".to_string())));
+            return Some(make_inline(self.arena, NodeValue::Text(b"]".to_vec())));
         }
 
         let is_image = self.brackets[brackets_len - 1].image;
@@ -720,7 +723,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
             };
             let endall = endtitle + scanners::spacechars(&self.input[endtitle..]).unwrap_or(0);
 
-            if endall < self.input.len() && self.input.as_bytes()[endall] == b')' {
+            if endall < self.input.len() && self.input[endall] == b')' {
                 self.pos = endall + 1;
                 let url = strings::clean_url(&self.input[starturl..endurl]);
                 let title = strings::clean_title(&self.input[starttitle..endtitle]);
@@ -732,8 +735,8 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
         }
 
         let (mut lab, mut found_label) = match self.link_label() {
-            Some(lab) => (lab.to_string(), true),
-            None => (String::new(), false),
+            Some(lab) => (lab.to_vec(), true),
+            None => (vec![], false),
         };
 
         if !found_label {
@@ -741,7 +744,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
         }
 
         if (!found_label || lab.is_empty()) && !self.brackets[brackets_len - 1].bracket_after {
-            lab = self.input[self.brackets[brackets_len - 1].position..initial_pos - 1].to_string();
+            lab = self.input[self.brackets[brackets_len - 1].position..initial_pos - 1].to_vec();
             found_label = true;
         }
 
@@ -759,10 +762,10 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
 
         self.brackets.pop();
         self.pos = initial_pos;
-        Some(make_inline(self.arena, NodeValue::Text("]".to_string())))
+        Some(make_inline(self.arena, NodeValue::Text(b"]".to_vec())))
     }
 
-    pub fn close_bracket_match(&mut self, is_image: bool, url: String, title: String) {
+    pub fn close_bracket_match(&mut self, is_image: bool, url: Vec<u8>, title: Vec<u8>) {
         let nl = NodeLink {
             url: url,
             title: title,
@@ -804,7 +807,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
         }
     }
 
-    pub fn link_label(&mut self) -> Option<&str> {
+    pub fn link_label(&mut self) -> Option<&[u8]> {
         let startpos = self.pos;
 
         if self.peek_char() != Some(&(b'[')) {
@@ -851,15 +854,15 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
     }
 }
 
-pub fn manual_scan_link_url(input: &str) -> Option<usize> {
+pub fn manual_scan_link_url(input: &[u8]) -> Option<usize> {
     let len = input.len();
     let mut i = 0;
     let mut nb_p = 0;
 
-    if i < len && input.as_bytes()[i] == b'<' {
+    if i < len && input[i] == b'<' {
         i += 1;
         while i < len {
-            let b = input.as_bytes()[i];
+            let b = input[i];
             if b == b'>' {
                 i += 1;
                 break;
@@ -873,21 +876,21 @@ pub fn manual_scan_link_url(input: &str) -> Option<usize> {
         }
     } else {
         while i < len {
-            if input.as_bytes()[i] == b'\\' {
+            if input[i] == b'\\' {
                 i += 2;
-            } else if input.as_bytes()[i] == b'(' {
+            } else if input[i] == b'(' {
                 nb_p += 1;
                 i += 1;
                 if nb_p > 32 {
                     return None;
                 }
-            } else if input.as_bytes()[i] == b')' {
+            } else if input[i] == b')' {
                 if nb_p == 0 {
                     break;
                 }
                 nb_p -= 1;
                 i += 1;
-            } else if isspace(input.as_bytes()[i]) {
+            } else if isspace(input[i]) {
                 break;
             } else {
                 i += 1;
@@ -901,7 +904,7 @@ pub fn manual_scan_link_url(input: &str) -> Option<usize> {
 pub fn make_inline<'a>(arena: &'a Arena<AstNode<'a>>, value: NodeValue) -> &'a AstNode<'a> {
     let ast = Ast {
         value: value,
-        content: String::new(),
+        content: vec![],
         start_line: 0,
         start_column: 0,
         end_line: 0,
@@ -914,14 +917,14 @@ pub fn make_inline<'a>(arena: &'a Arena<AstNode<'a>>, value: NodeValue) -> &'a A
 
 fn make_autolink<'a>(
     arena: &'a Arena<AstNode<'a>>,
-    url: &str,
+    url: &[u8],
     kind: AutolinkType,
 ) -> &'a AstNode<'a> {
     let inl = make_inline(
         arena,
         NodeValue::Link(NodeLink {
             url: strings::clean_autolink(url, kind),
-            title: String::new(),
+            title: vec![],
         }),
     );
     inl.append(make_inline(

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -26,7 +26,7 @@ const CODE_INDENT: usize = 4;
 /// See the documentation of the crate root for an example.
 pub fn parse_document<'a>(
     arena: &'a Arena<AstNode<'a>>,
-    buffer: &[u8],
+    buffer: &str,
     options: &ComrakOptions,
 ) -> &'a AstNode<'a> {
     let root: &'a AstNode<'a> = arena.alloc(Node::new(RefCell::new(Ast {
@@ -40,7 +40,7 @@ pub fn parse_document<'a>(
         last_line_blank: false,
     })));
     let mut parser = Parser::new(arena, root, options);
-    parser.feed(buffer, true);
+    parser.feed(buffer.as_bytes(), true);
     parser.finish()
 }
 
@@ -104,7 +104,7 @@ pub struct ComrakOptions {
     /// # fn main() {
     /// # let arena = typed_arena::Arena::new();
     /// let mut options = ComrakOptions::default();
-    /// let node = parse_document(&arena, b"hello hello hello hello hello hello", &options);
+    /// let node = parse_document(&arena, "hello hello hello hello hello hello", &options);
     /// let mut output = vec![];
     /// format_commonmark(node, &options, &mut output).unwrap();
     /// assert_eq!(String::from_utf8(output).unwrap(),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8,12 +8,13 @@ use entity;
 use nodes;
 use nodes::{NodeValue, Ast, NodeCodeBlock, NodeHeading, NodeList, ListType, ListDelimType,
             NodeHtmlBlock, make_block, AstNode};
-use regex::Regex;
+use regex::bytes::Regex;
 use scanners;
 use std::cell::RefCell;
 use std::cmp::min;
 use std::collections::HashMap;
 use std::mem;
+use std::str;
 use strings;
 use typed_arena::Arena;
 
@@ -25,12 +26,12 @@ const CODE_INDENT: usize = 4;
 /// See the documentation of the crate root for an example.
 pub fn parse_document<'a>(
     arena: &'a Arena<AstNode<'a>>,
-    buffer: &str,
+    buffer: &[u8],
     options: &ComrakOptions,
 ) -> &'a AstNode<'a> {
     let root: &'a AstNode<'a> = arena.alloc(Node::new(RefCell::new(Ast {
         value: NodeValue::Document,
-        content: String::new(),
+        content: vec![],
         start_line: 0,
         start_column: 0,
         end_line: 0,
@@ -45,7 +46,7 @@ pub fn parse_document<'a>(
 
 pub struct Parser<'a, 'o> {
     arena: &'a Arena<AstNode<'a>>,
-    refmap: HashMap<String, Reference>,
+    refmap: HashMap<Vec<u8>, Reference>,
     root: &'a AstNode<'a>,
     current: &'a AstNode<'a>,
     line_number: u32,
@@ -57,7 +58,7 @@ pub struct Parser<'a, 'o> {
     blank: bool,
     partially_consumed_tab: bool,
     last_line_length: usize,
-    linebuf: String,
+    linebuf: Vec<u8>,
     last_buffer_ended_with_cr: bool,
     options: &'o ComrakOptions,
 }
@@ -103,7 +104,7 @@ pub struct ComrakOptions {
     /// # fn main() {
     /// # let arena = typed_arena::Arena::new();
     /// let mut options = ComrakOptions::default();
-    /// let node = parse_document(&arena, "hello hello hello hello hello hello", &options);
+    /// let node = parse_document(&arena, b"hello hello hello hello hello hello", &options);
     /// let mut output = vec![];
     /// format_commonmark(node, &options, &mut output).unwrap();
     /// assert_eq!(String::from_utf8(output).unwrap(),
@@ -201,8 +202,8 @@ pub struct ComrakOptions {
 
 #[derive(Clone)]
 pub struct Reference {
-    pub url: String,
-    pub title: String,
+    pub url: Vec<u8>,
+    pub title: Vec<u8>,
 }
 
 impl<'a, 'o> Parser<'a, 'o> {
@@ -225,15 +226,15 @@ impl<'a, 'o> Parser<'a, 'o> {
             blank: false,
             partially_consumed_tab: false,
             last_line_length: 0,
-            linebuf: String::with_capacity(80),
+            linebuf: Vec::with_capacity(80),
             last_buffer_ended_with_cr: false,
             options: options,
         }
     }
 
-    pub fn feed(&mut self, s: &str, eof: bool) {
+    pub fn feed(&mut self, s: &[u8], eof: bool) {
         let mut i = 0;
-        let buffer = s.as_bytes();
+        let buffer = s;
         let sz = buffer.len();
 
         if self.last_buffer_ended_with_cr && buffer[i] == b'\n' {
@@ -261,8 +262,8 @@ impl<'a, 'o> Parser<'a, 'o> {
 
             if process {
                 if !self.linebuf.is_empty() {
-                    self.linebuf += &s[i..eol];
-                    let linebuf = mem::replace(&mut self.linebuf, String::with_capacity(80));
+                    self.linebuf.extend_from_slice(&s[i..eol]);
+                    let linebuf = mem::replace(&mut self.linebuf, Vec::with_capacity(80));
                     self.process_line(&linebuf);
                 } else if sz > eol && buffer[eol] == b'\n' {
                     self.process_line(&s[i..eol + 1]);
@@ -270,11 +271,11 @@ impl<'a, 'o> Parser<'a, 'o> {
                     self.process_line(&s[i..eol]);
                 }
             } else if eol < sz && buffer[eol] == b'\0' {
-                self.linebuf += &s[i..eol];
-                self.linebuf.push('\u{fffd}');
+                self.linebuf.extend_from_slice(&s[i..eol]);
+                self.linebuf.extend_from_slice(&"\u{fffd}".to_string().into_bytes());
                 eol += 1;
             } else {
-                self.linebuf += &s[i..eol];
+                self.linebuf.extend_from_slice(&s[i..eol]);
             }
 
             i = eol;
@@ -290,7 +291,7 @@ impl<'a, 'o> Parser<'a, 'o> {
         }
     }
 
-    fn find_first_nonspace(&mut self, line: &str) {
+    fn find_first_nonspace(&mut self, line: &[u8]) {
         self.first_nonspace = self.offset;
         self.first_nonspace_column = self.column;
         let mut chars_to_tab = TAB_STOP - (self.column % TAB_STOP);
@@ -299,7 +300,7 @@ impl<'a, 'o> Parser<'a, 'o> {
             if self.first_nonspace >= line.len() {
                 break;
             }
-            match line.as_bytes()[self.first_nonspace] {
+            match line[self.first_nonspace] {
                 32 => {
                     self.first_nonspace += 1;
                     self.first_nonspace_column += 1;
@@ -319,15 +320,15 @@ impl<'a, 'o> Parser<'a, 'o> {
 
         self.indent = self.first_nonspace_column - self.column;
         self.blank = self.first_nonspace < line.len() &&
-            strings::is_line_end_char(line.as_bytes()[self.first_nonspace]);
+            strings::is_line_end_char(line[self.first_nonspace]);
     }
 
-    fn process_line(&mut self, line: &str) {
-        let mut new_line: String;
+    fn process_line(&mut self, line: &[u8]) {
+        let mut new_line: Vec<u8>;
         let line =
-            if line.is_empty() || !strings::is_line_end_char(*line.as_bytes().last().unwrap()) {
+            if line.is_empty() || !strings::is_line_end_char(*line.last().unwrap()) {
                 new_line = line.into();
-                new_line.push('\n');
+                new_line.push(b'\n');
                 &new_line
             } else {
                 line
@@ -338,7 +339,7 @@ impl<'a, 'o> Parser<'a, 'o> {
         self.blank = false;
         self.partially_consumed_tab = false;
 
-        if self.line_number == 0 && line.len() >= 3 && line.chars().next().unwrap() == '\u{feff}' {
+        if self.line_number == 0 && line.len() >= 3 && unsafe { str::from_utf8_unchecked(line) }.chars().next().unwrap() == '\u{feff}' {
             self.offset += 3;
         }
 
@@ -356,15 +357,15 @@ impl<'a, 'o> Parser<'a, 'o> {
         }
 
         self.last_line_length = line.len();
-        if self.last_line_length > 0 && line.as_bytes()[self.last_line_length - 1] == b'\n' {
+        if self.last_line_length > 0 && line[self.last_line_length - 1] == b'\n' {
             self.last_line_length -= 1;
         }
-        if self.last_line_length > 0 && line.as_bytes()[self.last_line_length - 1] == b'\r' {
+        if self.last_line_length > 0 && line[self.last_line_length - 1] == b'\r' {
             self.last_line_length -= 1;
         }
     }
 
-    fn check_open_blocks(&mut self, line: &str, all_matched: &mut bool) -> Option<&'a AstNode<'a>> {
+    fn check_open_blocks(&mut self, line: &[u8], all_matched: &mut bool) -> Option<&'a AstNode<'a>> {
         let (new_all_matched, mut container, should_continue) =
             self.check_open_blocks_inner(self.root, line);
 
@@ -383,7 +384,7 @@ impl<'a, 'o> Parser<'a, 'o> {
     fn check_open_blocks_inner(
         &mut self,
         mut container: &'a AstNode<'a>,
-        line: &str,
+        line: &[u8],
     ) -> (bool, &'a AstNode<'a>, bool) {
         let mut should_continue = true;
 
@@ -437,7 +438,7 @@ impl<'a, 'o> Parser<'a, 'o> {
         (true, container, should_continue)
     }
 
-    fn open_new_blocks(&mut self, container: &mut &'a AstNode<'a>, line: &str, all_matched: bool) {
+    fn open_new_blocks(&mut self, container: &mut &'a AstNode<'a>, line: &[u8], all_matched: bool) {
         let mut matched: usize = 0;
         let mut nl: NodeList = NodeList::default();
         let mut sc: scanners::SetextChar = scanners::SetextChar::Equals;
@@ -455,11 +456,11 @@ impl<'a, 'o> Parser<'a, 'o> {
             self.find_first_nonspace(line);
             let indented = self.indent >= CODE_INDENT;
 
-            if !indented && line.as_bytes()[self.first_nonspace] == b'>' {
+            if !indented && line[self.first_nonspace] == b'>' {
                 let blockquote_startpos = self.first_nonspace;
                 let offset = self.first_nonspace + 1 - self.offset;
                 self.advance_offset(line, offset, false);
-                if strings::is_space_or_tab(line.as_bytes()[self.offset]) {
+                if strings::is_space_or_tab(line[self.offset]) {
                     self.advance_offset(line, 1, true);
                 }
                 *container =
@@ -480,11 +481,11 @@ impl<'a, 'o> Parser<'a, 'o> {
                 );
 
                 let mut hashpos = line[self.first_nonspace..]
-                    .bytes()
-                    .position(|c| c == b'#')
+                    .iter()
+                    .position(|&c| c == b'#')
                     .unwrap() + self.first_nonspace;
                 let mut level = 0;
-                while line.as_bytes()[hashpos] == b'#' {
+                while line[hashpos] == b'#' {
                     level += 1;
                     hashpos += 1;
                 }
@@ -504,11 +505,11 @@ impl<'a, 'o> Parser<'a, 'o> {
                 let offset = self.offset;
                 let ncb = NodeCodeBlock {
                     fenced: true,
-                    fence_char: line.as_bytes()[first_nonspace],
+                    fence_char: line[first_nonspace],
                     fence_length: matched,
                     fence_offset: first_nonspace - offset,
-                    info: String::with_capacity(10),
-                    literal: String::with_capacity(80),
+                    info: Vec::with_capacity(10),
+                    literal: Vec::with_capacity(80),
                 };
                 *container =
                     self.add_child(*container, NodeValue::CodeBlock(ncb), first_nonspace + 1);
@@ -531,7 +532,7 @@ impl<'a, 'o> Parser<'a, 'o> {
                 let offset = self.first_nonspace + 1;
                 let nhb = NodeHtmlBlock {
                     block_type: matched as u8,
-                    literal: String::with_capacity(10),
+                    literal: Vec::with_capacity(10),
                 };
 
                 *container = self.add_child(*container, NodeValue::HtmlBlock(nhb), offset);
@@ -594,13 +595,13 @@ impl<'a, 'o> Parser<'a, 'o> {
                     (self.partially_consumed_tab, self.offset, self.column);
 
                 while self.column - save_column <= 5 &&
-                    strings::is_space_or_tab(line.as_bytes()[self.offset])
+                    strings::is_space_or_tab(line[self.offset])
                 {
                     self.advance_offset(line, 1, true);
                 }
 
                 let i = self.column - save_column;
-                if i >= 5 || i < 1 || strings::is_line_end_char(line.as_bytes()[self.offset]) {
+                if i >= 5 || i < 1 || strings::is_line_end_char(line[self.offset]) {
                     nl.padding = matched + 1;
                     self.offset = save_offset;
                     self.column = save_column;
@@ -632,8 +633,8 @@ impl<'a, 'o> Parser<'a, 'o> {
                     fence_char: 0,
                     fence_length: 0,
                     fence_offset: 0,
-                    info: String::new(),
-                    literal: String::with_capacity(80),
+                    info: vec![],
+                    literal: Vec::with_capacity(80),
                 };
                 let offset = self.offset + 1;
                 *container = self.add_child(*container, NodeValue::CodeBlock(ncb), offset);
@@ -666,9 +667,9 @@ impl<'a, 'o> Parser<'a, 'o> {
         }
     }
 
-    fn advance_offset(&mut self, line: &str, mut count: usize, columns: bool) {
+    fn advance_offset(&mut self, line: &[u8], mut count: usize, columns: bool) {
         while count > 0 {
-            match line.as_bytes()[self.offset] {
+            match line[self.offset] {
                 9 => {
                     let chars_to_tab = TAB_STOP - (self.column % TAB_STOP);
                     if columns {
@@ -694,12 +695,12 @@ impl<'a, 'o> Parser<'a, 'o> {
         }
     }
 
-    fn parse_block_quote_prefix(&mut self, line: &str) -> bool {
+    fn parse_block_quote_prefix(&mut self, line: &[u8]) -> bool {
         let indent = self.indent;
-        if indent <= 3 && line.as_bytes()[self.first_nonspace] == b'>' {
+        if indent <= 3 && line[self.first_nonspace] == b'>' {
             self.advance_offset(line, indent + 1, true);
 
-            if strings::is_space_or_tab(line.as_bytes()[self.offset]) {
+            if strings::is_space_or_tab(line[self.offset]) {
                 self.advance_offset(line, 1, true);
             }
 
@@ -711,7 +712,7 @@ impl<'a, 'o> Parser<'a, 'o> {
 
     fn parse_node_item_prefix(
         &mut self,
-        line: &str,
+        line: &[u8],
         container: &'a AstNode<'a>,
         nl: &NodeList,
     ) -> bool {
@@ -729,7 +730,7 @@ impl<'a, 'o> Parser<'a, 'o> {
 
     fn parse_code_block_prefix(
         &mut self,
-        line: &str,
+        line: &[u8],
         container: &'a AstNode<'a>,
         ast: &mut Ast,
         should_continue: &mut bool,
@@ -758,7 +759,7 @@ impl<'a, 'o> Parser<'a, 'o> {
             return false;
         }
 
-        let matched = if self.indent <= 3 && line.as_bytes()[self.first_nonspace] == fence_char {
+        let matched = if self.indent <= 3 && line[self.first_nonspace] == fence_char {
             scanners::close_code_fence(&line[self.first_nonspace..]).unwrap_or(0)
         } else {
             0
@@ -773,7 +774,7 @@ impl<'a, 'o> Parser<'a, 'o> {
         }
 
         let mut i = fence_offset;
-        while i > 0 && strings::is_space_or_tab(line.as_bytes()[self.offset]) {
+        while i > 0 && strings::is_space_or_tab(line[self.offset]) {
             self.advance_offset(line, 1, true);
             i -= 1;
         }
@@ -811,7 +812,7 @@ impl<'a, 'o> Parser<'a, 'o> {
         &mut self,
         mut container: &'a AstNode<'a>,
         last_matched_container: &'a AstNode<'a>,
-        line: &str,
+        line: &[u8],
     ) {
         self.find_first_nonspace(line);
 
@@ -883,7 +884,7 @@ impl<'a, 'o> Parser<'a, 'o> {
                     if self.blank {
                         // do nothing
                     } else if container.data.borrow().value.accepts_lines() {
-                        let mut line: String = line.into();
+                        let mut line: Vec<u8> = line.into();
                         if let NodeValue::Heading(ref nh) = container.data.borrow().value {
                             if !nh.setext {
                                 strings::chop_trailing_hashtags(&mut line);
@@ -906,24 +907,24 @@ impl<'a, 'o> Parser<'a, 'o> {
         }
     }
 
-    fn add_line(&mut self, node: &'a AstNode<'a>, line: &str) {
+    fn add_line(&mut self, node: &'a AstNode<'a>, line: &[u8]) {
         let mut ast = node.data.borrow_mut();
         assert!(ast.open);
         if self.partially_consumed_tab {
             self.offset += 1;
             let chars_to_tab = TAB_STOP - (self.column % TAB_STOP);
             for _ in 0..chars_to_tab {
-                ast.content.push(' ');
+                ast.content.push(b' ');
             }
         }
         if self.offset < line.len() {
-            ast.content += &line[self.offset..];
+            ast.content.extend_from_slice(&line[self.offset..]);
         }
     }
 
     pub fn finish(&mut self) -> &'a AstNode<'a> {
         if !self.linebuf.is_empty() {
-            let linebuf = mem::replace(&mut self.linebuf, String::new());
+            let linebuf = mem::replace(&mut self.linebuf, vec![]);
             self.process_line(&linebuf);
         }
 
@@ -965,10 +966,10 @@ impl<'a, 'o> Parser<'a, 'o> {
         {
             ast.end_line = self.line_number;
             ast.end_column = self.linebuf.len();
-            if ast.end_column > 0 && self.linebuf.as_bytes()[ast.end_column - 1] == b'\n' {
+            if ast.end_column > 0 && self.linebuf[ast.end_column - 1] == b'\n' {
                 ast.end_column -= 1;
             }
-            if ast.end_column > 0 && self.linebuf.as_bytes()[ast.end_column - 1] == b'\r' {
+            if ast.end_column > 0 && self.linebuf[ast.end_column - 1] == b'\r' {
                 ast.end_column -= 1;
             }
         } else {
@@ -983,11 +984,13 @@ impl<'a, 'o> Parser<'a, 'o> {
 
         match ast.value {
             NodeValue::Paragraph => {
-                while !content.is_empty() && content.as_bytes()[0] == b'[' &&
+                while !content.is_empty() && content[0] == b'[' &&
                     unwrap_into(self.parse_reference_inline(content), &mut pos)
                 {
                     while pos > 0 {
-                        pos -= content.remove(0).len_utf8();
+                        // TODO
+                        content.remove(0);
+                        pos -= 1;
                     }
                 }
                 if strings::is_blank(content) {
@@ -997,11 +1000,11 @@ impl<'a, 'o> Parser<'a, 'o> {
             NodeValue::CodeBlock(ref mut ncb) => {
                 if !ncb.fenced {
                     strings::remove_trailing_blank_lines(content);
-                    content.push('\n');
+                    content.push(b'\n');
                 } else {
                     let mut pos = 0;
                     while pos < content.len() {
-                        if strings::is_line_end_char(content.as_bytes()[pos]) {
+                        if strings::is_line_end_char(content[pos]) {
                             break;
                         }
                         pos += 1;
@@ -1013,15 +1016,17 @@ impl<'a, 'o> Parser<'a, 'o> {
                     strings::unescape(&mut tmp);
                     ncb.info = tmp;
 
-                    if content.as_bytes()[pos] == b'\r' {
+                    if content[pos] == b'\r' {
                         pos += 1;
                     }
-                    if content.as_bytes()[pos] == b'\n' {
+                    if content[pos] == b'\n' {
                         pos += 1;
                     }
 
+                    // TODO
                     while pos > 0 {
-                        pos -= content.remove(0).len_utf8();
+                        content.remove(0);
+                        pos -= 1;
                     }
                 }
                 mem::swap(&mut ncb.literal, content);
@@ -1116,7 +1121,7 @@ impl<'a, 'o> Parser<'a, 'o> {
 
                         match ns.data.borrow().value {
                             NodeValue::Text(ref adj) => {
-                                *root += adj;
+                                root.extend_from_slice(adj);
                                 ns.detach();
                             }
                             _ => {
@@ -1142,7 +1147,7 @@ impl<'a, 'o> Parser<'a, 'o> {
         }
     }
 
-    fn postprocess_text_node(&mut self, node: &'a AstNode<'a>, text: &mut String) {
+    fn postprocess_text_node(&mut self, node: &'a AstNode<'a>, text: &mut Vec<u8>) {
         if self.options.ext_tasklist {
             self.process_tasklist(node, text);
         }
@@ -1153,14 +1158,14 @@ impl<'a, 'o> Parser<'a, 'o> {
 
     }
 
-    fn process_tasklist(&mut self, node: &'a AstNode<'a>, text: &mut String) {
+    fn process_tasklist(&mut self, node: &'a AstNode<'a>, text: &mut Vec<u8>) {
         lazy_static! {
             static ref TASKLIST: Regex = Regex::new(r"\A(\s*\[([xX ])\])(?:\z|\s)").unwrap();
         }
 
         let (active, end) = match TASKLIST.captures(text) {
             None => return,
-            Some(c) => (c.get(2).unwrap().as_str() != " ", c.get(1).unwrap().end()),
+            Some(c) => (c.get(2).unwrap().as_bytes() != b" ", c.get(1).unwrap().end()),
         };
 
         let parent = node.parent().unwrap();
@@ -1178,21 +1183,21 @@ impl<'a, 'o> Parser<'a, 'o> {
             _ => return,
         }
 
-        *text = text[end..].to_string();
+        *text = text[end..].to_vec();
         let checkbox = inlines::make_inline(
             self.arena,
             NodeValue::HtmlInline(
-                (if active {
-                     "<input type=\"checkbox\" disabled=\"\" checked=\"\" />"
-                 } else {
-                     "<input type=\"checkbox\" disabled=\"\" />"
-                 }).to_string(),
+                if active {
+                    b"<input type=\"checkbox\" disabled=\"\" checked=\"\" />".to_vec()
+                } else {
+                    b"<input type=\"checkbox\" disabled=\"\" />".to_vec()
+                }
             ),
         );
         node.insert_before(checkbox);
     }
 
-    fn parse_reference_inline(&mut self, content: &str) -> Option<usize> {
+    fn parse_reference_inline(&mut self, content: &[u8]) -> Option<usize> {
         let delimiter_arena = Arena::new();
         let mut subj = inlines::Subject::new(
             self.arena,
@@ -1202,10 +1207,10 @@ impl<'a, 'o> Parser<'a, 'o> {
             &delimiter_arena,
         );
 
-        let mut lab = match subj.link_label() {
+        let mut lab: Vec<u8> = match subj.link_label() {
             Some(lab) => if lab.is_empty() { return None } else { lab },
             None => return None,
-        }.to_string();
+        }.to_vec();
 
         if subj.peek_char() != Some(&(b':')) {
             return None;
@@ -1217,7 +1222,7 @@ impl<'a, 'o> Parser<'a, 'o> {
             Some(matchlen) => matchlen,
             None => return None,
         };
-        let url = subj.input[subj.pos..subj.pos + matchlen].to_string();
+        let url = subj.input[subj.pos..subj.pos + matchlen].to_vec();
         subj.pos += matchlen;
 
         let beforetitle = subj.pos;
@@ -1226,11 +1231,11 @@ impl<'a, 'o> Parser<'a, 'o> {
             Some(matchlen) => {
                 let t = &subj.input[subj.pos..subj.pos + matchlen];
                 subj.pos += matchlen;
-                t.to_string()
+                t.to_vec()
             }
             _ => {
                 subj.pos = beforetitle;
-                String::new()
+                vec![]
             }
         };
 
@@ -1249,7 +1254,7 @@ impl<'a, 'o> Parser<'a, 'o> {
 
         lab = strings::normalize_reference_label(&lab);
         if !lab.is_empty() {
-            subj.refmap.entry(lab).or_insert(Reference {
+            subj.refmap.entry(lab.to_vec()).or_insert(Reference {
                 url: strings::clean_url(&url),
                 title: strings::clean_title(&title),
             });
@@ -1265,25 +1270,25 @@ enum AddTextResult {
 }
 
 fn parse_list_marker(
-    line: &str,
+    line: &[u8],
     mut pos: usize,
     interrupts_paragraph: bool,
 ) -> Option<(usize, NodeList)> {
-    let mut c = line.as_bytes()[pos];
+    let mut c = line[pos];
     let startpos = pos;
 
     if c == b'*' || c == b'-' || c == b'+' {
         pos += 1;
-        if !isspace(line.as_bytes()[pos]) {
+        if !isspace(line[pos]) {
             return None;
         }
 
         if interrupts_paragraph {
             let mut i = pos;
-            while strings::is_space_or_tab(line.as_bytes()[i]) {
+            while strings::is_space_or_tab(line[i]) {
                 i += 1;
             }
-            if line.as_bytes()[i] == b'\n' {
+            if line[i] == b'\n' {
                 return None;
             }
         }
@@ -1305,11 +1310,11 @@ fn parse_list_marker(
         let mut digits = 0;
 
         loop {
-            start = (10 * start) + (line.as_bytes()[pos] - b'0') as usize;
+            start = (10 * start) + (line[pos] - b'0') as usize;
             pos += 1;
             digits += 1;
 
-            if !(digits < 9 && isdigit(line.as_bytes()[pos])) {
+            if !(digits < 9 && isdigit(line[pos])) {
                 break;
             }
         }
@@ -1318,23 +1323,23 @@ fn parse_list_marker(
             return None;
         }
 
-        c = line.as_bytes()[pos];
+        c = line[pos];
         if c != b'.' && c != b')' {
             return None;
         }
 
         pos += 1;
 
-        if !isspace(line.as_bytes()[pos]) {
+        if !isspace(line[pos]) {
             return None;
         }
 
         if interrupts_paragraph {
             let mut i = pos;
-            while strings::is_space_or_tab(line.as_bytes()[i]) {
+            while strings::is_space_or_tab(line[i]) {
                 i += 1;
             }
-            if strings::is_line_end_char(line.as_bytes()[i]) {
+            if strings::is_line_end_char(line[i]) {
                 return None;
             }
         }

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -224,7 +224,6 @@ pub fn normalize_reference_label(i: &[u8]) -> Vec<u8> {
     let i = trim_slice(i);
     let mut v = String::with_capacity(i.len());
     let mut last_was_whitespace = false;
-    // TODO
     for c in unsafe { str::from_utf8_unchecked(i) }.chars() {
         for e in c.to_lowercase() {
             if e.is_whitespace() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -31,14 +31,14 @@ where
     let mut options = ComrakOptions::default();
     opts(&mut options);
 
-    let root = parse_document(&arena, &input.chars().collect::<String>(), &options);
+    let root = parse_document(&arena, input.as_bytes(), &options);
     let mut output = vec![];
     html::format_document(root, &options, &mut output).unwrap();
     compare_strs(&String::from_utf8(output).unwrap(), expected, "regular");
 
     let mut md = vec![];
     cm::format_document(root, &options, &mut md).unwrap();
-    let root = parse_document(&arena, &String::from_utf8(md).unwrap(), &options);
+    let root = parse_document(&arena, &md, &options);
     let mut output_from_rt = vec![];
     html::format_document(root, &options, &mut output_from_rt).unwrap();
     compare_strs(&String::from_utf8(output_from_rt).unwrap(), expected, "roundtrip");

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -31,14 +31,14 @@ where
     let mut options = ComrakOptions::default();
     opts(&mut options);
 
-    let root = parse_document(&arena, input.as_bytes(), &options);
+    let root = parse_document(&arena, input, &options);
     let mut output = vec![];
     html::format_document(root, &options, &mut output).unwrap();
     compare_strs(&String::from_utf8(output).unwrap(), expected, "regular");
 
     let mut md = vec![];
     cm::format_document(root, &options, &mut md).unwrap();
-    let root = parse_document(&arena, &md, &options);
+    let root = parse_document(&arena, &String::from_utf8(md).unwrap(), &options);
     let mut output_from_rt = vec![];
     html::format_document(root, &options, &mut output_from_rt).unwrap();
     compare_strs(&String::from_utf8(output_from_rt).unwrap(), expected, "roundtrip");


### PR DESCRIPTION
Refs #25.

Replace `String`/`str` with `Vec<u8>`/`[u8]`. I'm not entirely pleased with the amount of `unsafe` blocks this adds where we reassert the input data is indeed UTF-8.

`make bench` comparison:

```
master: mean = 1.7500, median = 1.7500, stdev = 0.0694
opt:    mean = 1.6210, median = 1.6050, stdev = 0.0691
```

/cc @DemiMarie 