### PR TITLE
Add header IDs extension

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -65,7 +65,7 @@ pub fn unescape(text: &[u8]) -> Option<(Vec<u8>, usize)> {
 }
 
 fn lookup(text: &[u8]) -> Option<&[u8]> {
-    let entity_str = format!("&{};", unsafe {str::from_utf8_unchecked(text) });
+    let entity_str = format!("&{};", unsafe { str::from_utf8_unchecked(text) });
 
     let entity = ENTITIES.iter().find(|e| e.entity == entity_str);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,15 @@ fn main() {
                 .default_value("0")
                 .help("Specify wrap width (0 = nowrap)"),
         )
+        .arg(
+            clap::Arg::with_name("header-ids")
+                .long("header-ids")
+                .takes_value(true)
+                .value_name("PREFIX")
+                .help(
+                    "Use the Comrak header IDs extension, with the given ID prefix",
+                ),
+        )
         .get_matches();
 
     let mut exts = matches.values_of("extension").map_or(
@@ -122,6 +131,7 @@ fn main() {
         ext_autolink: exts.remove("autolink"),
         ext_tasklist: exts.remove("tasklist"),
         ext_superscript: exts.remove("superscript"),
+        ext_header_ids: matches.value_of("header-ids").map(|s| s.to_string()),
     };
 
     assert!(exts.is_empty());

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -63,7 +63,7 @@ pub struct Parser<'a, 'o> {
     options: &'o ComrakOptions,
 }
 
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone)]
 /// Options for both parser and formatter functions.
 pub struct ComrakOptions {
     /// [Soft line breaks](http://spec.commonmark.org/0.27/#soft-line-breaks) in the input
@@ -197,6 +197,17 @@ pub struct ComrakOptions {
     ///            "<p>e = mc<sup>2</sup>.</p>\n");
     /// ```
     pub ext_superscript: bool,
+
+    /// Enables the header IDs Comrak extension.
+    ///
+    /// ```
+    /// # use comrak::{markdown_to_html, ComrakOptions};
+    /// let mut options = ComrakOptions::default();
+    /// options.ext_header_ids = Some("user-content-".to_string());
+    /// assert_eq!(markdown_to_html("# README\n", &options),
+    ///            "<h1><a href=\"#readme\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-readme\"></a>README</h1>\n");
+    /// ```
+    pub ext_header_ids: Option<String>,
 }
 
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -515,3 +515,26 @@ fn superscript() {
               concat!("<p>e = mc<sup>2</sup>.</p>\n"),
               |opts| opts.ext_superscript = true);
 }
+
+#[test]
+fn header_ids() {
+    html_opts(
+        concat!(
+            "# Hi.\n",
+            "## Hi 1.\n",
+            "### Hi.\n",
+            "#### Hello.\n",
+            "##### Hi.\n",
+            "###### Hello.\n"
+        ),
+        concat!(
+            "<h1><a href=\"#hi\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi\"></a>Hi.</h1>\n",
+            "<h2><a href=\"#hi-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-1\"></a>Hi 1.</h2>\n",
+            "<h3><a href=\"#hi-2\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-2\"></a>Hi.</h3>\n",
+            "<h4><a href=\"#hello\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello\"></a>Hello.</h4>\n",
+            "<h5><a href=\"#hi-3\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-3\"></a>Hi.</h5>\n",
+            "<h6><a href=\"#hello-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello-1\"></a>Hello.</h6>\n"
+        ),
+        |opts| opts.ext_header_ids = Some("user-content-".to_owned()),
+    );
+}


### PR DESCRIPTION
Uses the same logic as GitHub's own header ID filter.

Fixes #40.