### PR TITLE
Speed ups

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1111,7 +1111,9 @@ impl<'a, 'o> Parser<'a, 'o> {
                         seeked += pos;
                     }
                 }
-                *content = content[seeked..].to_vec();
+                if seeked != 0 {
+                    *content = content[seeked..].to_vec();
+                }
                 if strings::is_blank(content) {
                     node.detach();
                 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -606,7 +606,7 @@ impl<'a, 'o> Parser<'a, 'o> {
                     fence_length: matched,
                     fence_offset: first_nonspace - offset,
                     info: Vec::with_capacity(10),
-                    literal: Vec::with_capacity(80),
+                    literal: Vec::new(),
                 };
                 *container =
                     self.add_child(*container, NodeValue::CodeBlock(ncb), first_nonspace + 1);
@@ -625,7 +625,7 @@ impl<'a, 'o> Parser<'a, 'o> {
                 let offset = self.first_nonspace + 1;
                 let nhb = NodeHtmlBlock {
                     block_type: matched as u8,
-                    literal: Vec::with_capacity(10),
+                    literal: Vec::new(),
                 };
 
                 *container = self.add_child(*container, NodeValue::HtmlBlock(nhb), offset);
@@ -731,7 +731,7 @@ impl<'a, 'o> Parser<'a, 'o> {
                     fence_length: 0,
                     fence_offset: 0,
                     info: vec![],
-                    literal: Vec::with_capacity(80),
+                    literal: Vec::new(),
                 };
                 let offset = self.offset + 1;
                 *container = self.add_child(*container, NodeValue::CodeBlock(ncb), offset);
@@ -1152,11 +1152,9 @@ impl<'a, 'o> Parser<'a, 'o> {
                     *content = content[pos..].to_vec();
                 }
                 mem::swap(&mut ncb.literal, content);
-                content.clear();
             }
             NodeValue::HtmlBlock(ref mut nhb) => {
                 mem::swap(&mut nhb.literal, content);
-                content.clear();
             }
             NodeValue::List(ref mut nl) => {
                 nl.tight = true;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1399,7 +1399,9 @@ impl<'a, 'o> Parser<'a, 'o> {
     }
 
     fn parse_reference_inline(&mut self, content: &[u8]) -> Option<usize> {
-        let delimiter_arena = Arena::new();
+        // In this case reference inlines rarely have delimiters
+        // so we often just need the minimal case
+        let delimiter_arena = Arena::with_capacity(0);
         let mut subj = inlines::Subject::new(
             self.arena,
             self.options,

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -1,3 +1,14 @@
+/*!
+  In many of these cases the AST will be scanned and then it
+  is found there is no match. In many of these cases the scan
+  turns up False. It can be see that in the very simplest cases,
+  usually by doing a char check at the very begginning of the
+  line, we can eliminate these checks without the same allocations
+  that are done otherwise and cause the program considerable
+  slowdown.
+
+*/
+
 use pest::Parser;
 use std::str;
 use twoway::find_bytes;
@@ -24,6 +35,9 @@ fn is_match(rule: Rule, line: &[u8]) -> bool {
 
 #[inline(always)]
 pub fn atx_heading_start(line: &[u8]) -> Option<usize> {
+    if line[0] != b'#'{
+        return None
+    }
     search(Rule::atx_heading_start, line)
 }
 
@@ -55,11 +69,17 @@ pub fn html_block_end_5(line: &[u8]) -> bool {
 
 #[inline(always)]
 pub fn open_code_fence(line: &[u8]) -> Option<usize> {
+    if line[0] != b'`' && line[0] != b'~' {
+        return None
+    }
     search(Rule::open_code_fence, line)
 }
 
 #[inline(always)]
 pub fn close_code_fence(line: &[u8]) -> Option<usize> {
+    if line[0] != b'`' && line[0] != b'~' {
+        return None
+    }
     search(Rule::close_code_fence, line)
 }
 
@@ -108,7 +128,8 @@ pub enum SetextChar {
 
 #[inline(always)]
 pub fn setext_heading_line(line: &[u8]) -> Option<SetextChar> {
-    if is_match(Rule::setext_heading_line, line) {
+    if (line[0] == b'=' || line[0] == b'-')
+       && is_match(Rule::setext_heading_line, line) {
         if line[0] == b'=' {
             Some(SetextChar::Equals)
         } else {
@@ -121,6 +142,9 @@ pub fn setext_heading_line(line: &[u8]) -> Option<SetextChar> {
 
 #[inline(always)]
 pub fn thematic_break(line: &[u8]) -> Option<usize> {
+    if line[0] != b'*' && line[0] != b'-' && line[0] != b'_' {
+        return None
+    }
     search(Rule::thematic_break, line)
 }
 


### PR DESCRIPTION
Hey these changes are a part of a heap profiling pass that we've been working on. It basically identifies the most common things that are slowing down the parser or things that are being allocated but never used. 

Quick run-down:

876e8b9: These vecs are allocated with a certain size, but it is often the case that they are never used. We let the allocator give them size in the case that they are used.

67faebf: Often seek is 0 so we don't need to do the memory copying and overwriting unless it's different.

f9b0f9d: The reference inlines noramlly don't have a delimiter, so we start the delimiter with zero capacity.

2e00ec7: Big win, often scanners.rs creates a large reference structure when we could just check the very first character. Since these are called so often this eliminates a large amount of unneeded allocations.

Benches are done on average of 3.
Bench speedup:  `(9,511,724 + 9,335,745 + 9,226,028)/3  = 9357832`
Bench master:      `(12,177,662 + 12,865,365 + 12,590,586)/3 = 12544537`