### PR TITLE
Cleanup `feed` and a NUL replacement fix

### DIFF
--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -315,15 +315,6 @@ pub struct Ast {
     /// The line in the input document the node starts at.
     pub start_line: u32,
 
-    /// The column in the input document the node starts at.
-    pub start_column: usize,
-
-    /// The line in the input document the node ends at.
-    pub end_line: u32,
-
-    /// The column in the input document the node ends at.
-    pub end_column: usize,
-
     #[doc(hidden)]
     pub content: Vec<u8>,
     #[doc(hidden)]
@@ -333,14 +324,11 @@ pub struct Ast {
 }
 
 #[doc(hidden)]
-pub fn make_block(value: NodeValue, start_line: u32, start_column: usize) -> Ast {
+pub fn make_block(value: NodeValue, start_line: u32) -> Ast {
     Ast {
         value: value,
         content: vec![],
         start_line: start_line,
-        start_column: start_column,
-        end_line: start_line,
-        end_column: 0,
         open: true,
         last_line_blank: false,
     }

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1125,9 +1125,6 @@ pub fn make_inline<'a>(arena: &'a Arena<AstNode<'a>>, value: NodeValue) -> &'a A
         value: value,
         content: vec![],
         start_line: 0,
-        start_column: 0,
-        end_line: 0,
-        end_column: 0,
         open: false,
         last_line_blank: false,
     };

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -373,7 +373,8 @@ impl<'a, 'o> Parser<'a, 'o> {
                 self.linebuf.extend_from_slice(&s[i..eol]);
                 self.linebuf
                     .extend_from_slice(&"\u{fffd}".to_string().into_bytes());
-                eol += 1;
+                i = eol + 1;
+                continue;
             } else {
                 self.linebuf.extend_from_slice(&s[i..eol]);
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -331,21 +331,17 @@ impl<'a, 'o> Parser<'a, 'o> {
         let mut linebuf = vec![];
 
         while i < sz {
-            let mut process = false;
+            let mut process = true;
             let mut eol = i;
             while eol < sz {
                 if strings::is_line_end_char(buffer[eol]) {
-                    process = true;
                     break;
                 }
                 if buffer[eol] == 0 {
+                    process = false;
                     break;
                 }
                 eol += 1;
-            }
-
-            if eol >= sz {
-                process = true;
             }
 
             if process {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -353,20 +353,19 @@ impl<'a, 'o> Parser<'a, 'o> {
                 } else {
                     self.process_line(&s[i..eol]);
                 }
+
+                i = eol;
+                if i < sz && s[i] == b'\r' {
+                    i += 1;
+                }
+                if i < sz && s[i] == b'\n' {
+                    i += 1;
+                }
             } else {
                 debug_assert!(eol < sz && s[eol] == b'\0');
                 linebuf.extend_from_slice(&s[i..eol]);
                 linebuf.extend_from_slice(&"\u{fffd}".to_string().into_bytes());
                 i = eol + 1;
-                continue;
-            }
-
-            i = eol;
-            if i < sz && s[i] == b'\r' {
-                i += 1;
-            }
-            if i < sz && s[i] == b'\n' {
-                i += 1;
             }
         }
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -346,8 +346,8 @@ impl<'a, 'o> Parser<'a, 'o> {
             if process {
                 if !linebuf.is_empty() {
                     linebuf.extend_from_slice(&s[i..eol]);
-                    let linebuf = mem::replace(&mut linebuf, Vec::with_capacity(80));
                     self.process_line(&linebuf);
+                    linebuf.truncate(0);
                 } else if sz > eol && s[eol] == b'\n' {
                     self.process_line(&s[i..eol + 1]);
                 } else {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -353,13 +353,12 @@ impl<'a, 'o> Parser<'a, 'o> {
                 } else {
                     self.process_line(&s[i..eol]);
                 }
-            } else if eol < sz && s[eol] == b'\0' {
+            } else {
+                debug_assert!(eol < sz && s[eol] == b'\0');
                 linebuf.extend_from_slice(&s[i..eol]);
                 linebuf.extend_from_slice(&"\u{fffd}".to_string().into_bytes());
                 i = eol + 1;
                 continue;
-            } else {
-                linebuf.extend_from_slice(&s[i..eol]);
             }
 
             i = eol;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -55,7 +55,6 @@ pub struct Parser<'a, 'o> {
     blank: bool,
     partially_consumed_tab: bool,
     last_line_length: usize,
-    last_buffer_ended_with_cr: bool,
     options: &'o ComrakOptions,
 }
 
@@ -320,7 +319,6 @@ impl<'a, 'o> Parser<'a, 'o> {
             blank: false,
             partially_consumed_tab: false,
             last_line_length: 0,
-            last_buffer_ended_with_cr: false,
             options: options,
         }
     }
@@ -331,11 +329,6 @@ impl<'a, 'o> Parser<'a, 'o> {
         let buffer = s;
         let sz = buffer.len();
         let mut linebuf = vec![];
-
-        if self.last_buffer_ended_with_cr && buffer[i] == b'\n' {
-            i += 1;
-        }
-        self.last_buffer_ended_with_cr = false;
 
         while i < sz {
             let mut process = false;
@@ -377,9 +370,6 @@ impl<'a, 'o> Parser<'a, 'o> {
             i = eol;
             if i < sz && buffer[i] == b'\r' {
                 i += 1;
-                if i == sz {
-                    self.last_buffer_ended_with_cr = true;
-                }
             }
             if i < sz && buffer[i] == b'\n' {
                 i += 1;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -300,7 +300,7 @@ struct FootnoteDefinition<'a> {
 }
 
 impl<'a, 'o> Parser<'a, 'o> {
-    pub fn new(
+    fn new(
         arena: &'a Arena<AstNode<'a>>,
         root: &'a AstNode<'a>,
         options: &'o ComrakOptions,
@@ -1006,7 +1006,7 @@ impl<'a, 'o> Parser<'a, 'o> {
         }
     }
 
-    pub fn finish(&mut self) -> &'a AstNode<'a> {
+    fn finish(&mut self) -> &'a AstNode<'a> {
         self.finalize_document();
         self.postprocess_text_nodes(self.root);
         self.root

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -326,18 +326,17 @@ impl<'a, 'o> Parser<'a, 'o> {
     fn feed(&mut self, s: &str) {
         let s = s.as_bytes();
         let mut i = 0;
-        let buffer = s;
-        let sz = buffer.len();
+        let sz = s.len();
         let mut linebuf = vec![];
 
         while i < sz {
             let mut process = true;
             let mut eol = i;
             while eol < sz {
-                if strings::is_line_end_char(buffer[eol]) {
+                if strings::is_line_end_char(s[eol]) {
                     break;
                 }
-                if buffer[eol] == 0 {
+                if s[eol] == 0 {
                     process = false;
                     break;
                 }
@@ -349,12 +348,12 @@ impl<'a, 'o> Parser<'a, 'o> {
                     linebuf.extend_from_slice(&s[i..eol]);
                     let linebuf = mem::replace(&mut linebuf, Vec::with_capacity(80));
                     self.process_line(&linebuf);
-                } else if sz > eol && buffer[eol] == b'\n' {
+                } else if sz > eol && s[eol] == b'\n' {
                     self.process_line(&s[i..eol + 1]);
                 } else {
                     self.process_line(&s[i..eol]);
                 }
-            } else if eol < sz && buffer[eol] == b'\0' {
+            } else if eol < sz && s[eol] == b'\0' {
                 linebuf.extend_from_slice(&s[i..eol]);
                 linebuf.extend_from_slice(&"\u{fffd}".to_string().into_bytes());
                 i = eol + 1;
@@ -364,10 +363,10 @@ impl<'a, 'o> Parser<'a, 'o> {
             }
 
             i = eol;
-            if i < sz && buffer[i] == b'\r' {
+            if i < sz && s[i] == b'\r' {
                 i += 1;
             }
-            if i < sz && buffer[i] == b'\n' {
+            if i < sz && s[i] == b'\n' {
                 i += 1;
             }
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -37,7 +37,7 @@ pub fn parse_document<'a>(
         last_line_blank: false,
     })));
     let mut parser = Parser::new(arena, root, options);
-    parser.feed(buffer, true);
+    parser.feed(buffer);
     parser.finish()
 }
 
@@ -327,7 +327,7 @@ impl<'a, 'o> Parser<'a, 'o> {
         }
     }
 
-    fn feed(&mut self, s: &str, eof: bool) {
+    fn feed(&mut self, s: &str) {
         let s = s.as_bytes();
         let mut i = 0;
         let buffer = s;
@@ -352,7 +352,7 @@ impl<'a, 'o> Parser<'a, 'o> {
                 eol += 1;
             }
 
-            if eol >= sz && eof {
+            if eol >= sz {
                 process = true;
             }
 

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -58,18 +58,16 @@ fn try_opening_header<'a, 'o>(
         });
     }
 
-    let start_column = container.data.borrow().start_column;
     let child = make_block(
         NodeValue::Table(alignments),
         parser.line_number,
-        start_column,
     );
     let table = parser.arena.alloc(Node::new(RefCell::new(child)));
     container.append(table);
 
-    let header = parser.add_child(table, NodeValue::TableRow(true), start_column);
+    let header = parser.add_child(table, NodeValue::TableRow(true));
     for header_str in header_row {
-        let header_cell = parser.add_child(header, NodeValue::TableCell, start_column);
+        let header_cell = parser.add_child(header, NodeValue::TableCell);
         header_cell.data.borrow_mut().content = header_str;
     }
 
@@ -92,7 +90,6 @@ fn try_opening_row<'a, 'o>(
     let new_row = parser.add_child(
         container,
         NodeValue::TableRow(false),
-        container.data.borrow().start_column,
     );
 
     let mut i = 0;
@@ -100,7 +97,6 @@ fn try_opening_row<'a, 'o>(
         let cell = parser.add_child(
             new_row,
             NodeValue::TableCell,
-            container.data.borrow().start_column,
         );
         cell.data.borrow_mut().content = this_row[i].clone();
         i += 1;
@@ -110,7 +106,6 @@ fn try_opening_row<'a, 'o>(
         parser.add_child(
             new_row,
             NodeValue::TableCell,
-            container.data.borrow().start_column,
         );
         i += 1;
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -870,3 +870,31 @@ fn angle_bracketed_link_fallback_2() {
     // Test should probably be in the spec.
     html("[a](<b\n)", "<p><a href=\"%3Cb\">a</a></p>\n");
 }
+
+// Again, at least some of these cases are not covered by the reference
+// implementation's test suite - 3 and 4 were broken in comrak.
+
+#[test]
+fn nul_replacement_1() {
+    html("a\0b", "<p>a\u{fffd}b</p>\n");
+}
+
+#[test]
+fn nul_replacement_2() {
+    html("a\0b\0c", "<p>a\u{fffd}b\u{fffd}c</p>\n");
+}
+
+#[test]
+fn nul_replacement_3() {
+    html("a\0\nb", "<p>a\u{fffd}\nb</p>\n");
+}
+
+#[test]
+fn nul_replacement_4() {
+    html("a\0\r\nb", "<p>a\u{fffd}\nb</p>\n");
+}
+
+#[test]
+fn nul_replacement_5() {
+    html("a\r\n\0b", "<p>a\n\u{fffd}b</p>\n");
+}


### PR DESCRIPTION
My goal here was to simplify `feed` but I ended up doing a few other things:

- Fix the accounting around `\0` and newlines in the first commit - these were missed in the test suite, and seem to pass in the reference implementation.
- Remove three of the line/column accounting variables from `Ast`. Most were only read to deal with accounting from feed being called multiple times, and even then the further results not actually used meaningfully. The final one, `start_line`, is only read in one location, and removing it doesn't affect the test suite to my recollection, but messing with it isn't particularly relevant here.