### PR TITLE
Callback for Broken Reference Links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ mod tests;
 
 pub use cm::format_document as format_commonmark;
 pub use html::format_document as format_html;
-pub use parser::{parse_document, ComrakOptions};
+pub use parser::{parse_document, parse_document_with_broken_link_callback, ComrakOptions};
 pub use typed_arena::Arena;
 pub use html::Anchorizer;
 

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -893,6 +893,8 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
         let is_image = self.brackets[brackets_len - 1].image;
         let after_link_text_pos = self.pos;
 
+        // Try to find a link destination within parenthesis
+
         let mut sps = 0;
         let mut url: &[u8] = &[];
         let mut n: usize = 0;
@@ -924,6 +926,8 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
                 self.pos = after_link_text_pos;
             }
         }
+
+        // Try to see if this is a reference link
 
         let (mut lab, mut found_label) = match self.link_label() {
             Some(lab) => (lab.to_vec(), true),

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -15,7 +15,7 @@ use unicode_categories::UnicodeCategories;
 const MAXBACKTICKS: usize = 80;
 const MAX_LINK_LABEL_LENGTH: usize = 1000;
 
-pub struct Subject<'a: 'd, 'r, 'o, 'd, 'i> {
+pub struct Subject<'a: 'd, 'r, 'o, 'd, 'i, 'c, 'subj> {
     pub arena: &'a Arena<AstNode<'a>>,
     options: &'o ComrakOptions,
     pub input: &'i [u8],
@@ -29,6 +29,10 @@ pub struct Subject<'a: 'd, 'r, 'o, 'd, 'i> {
     special_chars: [bool; 256],
     skip_chars: [bool; 256],
     smart_chars: [bool; 256],
+    // Need to borrow the callback from the parser only for the lifetime of the Subject, 'subj, and
+    // then give it back when the Subject goes out of scope. Needs to be a mutable reference so we
+    // can call the FnMut and let it mutate its captured variables.
+    callback: Option<&'subj mut &'c mut dyn FnMut(&[u8]) -> Option<(Vec<u8>, Vec<u8>)>>,
 }
 
 pub struct Delimiter<'a: 'd, 'd> {
@@ -50,13 +54,14 @@ struct Bracket<'a: 'd, 'd> {
     bracket_after: bool,
 }
 
-impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
+impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
     pub fn new(
         arena: &'a Arena<AstNode<'a>>,
         options: &'o ComrakOptions,
         input: &'i [u8],
         refmap: &'r mut HashMap<Vec<u8>, Reference>,
         delimiter_arena: &'d Arena<Delimiter<'a, 'd>>,
+        callback: Option<&'subj mut &'c mut dyn FnMut(&[u8]) -> Option<(Vec<u8>, Vec<u8>)>>,
     ) -> Self {
         let mut s = Subject {
             arena: arena,
@@ -72,6 +77,7 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
             special_chars: [false; 256],
             skip_chars: [false; 256],
             smart_chars: [false; 256],
+            callback: callback,
         };
         for &c in &[
             b'\n', b'\r', b'_', b'*', b'"', b'`', b'\\', b'&', b'<', b'[', b']', b'!',
@@ -943,12 +949,20 @@ impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
             found_label = true;
         }
 
-        let reff: Option<Reference> = if found_label {
-            lab = strings::normalize_label(&lab);
+        // Need to normalize both to lookup in refmap and to call callback
+        lab = strings::normalize_label(&lab);
+        let mut reff = if found_label {
             self.refmap.get(&lab).cloned()
         } else {
             None
         };
+
+        // Attempt to use the provided broken link callback if a reference cannot be resolved
+        if reff.is_none() {
+            if let Some(ref mut callback) = self.callback {
+                reff = callback(&lab).map(|(url, title)| Reference {url: url, title: title});
+            }
+        }
 
         if let Some(reff) = reff {
             self.close_bracket_match(is_image, reff.url.clone(), reff.title.clone());

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1355,10 +1355,12 @@ impl<'a, 'o> Parser<'a, 'o> {
                 let mut this_bracket = false;
                 loop {
                     match n.data.borrow_mut().value {
+                        // Join adjacent text nodes together
                         NodeValue::Text(ref mut root) => {
                             let ns = match n.next_sibling() {
                                 Some(ns) => ns,
                                 _ => {
+                                    // Post-process once we are finished joining text nodes
                                     self.postprocess_text_node(n, root);
                                     break;
                                 }
@@ -1370,6 +1372,7 @@ impl<'a, 'o> Parser<'a, 'o> {
                                     ns.detach();
                                 }
                                 _ => {
+                                    // Post-process once we are finished joining text nodes
                                     self.postprocess_text_node(n, root);
                                     break;
                                 }

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -6,8 +6,8 @@ use std::cell::RefCell;
 use std::cmp::min;
 use strings::trim;
 
-pub fn try_opening_block<'a, 'o>(
-    parser: &mut Parser<'a, 'o>,
+pub fn try_opening_block<'a, 'o, 'c>(
+    parser: &mut Parser<'a, 'o, 'c>,
     container: &'a AstNode<'a>,
     line: &[u8],
 ) -> Option<(&'a AstNode<'a>, bool)> {
@@ -23,8 +23,8 @@ pub fn try_opening_block<'a, 'o>(
     }
 }
 
-fn try_opening_header<'a, 'o>(
-    parser: &mut Parser<'a, 'o>,
+fn try_opening_header<'a, 'o, 'c>(
+    parser: &mut Parser<'a, 'o, 'c>,
     container: &'a AstNode<'a>,
     line: &[u8],
 ) -> Option<(&'a AstNode<'a>, bool)> {
@@ -74,8 +74,8 @@ fn try_opening_header<'a, 'o>(
     Some((table, true))
 }
 
-fn try_opening_row<'a, 'o>(
-    parser: &mut Parser<'a, 'o>,
+fn try_opening_row<'a, 'o, 'c>(
+    parser: &mut Parser<'a, 'o, 'c>,
     container: &'a AstNode<'a>,
     alignments: &[TableAlignment],
     line: &[u8],


### PR DESCRIPTION
**Wow!** This implementation is *so* much simpler than #98. I totally get why `pulldown-cmark` went with this.

---

This PR adds a new method `parse_document_with_broken_link_callback` which allows you to pass in a function/closure which will be used to resolve broken reference links. This is similar in spirit (but quite different in reality) than [the method that `pulldown-cmark` has for this](https://docs.rs/pulldown-cmark/0.2.0/pulldown_cmark/struct.Parser.html#method.new_with_broken_link_callback).

I think the approach I've taken here is even more flexible than `pulldown-cmark`. Our closure is `FnMut` instead of `Fn` which means that the user can do whatever they want in the closure to resolve the broken reference. We also use byte slices instead of string slices since that is conventionally what is used throughout the rest of this library.

The change has been tested locally and I added a doctest that both documents how to use this and to show that it really works.

I copied the additional comments I added in my previous PR to this PR so the codebase still improves even though we went with a different approach. :)

If these changes work and they get merged, feel free to close my other PR. :smile: :tada: 

## Documentation Screenshot

![image](https://user-images.githubusercontent.com/530939/52602677-946da680-2e31-11e9-96e3-22dd46323b0d.png)

## Compatibility

Unlike my previous PR (#98), this PR is actually **completely backwards compatible**. By adding a new function and implementing the old one in terms of that, none of my changes can break anyone's code. Feel free to just bump the patch version and release this when it is ready. :tada: 