### PR TITLE
Implement Default for NodeHtmlBlock

### DIFF
--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -270,7 +270,7 @@ pub struct NodeHeading {
 }
 
 /// The metadata of an included HTML block.
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct NodeHtmlBlock {
     #[doc(hidden)]
     pub block_type: u8,


### PR DESCRIPTION
Added Default derive for NodeHtmlBlock so that it can be constructed even though one of its fields is hidden.

This is useful for when you are replacing a node in the AST by creating an HTML block in its place. Having `Default` implemented makes it so you can specify only the fields you care about and not have to know about the `#[doc(hidden)]` fields.

```rust
NodeHtmlBlock {
    literal: b"<h1>Hello!</h1>".to_vec(),
    ..NodeHtmlBlock::default()
}
```

I noticed that the other structs with hidden fields (other than `Ast`) all implement `Default`, so I thought I would add it for `NodeHtmlBlock` too.

It is probably a good idea to add some constructors for `Ast` as well so that people can create that struct when needed (to add brand new nodes to the tree). I don't know what those constructors would be (don't know the code well enough), so I'll leave that up to you. :)