### PR TITLE
split options into 3 substructs

### DIFF
--- a/examples/s-expr.rs
+++ b/examples/s-expr.rs
@@ -16,7 +16,7 @@ const INDENT: usize = 4;
 const CLOSE_NEWLINE: bool = false;
 
 use comrak::nodes::{AstNode, NodeValue};
-use comrak::{parse_document, Arena, ComrakOptions};
+use comrak::{parse_document, Arena, ComrakOptions, ComrakExtensionOptions};
 use std::env;
 use std::error::Error;
 use std::fs::File;
@@ -78,14 +78,17 @@ fn dump(source: &str) -> io::Result<()> {
     let arena = Arena::new();
 
     let opts = ComrakOptions {
-        ext_strikethrough: true,
-        ext_tagfilter: true,
-        ext_table: true,
-        ext_autolink: true,
-        ext_tasklist: true,
-        ext_superscript: true,
-        ext_footnotes: true,
-        ext_description_lists: true,
+        extension: ComrakExtensionOptions {
+            strikethrough: true,
+            tagfilter: true,
+            table: true,
+            autolink: true,
+            tasklist: true,
+            superscript: true,
+            footnotes: true,
+            description_lists: true,
+            ..ComrakExtensionOptions::default()
+        },
         ..ComrakOptions::default()
     };
 
@@ -95,7 +98,7 @@ fn dump(source: &str) -> io::Result<()> {
     iter_nodes(doc, &mut output, 0)
 }
 
-fn main() -> Result<(), Box<Error>> {
+fn main() -> Result<(), Box<dyn Error>> {
     let mut args = env::args_os().skip(1).peekable();
     let mut body = String::new();
 

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -145,8 +145,8 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
                 self.begin_content = self.begin_content && isdigit(buf[i]);
             }
 
-            if self.options.width > 0
-                && self.column > self.options.width
+            if self.options.render.width > 0
+                && self.column > self.options.render.width
                 && !self.begin_line
                 && self.last_breakable > 0
             {
@@ -282,7 +282,7 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
 
     fn format_node(&mut self, node: &'a AstNode<'a>, entering: bool) -> bool {
         self.node = node;
-        let allow_wrap = self.options.width > 0 && !self.options.hardbreaks;
+        let allow_wrap = self.options.render.width > 0 && !self.options.render.hardbreaks;
 
         if !(match node.data.borrow().value {
             NodeValue::Item(..) => true,
@@ -444,13 +444,13 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
                 self.output(literal, allow_wrap, Escaping::Normal);
             },
             NodeValue::LineBreak => if entering {
-                if !self.options.hardbreaks {
+                if !self.options.render.hardbreaks {
                     write!(self, "  ").unwrap();
                 }
                 self.cr();
             },
             NodeValue::SoftBreak => if entering {
-                if !self.no_linebreaks && self.options.width == 0 && !self.options.hardbreaks {
+                if !self.no_linebreaks && self.options.render.width == 0 && !self.options.render.hardbreaks {
                     self.cr();
                 } else {
                     self.output(&[b' '], allow_wrap, Escaping::Literal);

--- a/src/html.rs
+++ b/src/html.rs
@@ -452,7 +452,7 @@ impl<'o> HtmlFormatter<'o> {
                     self.cr()?;
                     write!(self.output, "<h{}>", nch.level)?;
 
-                    if let Some(ref prefix) = self.options.ext_header_ids {
+                    if let Some(ref prefix) = self.options.extension.header_ids {
                         let mut text_content = Vec::with_capacity(20);
                         self.collect_text(node, &mut text_content);
 
@@ -481,7 +481,7 @@ impl<'o> HtmlFormatter<'o> {
                         first_tag += 1;
                     }
 
-                    if self.options.github_pre_lang {
+                    if self.options.render.github_pre_lang {
                         self.output.write_all(b"<pre lang=\"")?;
                         self.escape(&ncb.info[..first_tag])?;
                         self.output.write_all(b"\"><code>")?;
@@ -496,9 +496,9 @@ impl<'o> HtmlFormatter<'o> {
             },
             NodeValue::HtmlBlock(ref nhb) => if entering {
                 self.cr()?;
-                if !self.options.unsafe_ {
+                if !self.options.render.unsafe_ {
                     self.output.write_all(b"<!-- raw HTML omitted -->")?;
-                } else if self.options.ext_tagfilter {
+                } else if self.options.extension.tagfilter {
                     tagfilter_block(&nhb.literal, &mut self.output)?;
                 } else {
                     self.output.write_all(&nhb.literal)?;
@@ -543,7 +543,7 @@ impl<'o> HtmlFormatter<'o> {
                 self.output.write_all(b"<br />\n")?;
             },
             NodeValue::SoftBreak => if entering {
-                if self.options.hardbreaks {
+                if self.options.render.hardbreaks {
                     self.output.write_all(b"<br />\n")?;
                 } else {
                     self.output.write_all(b"\n")?;
@@ -555,9 +555,9 @@ impl<'o> HtmlFormatter<'o> {
                 self.output.write_all(b"</code>")?;
             },
             NodeValue::HtmlInline(ref literal) => if entering {
-                if !self.options.unsafe_ {
+                if !self.options.render.unsafe_ {
                     self.output.write_all(b"<!-- raw HTML omitted -->")?;
-                } else if self.options.ext_tagfilter && tagfilter(literal) {
+                } else if self.options.extension.tagfilter && tagfilter(literal) {
                     self.output.write_all(b"&lt;")?;
                     self.output.write_all(&literal[1..])?;
                 } else {
@@ -586,7 +586,7 @@ impl<'o> HtmlFormatter<'o> {
             },
             NodeValue::Link(ref nl) => if entering {
                 self.output.write_all(b"<a href=\"")?;
-                if self.options.unsafe_ || !dangerous_url(&nl.url) {
+                if self.options.render.unsafe_ || !dangerous_url(&nl.url) {
                     self.escape_href(&nl.url)?;
                 }
                 if !nl.title.is_empty() {
@@ -599,7 +599,7 @@ impl<'o> HtmlFormatter<'o> {
             },
             NodeValue::Image(ref nl) => if entering {
                 self.output.write_all(b"<img src=\"")?;
-                if self.options.unsafe_ || !dangerous_url(&nl.url) {
+                if self.options.render.unsafe_ || !dangerous_url(&nl.url) {
                     self.escape_href(&nl.url)?;
                 }
                 self.output.write_all(b"\" alt=\"")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ mod tests;
 
 pub use cm::format_document as format_commonmark;
 pub use html::format_document as format_html;
-pub use parser::{parse_document, parse_document_with_broken_link_callback, ComrakOptions};
+pub use parser::{parse_document, parse_document_with_broken_link_callback, ComrakOptions, ComrakExtensionOptions, ComrakParseOptions, ComrakRenderOptions};
 pub use typed_arena::Arena;
 pub use html::Anchorizer;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ extern crate comrak;
 #[macro_use]
 extern crate clap;
 
-use comrak::{Arena, ComrakOptions};
+use comrak::{Arena, ComrakOptions, ComrakExtensionOptions, ComrakParseOptions, ComrakRenderOptions};
 
 use std::boxed::Box;
 use std::collections::BTreeSet;
@@ -108,27 +108,33 @@ fn main() -> Result<(), Box<dyn Error>> {
         .map_or(BTreeSet::new(), |vals| vals.collect());
 
     let options = ComrakOptions {
-        hardbreaks: matches.is_present("hardbreaks"),
-        smart: matches.is_present("smart"),
-        github_pre_lang: matches.is_present("github-pre-lang") || matches.is_present("gfm"),
-        width: matches
-            .value_of("width")
-            .unwrap_or("0")
-            .parse()
-            .unwrap_or(0),
-        default_info_string: matches
-            .value_of("default-info-string")
-            .map(|e| e.to_owned()),
-        unsafe_: matches.is_present("unsafe"),
-        ext_strikethrough: exts.remove("strikethrough") || matches.is_present("gfm"),
-        ext_tagfilter: exts.remove("tagfilter") || matches.is_present("gfm"),
-        ext_table: exts.remove("table") || matches.is_present("gfm"),
-        ext_autolink: exts.remove("autolink") || matches.is_present("gfm"),
-        ext_tasklist: exts.remove("tasklist") || matches.is_present("gfm"),
-        ext_superscript: exts.remove("superscript"),
-        ext_header_ids: matches.value_of("header-ids").map(|s| s.to_string()),
-        ext_footnotes: exts.remove("footnotes"),
-        ext_description_lists: exts.remove("description-lists"),
+        extension: ComrakExtensionOptions {
+            strikethrough: exts.remove("strikethrough") || matches.is_present("gfm"),
+            tagfilter: exts.remove("tagfilter") || matches.is_present("gfm"),
+            table: exts.remove("table") || matches.is_present("gfm"),
+            autolink: exts.remove("autolink") || matches.is_present("gfm"),
+            tasklist: exts.remove("tasklist") || matches.is_present("gfm"),
+            superscript: exts.remove("superscript"),
+            header_ids: matches.value_of("header-ids").map(|s| s.to_string()),
+            footnotes: exts.remove("footnotes"),
+            description_lists: exts.remove("description-lists"),
+        },
+        parse: ComrakParseOptions {
+            smart: matches.is_present("smart"),
+            default_info_string: matches
+                .value_of("default-info-string")
+                .map(|e| e.to_owned()),
+        },
+        render: ComrakRenderOptions {
+            hardbreaks: matches.is_present("hardbreaks"),
+            github_pre_lang: matches.is_present("github-pre-lang") || matches.is_present("gfm"),
+            width: matches
+                .value_of("width")
+                .unwrap_or("0")
+                .parse()
+                .unwrap_or(0),
+            unsafe_: matches.is_present("unsafe"),
+        },
     };
 
     if !exts.is_empty() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -52,12 +52,12 @@ where
 }
 
 macro_rules! html_opts {
-    ([$($opt:ident),*], $lhs:expr, $rhs:expr,) => {
-        html_opts!([$($opt),*], $lhs, $rhs)
+    ([$($optclass:ident.$optname:ident),*], $lhs:expr, $rhs:expr,) => {
+        html_opts!([$($optclass.$optname),*], $lhs, $rhs)
     };
-    ([$($opt:ident),*], $lhs:expr, $rhs:expr) => {
+    ([$($optclass:ident.$optname:ident),*], $lhs:expr, $rhs:expr) => {
         html_opts($lhs, $rhs, |opts| {
-            $(opts.$opt = true;)*
+            $(opts.$optclass.$optname = true;)*
         });
     };
 }
@@ -153,7 +153,7 @@ fn setext_heading() {
 #[test]
 fn html_block_1() {
     html_opts!(
-        [unsafe_],
+        [render.unsafe_],
         concat!(
             "<script>\n",
             "*ok* </script> *ok*\n",
@@ -192,7 +192,7 @@ fn html_block_1() {
 #[test]
 fn html_block_2() {
     html_opts!(
-        [unsafe_],
+        [render.unsafe_],
         concat!("   <!-- abc\n", "\n", "ok --> *hi*\n", "*hi*\n"),
         concat!(
             "   <!-- abc\n",
@@ -206,7 +206,7 @@ fn html_block_2() {
 #[test]
 fn html_block_3() {
     html_opts!(
-        [unsafe_],
+        [render.unsafe_],
         concat!(" <? o\n", "k ?> *a*\n", "*a*\n"),
         concat!(" <? o\n", "k ?> *a*\n", "<p><em>a</em></p>\n"),
     );
@@ -215,7 +215,7 @@ fn html_block_3() {
 #[test]
 fn html_block_4() {
     html_opts!(
-        [unsafe_],
+        [render.unsafe_],
         concat!("<!X >\n", "ok\n", "<!X\n", "um > h\n", "ok\n"),
         concat!("<!X >\n", "<p>ok</p>\n", "<!X\n", "um > h\n", "<p>ok</p>\n"),
     );
@@ -224,7 +224,7 @@ fn html_block_4() {
 #[test]
 fn html_block_5() {
     html_opts!(
-        [unsafe_],
+        [render.unsafe_],
         concat!(
             "<![CDATA[\n",
             "\n",
@@ -247,7 +247,7 @@ fn html_block_5() {
 #[test]
 fn html_block_6() {
     html_opts!(
-        [unsafe_],
+        [render.unsafe_],
         concat!(" </table>\n", "*x*\n", "\n", "ok\n", "\n", "<li\n", "*x*\n"),
         concat!(" </table>\n", "*x*\n", "<p>ok</p>\n", "<li\n", "*x*\n"),
     );
@@ -256,7 +256,7 @@ fn html_block_6() {
 #[test]
 fn html_block_7() {
     html_opts!(
-        [unsafe_],
+        [render.unsafe_],
         concat!(
             "<a b >\n",
             "ok\n",
@@ -280,7 +280,7 @@ fn html_block_7() {
     );
 
     html_opts!(
-        [unsafe_],
+        [render.unsafe_],
         concat!("<a b c=x d='y' z=\"f\" >\n", "ok\n", "\n", "ok\n"),
         concat!("<a b c=x d='y' z=\"f\" >\n", "ok\n", "<p>ok</p>\n"),
     );
@@ -334,7 +334,7 @@ fn entities() {
 #[test]
 fn pointy_brace() {
     html_opts!(
-        [unsafe_],
+        [render.unsafe_],
         concat!(
             "URI autolink: <https://www.pixiv.net>\n",
             "\n",
@@ -408,7 +408,7 @@ fn reference_links() {
 #[test]
 fn strikethrough() {
     html_opts!(
-        [ext_strikethrough],
+        [extension.strikethrough],
         concat!(
             "This is ~strikethrough~.\n",
             "\n",
@@ -424,7 +424,7 @@ fn strikethrough() {
 #[test]
 fn table() {
     html_opts!(
-        [ext_table],
+        [extension.table],
         concat!("| a | b |\n", "|---|:-:|\n", "| c | d |\n"),
         concat!(
             "<table>\n",
@@ -448,7 +448,7 @@ fn table() {
 #[test]
 fn autolink_www() {
     html_opts!(
-        [ext_autolink],
+        [extension.autolink],
         concat!("www.autolink.com\n"),
         concat!("<p><a href=\"http://www.autolink.com\">www.autolink.com</a></p>\n"),
     );
@@ -457,7 +457,7 @@ fn autolink_www() {
 #[test]
 fn autolink_email() {
     html_opts!(
-        [ext_autolink],
+        [extension.autolink],
         concat!("john@smith.com\n"),
         concat!("<p><a href=\"mailto:john@smith.com\">john@smith.com</a></p>\n"),
     );
@@ -466,7 +466,7 @@ fn autolink_email() {
 #[test]
 fn autolink_scheme() {
     html_opts!(
-        [ext_autolink],
+        [extension.autolink],
         concat!("https://google.com/search\n"),
         concat!(
             "<p><a href=\"https://google.com/search\">https://google.\
@@ -478,7 +478,7 @@ fn autolink_scheme() {
 #[test]
 fn autolink_scheme_multiline() {
     html_opts!(
-        [ext_autolink],
+        [extension.autolink],
         concat!("https://google.com/search\nhttps://www.google.com/maps"),
         concat!(
             "<p><a href=\"https://google.com/search\">https://google.\
@@ -491,7 +491,7 @@ fn autolink_scheme_multiline() {
 #[test]
 fn autolink_no_link_bad() {
     html_opts!(
-        [ext_autolink],
+        [extension.autolink],
         concat!("@a.b.c@. x\n", "\n", "n@. x\n"),
         concat!("<p>@a.b.c@. x</p>\n", "<p>n@. x</p>\n"),
     );
@@ -500,7 +500,7 @@ fn autolink_no_link_bad() {
 #[test]
 fn tagfilter() {
     html_opts!(
-        [unsafe_, ext_tagfilter],
+        [render.unsafe_, extension.tagfilter],
         concat!("hi <xmp> ok\n", "\n", "<xmp>\n"),
         concat!("<p>hi &lt;xmp> ok</p>\n", "&lt;xmp>\n"),
     );
@@ -509,7 +509,7 @@ fn tagfilter() {
 #[test]
 fn tasklist() {
     html_opts!(
-        [unsafe_, ext_tasklist],
+        [render.unsafe_, extension.tasklist],
         concat!(
             "* [ ] Red\n",
             "* [x] Green\n",
@@ -554,7 +554,7 @@ fn tasklist() {
 #[test]
 fn tasklist_32() {
     html_opts!(
-        [unsafe_, ext_tasklist],
+        [render.unsafe_, extension.tasklist],
         concat!(
             "- [ ] List item 1\n",
             "- [ ] This list item is **bold**\n",
@@ -573,7 +573,7 @@ fn tasklist_32() {
 #[test]
 fn superscript() {
     html_opts!(
-        [ext_superscript],
+        [extension.superscript],
         concat!("e = mc^2^.\n"),
         concat!("<p>e = mc<sup>2</sup>.</p>\n"),
     );
@@ -600,14 +600,14 @@ fn header_ids() {
             "<h6><a href=\"#hello-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello-1\"></a>Hello.</h6>\n",
             "<h1><a href=\"#isnt-it-grand\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-isnt-it-grand\"></a>Isn't it grand?</h1>\n"
         ),
-        |opts| opts.ext_header_ids = Some("user-content-".to_owned()),
+        |opts| opts.extension.header_ids = Some("user-content-".to_owned()),
     );
 }
 
 #[test]
 fn footnotes() {
     html_opts!(
-        [ext_footnotes],
+        [extension.footnotes],
         concat!(
             "Here is a[^nowhere] footnote reference,[^1] and another.[^longnote]\n",
             "\n",
@@ -660,7 +660,7 @@ fn footnotes() {
 #[test]
 fn footnote_does_not_eat_exclamation() {
     html_opts!(
-        [ext_footnotes],
+        [extension.footnotes],
         concat!("Here's my footnote![^a]\n", "\n", "[^a]: Yep.\n"),
         concat!(
             "<p>Here's my footnote!<sup class=\"footnote-ref\"><a href=\"#fn1\" \
@@ -679,7 +679,7 @@ fn footnote_does_not_eat_exclamation() {
 #[test]
 fn footnote_in_table() {
     html_opts!(
-        [ext_table, ext_footnotes],
+        [extension.table, extension.footnotes],
         concat!(
             "A footnote in a paragraph[^1]\n",
             "\n",
@@ -744,24 +744,24 @@ fn no_panic_on_empty_bookended_atx_headers() {
 
 #[test]
 fn table_misparse_1() {
-    html_opts!([ext_table], "a\n-b", "<p>a\n-b</p>\n");
+    html_opts!([extension.table], "a\n-b", "<p>a\n-b</p>\n");
 }
 
 #[test]
 fn table_misparse_2() {
-    html_opts!([ext_table], "a\n-b\n-c", "<p>a\n-b\n-c</p>\n");
+    html_opts!([extension.table], "a\n-b\n-c", "<p>a\n-b\n-c</p>\n");
 }
 
 #[test]
 fn smart_chars() {
     html_opts!(
-        [smart],
+        [parse.smart],
         "Why 'hello' \"there\". It's good.",
         "<p>Why ‘hello’ “there”. It’s good.</p>\n",
     );
 
     html_opts!(
-        [smart],
+        [parse.smart],
         "Hm. Hm.. hm... yes- indeed-- quite---!",
         "<p>Hm. Hm.. hm… yes- indeed– quite—!</p>\n",
     );
@@ -770,7 +770,7 @@ fn smart_chars() {
 #[test]
 fn nested_tables_1() {
     html_opts!(
-        [ext_table],
+        [extension.table],
         concat!("- p\n", "\n", "    |a|b|\n", "    |-|-|\n", "    |c|d|\n",),
         concat!(
             "<ul>\n",
@@ -799,7 +799,7 @@ fn nested_tables_1() {
 #[test]
 fn nested_tables_2() {
     html_opts!(
-        [ext_table],
+        [extension.table],
         concat!("- |a|b|\n", "  |-|-|\n", "  |c|d|\n",),
         concat!(
             "<ul>\n",
@@ -827,7 +827,7 @@ fn nested_tables_2() {
 #[test]
 fn nested_tables_3() {
     html_opts!(
-        [ext_table],
+        [extension.table],
         concat!("> |a|b|\n", "> |-|-|\n", "> |c|d|\n",),
         concat!(
             "<blockquote>\n",
@@ -937,7 +937,7 @@ fn nul_replacement_5() {
 #[test]
 fn description_lists() {
     html_opts!(
-        [ext_description_lists],
+        [extension.description_lists],
         concat!(
             "Term 1\n",
             "\n",
@@ -966,7 +966,7 @@ fn description_lists() {
     );
 
     html_opts!(
-        [ext_description_lists],
+        [extension.description_lists],
         concat!(
             "* Nested\n",
             "\n",


### PR DESCRIPTION
Split options into 3 sub-`structs`. Making this a PR to `develop` rather than `master` because I'm not sure I actually want this to go in yet — it looks kind of ugly and unergonomic. So we'll hack on it a bit here.

/cc @casey FYI, since this affects things you might work on