### PR TITLE
Fix unescaping of `&CounterClockwiseContourIntegral;`

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -10,6 +10,7 @@ if [ x"$SPEC" = "xtrue" ]; then
 	python3 spec_tests.py --program=../../../target/debug/comrak
 	python3 roundtrip_tests.py --program=../../../target/debug/comrak
 	python3 spec_tests.py --no-normalize --spec regression.txt --program=../../../target/debug/comrak
+	python3 entity_tests.py --program=../../../target/debug/comrak
 else
 	cargo test --verbose
 fi

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -5,7 +5,7 @@ use std::cmp::min;
 use std::str;
 
 pub const ENTITY_MIN_LENGTH: usize = 2;
-pub const ENTITY_MAX_LENGTH: usize = 31;
+pub const ENTITY_MAX_LENGTH: usize = 32;
 
 fn isxdigit(ch: &u8) -> bool {
     (*ch >= b'0' && *ch <= b'9') || (*ch >= b'a' && *ch <= b'f') || (*ch >= b'A' && *ch <= b'F')


### PR DESCRIPTION
Add entity_tests.py to CI.