### PR TITLE
Remove list item indentation

### DIFF
--- a/src/cm.rs
+++ b/src/cm.rs
@@ -323,7 +323,7 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
                 let mut listmarker = vec![];
 
                 let marker_width = if parent.list_type == ListType::Bullet {
-                    4
+                    2
                 } else {
                     let mut list_number = parent.start;
                     let list_delim = parent.delimiter;
@@ -502,9 +502,9 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
             }
             NodeValue::TaskItem(checked) => if entering {
                 if checked {
-                    write!(self, " [x] ").unwrap();
+                    write!(self, "[x] ").unwrap();
                 } else {
-                    write!(self, " [ ] ").unwrap();
+                    write!(self, "[ ] ").unwrap();
                 }
             },
             NodeValue::Strikethrough => if entering {

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -348,7 +348,7 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
 
                 if entering {
                     if parent.list_type == ListType::Bullet {
-                        write!(self, "  - ").unwrap();
+                        write!(self, "- ").unwrap();
                     } else {
                         self.write_all(&listmarker).unwrap();
                     }


### PR DESCRIPTION
I'm using comrak to parse and dump a CM readme so I can apply automatic modifications to it. (In particular, adding a table of contents and keeping a table derived from an external data-source up to date.)

I noticed that list items get two extra spaces of indentation when formatted as CM. I think perhaps this is a bug, but I wasn't sure.

Since it's a relatively simple change to remove it, I decided to open a PR instead of opening an issue.

Please feel free to close if it's intentional!