### PR TITLE
Fix Clippy lint warning

### DIFF
--- a/src/ctype.rs
+++ b/src/ctype.rs
@@ -36,5 +36,5 @@ pub fn isalpha(ch: u8) -> bool {
 }
 
 pub fn isalnum(ch: u8) -> bool {
-    (CMARK_CTYPE_CLASS[ch as usize] == 3 || CMARK_CTYPE_CLASS[ch as usize] == 4)
+    CMARK_CTYPE_CLASS[ch as usize] == 3 || CMARK_CTYPE_CLASS[ch as usize] == 4
 }


### PR DESCRIPTION
Making Clippy happy is a good thing, cluttering build output with lint warnings is a bad thing.