### PR TITLE
make_block -> Ast::new, expose

### DIFF
--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -362,14 +362,16 @@ pub struct Ast {
     pub last_line_blank: bool,
 }
 
-/// Create a new AST node with the given value.
-pub fn make_ast(value: NodeValue) -> Ast {
-    Ast {
-        value: value,
-        content: vec![],
-        start_line: 0,
-        open: true,
-        last_line_blank: false,
+impl Ast {
+    /// Create a new AST node with the given value.
+    pub fn new(value: NodeValue) -> Self {
+        Ast {
+            value: value,
+            content: vec![],
+            start_line: 0,
+            open: true,
+            last_line_blank: false,
+        }
     }
 }
 

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -362,12 +362,12 @@ pub struct Ast {
     pub last_line_blank: bool,
 }
 
-#[doc(hidden)]
-pub fn make_block(value: NodeValue, start_line: u32) -> Ast {
+/// Create a new AST node with the given value.
+pub fn make_ast(value: NodeValue) -> Ast {
     Ast {
         value: value,
         content: vec![],
-        start_line: start_line,
+        start_line: 0,
         open: true,
         last_line_blank: false,
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7,7 +7,7 @@ use ctype::{isdigit, isspace};
 use entity;
 use nodes;
 use nodes::{
-    make_block, Ast, AstNode, ListDelimType, ListType, NodeCodeBlock, NodeDescriptionItem,
+    make_ast, Ast, AstNode, ListDelimType, ListType, NodeCodeBlock, NodeDescriptionItem,
     NodeHeading, NodeHtmlBlock, NodeList, NodeValue,
 };
 use regex::bytes::Regex;
@@ -1027,7 +1027,8 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
             parent = self.finalize(parent).unwrap();
         }
 
-        let child = make_block(value, self.line_number);
+        let mut child = make_ast(value);
+        child.start_line = self.line_number;
         let node = self.arena.alloc(Node::new(RefCell::new(child)));
         parent.append(node);
         node

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7,7 +7,7 @@ use ctype::{isdigit, isspace};
 use entity;
 use nodes;
 use nodes::{
-    make_ast, Ast, AstNode, ListDelimType, ListType, NodeCodeBlock, NodeDescriptionItem,
+    Ast, AstNode, ListDelimType, ListType, NodeCodeBlock, NodeDescriptionItem,
     NodeHeading, NodeHtmlBlock, NodeList, NodeValue,
 };
 use regex::bytes::Regex;
@@ -1027,7 +1027,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
             parent = self.finalize(parent).unwrap();
         }
 
-        let mut child = make_ast(value);
+        let mut child = Ast::new(value);
         child.start_line = self.line_number;
         let node = self.arena.alloc(Node::new(RefCell::new(child)));
         parent.append(node);

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -1,5 +1,5 @@
 use arena_tree::Node;
-use nodes::{make_ast, AstNode, NodeValue, TableAlignment};
+use nodes::{Ast, AstNode, NodeValue, TableAlignment};
 use parser::Parser;
 use scanners;
 use std::cell::RefCell;
@@ -58,7 +58,7 @@ fn try_opening_header<'a, 'o, 'c>(
         });
     }
 
-    let mut child = make_ast(NodeValue::Table(alignments));
+    let mut child = Ast::new(NodeValue::Table(alignments));
     child.start_line = parser.line_number;
     let table = parser.arena.alloc(Node::new(RefCell::new(child)));
     container.append(table);

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -1,5 +1,5 @@
 use arena_tree::Node;
-use nodes::{make_block, AstNode, NodeValue, TableAlignment};
+use nodes::{make_ast, AstNode, NodeValue, TableAlignment};
 use parser::Parser;
 use scanners;
 use std::cell::RefCell;
@@ -58,7 +58,8 @@ fn try_opening_header<'a, 'o, 'c>(
         });
     }
 
-    let child = make_block(NodeValue::Table(alignments), parser.line_number);
+    let mut child = make_ast(NodeValue::Table(alignments));
+    child.start_line = parser.line_number;
     let table = parser.arena.alloc(Node::new(RefCell::new(child)));
     container.append(table);
 


### PR DESCRIPTION
Ref @sunjay's comment in #101; make this function accessible and straightforward to use. (Most users won't be assigning line numbers when constructing ASTs manually.)