### PR TITLE
Remove a redundant check in parse_inlines

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1216,7 +1216,7 @@ impl<'a, 'o> Parser<'a, 'o> {
             &delimiter_arena,
         );
 
-        while !subj.eof() && subj.parse_inline(node) {}
+        while subj.parse_inline(node) {}
 
         subj.process_emphasis(None);
 


### PR DESCRIPTION
This check is redundant with code inside `Subject::parse_inline`. It is removed in downstream snoomark because we have an additional case inside `Subject::parse_inline` that is also checking for eof, that this check interferes with.

It doesn't look to me like this check is important for either correctness or performance.