### PR TITLE
Fix the grammar for scanning table marker rows

### DIFF
--- a/src/lexer.pest
+++ b/src/lexer.pest
@@ -48,6 +48,6 @@ table_newline = _{ "\r"? ~ "\n" }
 table_marker = _{ table_spacechar* ~ ":"? ~ "-"+ ~ ":"? ~ table_spacechar* }
 table_cell = { ( escaped_char | !("|" | "\r" | "\n") ~ any)* }
 
-table_start = { "|"? ~ table_marker ~ ("|" ~ table_marker)* ~ "|"? ~ table_spacechar* | table_newline }
+table_start = { "|"? ~ table_marker ~ ("|" ~ table_marker)* ~ "|"? ~ table_spacechar* ~ table_newline }
 table_cell_end = { "|" ~ table_spacechar* ~ table_newline? }
 table_row_end = { table_spacechar* ~ table_newline }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -673,3 +673,21 @@ fn no_panic_on_empty_bookended_atx_headers() {
         "<h1></h1>\n"
     );
 }
+
+#[test]
+fn table_misparse_1() {
+    html_opts(
+        "a\n-b",
+        "<p>a\n-b</p>\n",
+        |opts| opts.ext_table = true,
+    );
+}
+
+#[test]
+fn table_misparse_2() {
+    html_opts(
+        "a\n-b\n-c",
+        "<p>a\n-b\n-c</p>\n",
+        |opts| opts.ext_table = true,
+    );
+}


### PR DESCRIPTION
Scan all the way to newline. This makes some edge cases
parse in accordance with upstream cmark.

Looks like this might have been a typo in the grammar.

I've confirmed this doesn't regress comrak against the cm spec (it has 5 existing failures), though I don't know where the gfm spec source is.