### PR TITLE
Added a constructor for AstNode

### DIFF
--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -380,7 +380,21 @@ impl Ast {
 /// It is bound by the lifetime `'a`, which corresponds to the `Arena` nodes are allocated in.
 /// `AstNode`s are almost handled as a reference itself bound by `'a`.  Child `Ast`s are wrapped in
 /// `RefCell` for interior mutability.
+///
+/// You can construct a new `AstNode` from a `NodeValue` using the `From` trait:
+///
+/// ```no_run
+/// # use comrak::nodes::{AstNode, NodeValue};
+/// let root = AstNode::from(NodeValue::Document);
+/// ```
 pub type AstNode<'a> = Node<'a, RefCell<Ast>>;
+
+impl<'a> From<NodeValue> for AstNode<'a> {
+    /// Create a new AST node with the given value.
+    fn from(value: NodeValue) -> Self {
+        Node::new(RefCell::new(Ast::new(value)))
+    }
+}
 
 #[doc(hidden)]
 pub fn last_child_is_open<'a>(node: &'a AstNode<'a>) -> bool {


### PR DESCRIPTION
Hello again!
I added a constructor for AstNode so we don't have to go through 3 constructors every time just to create one.

The issue I'm addressing is that `AstNode` is `Node<'a, RefCell<Ast>>` which is three nested objects. That means to make one from a `NodeValue`, you have to use three constructors:

```rust
Node::new(RefCell::new(Ast::new(value)))
```

Rather than just make a utility function in my code, I thought it would be better to just add a constructor so you can do `AstNode::from(value)` instead.

If/when this gets merged, could you release a new patch version of `comrak`? Thanks as always! :smile: :tada: 

## Documentation Screenshot

![image](https://user-images.githubusercontent.com/530939/53272169-884dd880-36be-11e9-92cd-43d5438fae61.png)
