### PR TITLE
fix up how we invoke benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,3 @@ timebomb = "0.1.2"
 
 [features]
 default = ["clap"]
-benchmarks = []

--- a/benches/progit.rs
+++ b/benches/progit.rs
@@ -1,0 +1,24 @@
+#![feature(test)]
+
+extern crate test;
+extern crate comrak;
+
+use comrak::{parse_document, format_html, Arena, ComrakOptions};
+use test::Bencher;
+
+#[bench]
+fn bench_progit(b: &mut Bencher) {
+    use std::fs::File;
+    use std::io::Read;
+
+    let mut file = File::open("script/progit.md").unwrap();
+    let mut s = String::with_capacity(524288);
+    file.read_to_string(&mut s).unwrap();
+    b.iter(|| {
+        let arena = Arena::new();
+        let root = parse_document(&arena, &s, &ComrakOptions::default());
+        let mut output = vec![];
+        format_html(root, &ComrakOptions::default(), &mut output).unwrap()
+    });
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,6 @@
     unused_import_braces
 )]
 #![allow(unknown_lints, clippy::doc_markdown, cyclomatic_complexity)]
-#![cfg_attr(feature = "benchmarks", allow(unstable_features))]
-#![cfg_attr(feature = "benchmarks", feature(test))]
 
 extern crate entities;
 #[macro_use]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,5 @@
 use cm;
 use html;
-#[cfg(feature = "benchmarks")]
-use test::Bencher;
 use timebomb::timeout_ms;
 use {parse_document, Arena, ComrakOptions};
 
@@ -60,23 +58,6 @@ macro_rules! html_opts {
             $(opts.$optclass.$optname = true;)*
         });
     };
-}
-
-#[cfg(feature = "benchmarks")]
-#[cfg_attr(feature = "benchmarks", bench)]
-fn bench_progit(b: &mut Bencher) {
-    use std::fs::File;
-    use std::io::Read;
-
-    let mut file = File::open("script/progit.md").unwrap();
-    let mut s = String::with_capacity(524288);
-    file.read_to_string(&mut s).unwrap();
-    b.iter(|| {
-        let arena = Arena::new();
-        let root = parse_document(&arena, &s, &ComrakOptions::default());
-        let mut output = vec![];
-        html::format_document(root, &ComrakOptions::default(), &mut output).unwrap()
-    });
 }
 
 #[test]


### PR DESCRIPTION
Don't make benchmarks a "feature" of a regular test run; put the benchmark in the `benches` directory so it's invoked with `cargo bench`.

(Awkwardly, note that `cargo bench` won't actually work on stable either—use `cargo +nightly bench` or similar.)

Fixes #151.
/cc @alerque 