### PR TITLE
Document that label in the broken reference callback is normalized

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -50,6 +50,9 @@ pub fn parse_document<'a>(
 /// the reference name, and the returned pair will be used as the link destination and title if not
 /// None.
 ///
+/// **Note:** The label provided to the callback is the normalized representation of the label as
+/// described in the [GFM spec](https://github.github.com/gfm/#matches).
+///
 /// ```
 /// extern crate comrak;
 /// use comrak::{Arena, parse_document_with_broken_link_callback, format_html, ComrakOptions};


### PR DESCRIPTION
I implemented this feature, but still somehow forgot that the label gets normalized. I think this should be documented so other people also keep this in mind. :)

## Screenshot

![image](https://user-images.githubusercontent.com/530939/52906217-467fe680-3215-11e9-8ef0-134544409584.png)
