### PR TITLE
Back-to-back emphasis parsing

### DIFF
--- a/src/arena_tree.rs
+++ b/src/arena_tree.rs
@@ -20,7 +20,6 @@ make it a cell (`Cell` or `RefCell`) or use cells inside of it.
 
 use std::cell::Cell;
 
-
 /// A node inside a DOM-like tree.
 #[derive(Debug)]
 pub struct Node<'a, T: 'a> {
@@ -31,7 +30,6 @@ pub struct Node<'a, T: 'a> {
     last_child: Cell<Option<&'a Node<'a, T>>>,
     pub data: T,
 }
-
 
 fn same_ref<T>(a: &T, b: &T) -> bool {
     let a: *const T = a;
@@ -222,7 +220,6 @@ impl<'a, T> Node<'a, T> {
     }
 }
 
-
 macro_rules! axis_iterator {
     (#[$attr:meta] $name: ident: $next: ident) => {
         #[$attr]
@@ -270,7 +267,6 @@ axis_iterator! {
     ReverseChildren: previous_sibling
 }
 
-
 /// An iterator of references to a given node and its descendants, in tree order.
 #[derive(Debug)]
 pub struct Descendants<'a, T: 'a>(Traverse<'a, T>);
@@ -288,7 +284,6 @@ impl<'a, T> Iterator for Descendants<'a, T> {
         }
     }
 }
-
 
 #[derive(Debug, Clone)]
 pub enum NodeEdge<T> {
@@ -364,7 +359,6 @@ traverse_iterator! {
     node and its descendants, in reverse tree order."]
     ReverseTraverse: last_child, previous_sibling
 }
-
 
 #[cfg(test)]
 extern crate typed_arena;

--- a/src/ctype.rs
+++ b/src/ctype.rs
@@ -1,4 +1,3 @@
-
 #[cfg_attr(rustfmt, rustfmt_skip)]
 const CMARK_CTYPE_CLASS: [u8; 256] = [
     /*      0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f */

--- a/src/html.rs
+++ b/src/html.rs
@@ -45,7 +45,6 @@ impl<'w> Write for WriteWithLast<'w> {
     }
 }
 
-
 struct HtmlFormatter<'o> {
     output: &'o mut WriteWithLast<'o>,
     options: &'o ComrakOptions,
@@ -265,9 +264,9 @@ impl<'o> HtmlFormatter<'o> {
     fn format<'a>(&mut self, node: &'a AstNode<'a>, plain: bool) -> io::Result<()> {
         if plain {
             match node.data.borrow().value {
-                NodeValue::Text(ref literal) |
-                NodeValue::Code(ref literal) |
-                NodeValue::HtmlInline(ref literal) => {
+                NodeValue::Text(ref literal)
+                | NodeValue::Code(ref literal)
+                | NodeValue::HtmlInline(ref literal) => {
                     try!(self.escape(literal));
                 }
                 NodeValue::LineBreak | NodeValue::SoftBreak => {
@@ -606,9 +605,7 @@ impl<'o> HtmlFormatter<'o> {
                 try!(write!(
                     self.output,
                     "<sup class=\"footnote-ref\"><a href=\"#fn{}\" id=\"fnref{}\">[{}]</a></sup>",
-                    r,
-                    r,
-                    r
+                    r, r, r
                 ));
             },
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
 //! ```
 
 #![deny(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-       trivial_numeric_casts, unstable_features, unused_import_braces, unused_qualifications)]
+        trivial_numeric_casts, unstable_features, unused_import_braces, unused_qualifications)]
 #![cfg_attr(feature = "dev", allow(unstable_features))]
 #![allow(unknown_lints, doc_markdown, cyclomatic_complexity)]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 //! The `comrak` binary.
 
 #![deny(missing_docs, missing_debug_implementations, missing_copy_implementations, trivial_casts,
-       trivial_numeric_casts, unstable_features, unused_import_braces, unused_qualifications)]
+        trivial_numeric_casts, unstable_features, unused_import_braces, unused_qualifications)]
 #![cfg_attr(feature = "dev", allow(unstable_features))]
 #![allow(unknown_lints, doc_markdown, cyclomatic_complexity)]
 

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -147,9 +147,11 @@ pub struct NodeList {
     /// The kind of list (bullet (unordered) or ordered).
     pub list_type: ListType,
 
-    #[doc(hidden)] pub marker_offset: usize,
+    #[doc(hidden)]
+    pub marker_offset: usize,
 
-    #[doc(hidden)] pub padding: usize,
+    #[doc(hidden)]
+    pub padding: usize,
 
     /// For ordered lists, the ordinal the list starts at.
     pub start: usize,
@@ -209,7 +211,8 @@ pub struct NodeCodeBlock {
     /// For fenced code blocks, the length of the fence.
     pub fence_length: usize,
 
-    #[doc(hidden)] pub fence_offset: usize,
+    #[doc(hidden)]
+    pub fence_offset: usize,
 
     /// For fenced code blocks, the [info string](https://github.github.com/gfm/#info-string) after
     /// the opening fence, if any.
@@ -234,31 +237,31 @@ pub struct NodeHeading {
 /// The metadata of an included HTML block.
 #[derive(Debug, Clone)]
 pub struct NodeHtmlBlock {
-    #[doc(hidden)] pub block_type: u8,
+    #[doc(hidden)]
+    pub block_type: u8,
 
     /// The literal contents of the HTML block.  Per NodeCodeBlock, the content is included here
     /// rather than in any inline.
     pub literal: Vec<u8>,
 }
 
-
 impl NodeValue {
     /// Indicates whether this node is a block node or inline node.
     pub fn block(&self) -> bool {
         match *self {
-            NodeValue::Document |
-            NodeValue::BlockQuote |
-            NodeValue::FootnoteDefinition(_) |
-            NodeValue::List(..) |
-            NodeValue::Item(..) |
-            NodeValue::CodeBlock(..) |
-            NodeValue::HtmlBlock(..) |
-            NodeValue::Paragraph |
-            NodeValue::Heading(..) |
-            NodeValue::ThematicBreak |
-            NodeValue::Table(..) |
-            NodeValue::TableRow(..) |
-            NodeValue::TableCell => true,
+            NodeValue::Document
+            | NodeValue::BlockQuote
+            | NodeValue::FootnoteDefinition(_)
+            | NodeValue::List(..)
+            | NodeValue::Item(..)
+            | NodeValue::CodeBlock(..)
+            | NodeValue::HtmlBlock(..)
+            | NodeValue::Paragraph
+            | NodeValue::Heading(..)
+            | NodeValue::ThematicBreak
+            | NodeValue::Table(..)
+            | NodeValue::TableRow(..)
+            | NodeValue::TableCell => true,
             _ => false,
         }
     }
@@ -321,9 +324,12 @@ pub struct Ast {
     /// The column in the input document the node ends at.
     pub end_column: usize,
 
-    #[doc(hidden)] pub content: Vec<u8>,
-    #[doc(hidden)] pub open: bool,
-    #[doc(hidden)] pub last_line_blank: bool,
+    #[doc(hidden)]
+    pub content: Vec<u8>,
+    #[doc(hidden)]
+    pub open: bool,
+    #[doc(hidden)]
+    pub last_line_blank: bool,
 }
 
 #[doc(hidden)]
@@ -359,10 +365,10 @@ pub fn can_contain_type<'a>(node: &'a AstNode<'a>, child: &NodeValue) -> bool {
     }
 
     match node.data.borrow().value {
-        NodeValue::Document |
-        NodeValue::BlockQuote |
-        NodeValue::FootnoteDefinition(_) |
-        NodeValue::Item(..) => {
+        NodeValue::Document
+        | NodeValue::BlockQuote
+        | NodeValue::FootnoteDefinition(_)
+        | NodeValue::Item(..) => {
             child.block() && match *child {
                 NodeValue::Item(..) => false,
                 _ => true,
@@ -374,12 +380,12 @@ pub fn can_contain_type<'a>(node: &'a AstNode<'a>, child: &NodeValue) -> bool {
             _ => false,
         },
 
-        NodeValue::Paragraph |
-        NodeValue::Heading(..) |
-        NodeValue::Emph |
-        NodeValue::Strong |
-        NodeValue::Link(..) |
-        NodeValue::Image(..) => !child.block(),
+        NodeValue::Paragraph
+        | NodeValue::Heading(..)
+        | NodeValue::Emph
+        | NodeValue::Strong
+        | NodeValue::Link(..)
+        | NodeValue::Image(..) => !child.block(),
 
         NodeValue::Table(..) => match *child {
             NodeValue::TableRow(..) => true,
@@ -392,14 +398,14 @@ pub fn can_contain_type<'a>(node: &'a AstNode<'a>, child: &NodeValue) -> bool {
         },
 
         NodeValue::TableCell => match *child {
-            NodeValue::Text(..) |
-            NodeValue::Code(..) |
-            NodeValue::Emph |
-            NodeValue::Strong |
-            NodeValue::Link(..) |
-            NodeValue::Image(..) |
-            NodeValue::Strikethrough |
-            NodeValue::HtmlInline(..) => true,
+            NodeValue::Text(..)
+            | NodeValue::Code(..)
+            | NodeValue::Emph
+            | NodeValue::Strong
+            | NodeValue::Link(..)
+            | NodeValue::Image(..)
+            | NodeValue::Strikethrough
+            | NodeValue::HtmlInline(..) => true,
             _ => false,
         },
 

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -70,18 +70,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
         };
         s.special_chars.extend_from_slice(&[false; 256]);
         for &c in &[
-            b'\n',
-            b'\r',
-            b'_',
-            b'*',
-            b'"',
-            b'`',
-            b'\\',
-            b'&',
-            b'<',
-            b'[',
-            b']',
-            b'!',
+            b'\n', b'\r', b'_', b'*', b'"', b'`', b'\\', b'&', b'<', b'[', b']', b'!'
         ] {
             s.special_chars[c as usize] = true;
         }
@@ -327,7 +316,6 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
     pub fn eof(&self) -> bool {
         self.pos >= self.input.len()
     }
-
 
     #[inline]
     pub fn peek_char(&self) -> Option<&u8> {

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -31,6 +31,7 @@ pub struct Subject<'a: 'd, 'r, 'o, 'd, 'i> {
 
 pub struct Delimiter<'a: 'd, 'd> {
     inl: &'a AstNode<'a>,
+    length: usize,
     delim_char: u8,
     can_open: bool,
     can_close: bool,
@@ -179,39 +180,14 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
                 while opener.is_some() && !Self::del_ref_eq(opener, stack_bottom)
                     && !Self::del_ref_eq(
                         opener,
-                        openers_bottom[closer
-                                           .unwrap()
-                                           .inl
-                                           .data
-                                           .borrow()
-                                           .value
-                                           .text()
-                                           .unwrap()
-                                           .len() % 3]
+                        openers_bottom[closer.unwrap().length % 3]
                             [closer.unwrap().delim_char as usize],
                     ) {
                     if opener.unwrap().can_open
                         && opener.unwrap().delim_char == closer.unwrap().delim_char
                     {
                         let odd_match = (closer.unwrap().can_open || opener.unwrap().can_close)
-                            && ((opener
-                                .unwrap()
-                                .inl
-                                .data
-                                .borrow()
-                                .value
-                                .text()
-                                .unwrap()
-                                .len()
-                                + closer
-                                    .unwrap()
-                                    .inl
-                                    .data
-                                    .borrow()
-                                    .value
-                                    .text()
-                                    .unwrap()
-                                    .len()) % 3 == 0);
+                            && ((opener.unwrap().length + closer.unwrap().length) % 3 == 0);
                         if !odd_match {
                             opener_found = true;
                             break;
@@ -273,15 +249,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
                     closer = closer.unwrap().next.get();
                 }
                 if !opener_found {
-                    let ix = old_closer
-                        .unwrap()
-                        .inl
-                        .data
-                        .borrow()
-                        .value
-                        .text()
-                        .unwrap()
-                        .len() % 3;
+                    let ix = old_closer.unwrap().length % 3;
                     openers_bottom[ix][old_closer.unwrap().delim_char as usize] =
                         old_closer.unwrap().prev.get();
                     if !old_closer.unwrap().can_open {
@@ -494,6 +462,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
             prev: Cell::new(self.last_delimiter),
             next: Cell::new(None),
             inl: inl,
+            length: inl.data.borrow().value.text().unwrap().len(),
             delim_char: c,
             can_open: can_open,
             can_close: can_close,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -240,7 +240,6 @@ pub struct ComrakOptions {
     pub ext_footnotes: bool,
 }
 
-
 #[derive(Clone)]
 pub struct Reference {
     pub url: Vec<u8>,

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -79,7 +79,6 @@ fn try_opening_header<'a, 'o>(
     Some((table, true))
 }
 
-
 fn try_opening_row<'a, 'o>(
     parser: &mut Parser<'a, 'o>,
     container: &'a AstNode<'a>,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -607,10 +607,7 @@ fn footnotes() {
 #[test]
 fn footnote_does_not_eat_exclamation() {
     html_opts(
-        concat!("Here's my footnote![^a]\n",
-                "\n",
-                "[^a]: Yep.\n"
-        ),
+        concat!("Here's my footnote![^a]\n", "\n", "[^a]: Yep.\n"),
         concat!(
             "<p>Here's my footnote!<sup class=\"footnote-ref\"><a href=\"#fn1\" \
              id=\"fnref1\">[1]</a></sup></p>\n",
@@ -623,5 +620,13 @@ fn footnote_does_not_eat_exclamation() {
             "</section>\n"
         ),
         |opts| opts.ext_footnotes = true,
+    );
+}
+
+#[test]
+fn regression_back_to_back_ranges() {
+    html(
+        "**bold*****bold+italic***",
+        "<p><strong>bold</strong><em><strong>bold+italic</strong></em></p>\n",
     );
 }


### PR DESCRIPTION
Fixes https://github.com/kivikakk/comrak/issues/45. We need to cache the length of the delimiter, as the inline content itself isn't immutable as we process emphases.

/cc @SSJohns 