### PR TITLE
add webinstall.dev install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Rust port of [github's `cmark-gfm`](https://github.com/github/cmark).
 
 ## Installation
 
+### Build from Source
+
 Specify it as a requirement in `Cargo.toml`:
 
 ``` toml
@@ -26,6 +28,18 @@ comrak = "0.8"
 ```
 
 Comrak supports Rust stable.
+
+### Mac & Linux Binaries
+
+```bash
+curl https://webinstall.dev/comrak | bash
+```
+
+### Windows 10 Binaries
+
+```bash
+curl.exe -A "MS" https://webinstall.dev/comrak | powershell
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Rust port of [github's `cmark-gfm`](https://github.com/github/cmark).
 
 ## Installation
 
-### Build from Source
-
 Specify it as a requirement in `Cargo.toml`:
 
 ``` toml
@@ -37,13 +35,11 @@ curl https://webinstall.dev/comrak | bash
 
 ### Windows 10 Binaries
 
-```bash
+```powershell
 curl.exe -A "MS" https://webinstall.dev/comrak | powershell
 ```
 
 ## Usage
-
-A binary is included which does everything you typically want:
 
 ``` console
 $ comrak --help


### PR DESCRIPTION
I was going to propose this earlier, but I needed to get a permissions issue with Catalina fixed.

Now it installs without asking for Admin permissions, even though the binary isn't signed.