### PR TITLE
make changes to the API more evident

### DIFF
--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -176,11 +176,8 @@ pub struct NodeList {
     /// The kind of list (bullet (unordered) or ordered).
     pub list_type: ListType,
 
-    #[doc(hidden)]
-    pub marker_offset: usize,
-
-    #[doc(hidden)]
-    pub padding: usize,
+    pub(crate) marker_offset: usize,
+    pub(crate) padding: usize,
 
     /// For ordered lists, the ordinal the list starts at.
     pub start: usize,
@@ -199,11 +196,8 @@ pub struct NodeList {
 /// The metadata of a description list
 #[derive(Debug, Default, Clone, Copy)]
 pub struct NodeDescriptionItem {
-    #[doc(hidden)]
-    pub marker_offset: usize,
-
-    #[doc(hidden)]
-    pub padding: usize,
+    pub(crate) marker_offset: usize,
+    pub(crate) padding: usize,
 }
 
 /// The type of list.
@@ -250,8 +244,7 @@ pub struct NodeCodeBlock {
     /// For fenced code blocks, the length of the fence.
     pub fence_length: usize,
 
-    #[doc(hidden)]
-    pub fence_offset: usize,
+    pub(crate) fence_offset: usize,
 
     /// For fenced code blocks, the [info string](https://github.github.com/gfm/#info-string) after
     /// the opening fence, if any.
@@ -276,8 +269,7 @@ pub struct NodeHeading {
 /// The metadata of an included HTML block.
 #[derive(Debug, Default, Clone)]
 pub struct NodeHtmlBlock {
-    #[doc(hidden)]
-    pub block_type: u8,
+    pub(crate) block_type: u8,
 
     /// The literal contents of the HTML block.  Per NodeCodeBlock, the content is included here
     /// rather than in any inline.
@@ -306,15 +298,7 @@ impl NodeValue {
             | NodeValue::TableCell)
     }
 
-    #[doc(hidden)]
-    pub fn accepts_lines(&self) -> bool {
-        matches!(
-            *self,
-            NodeValue::Paragraph | NodeValue::Heading(..) | NodeValue::CodeBlock(..)
-        )
-    }
-
-    /// Indicates whether this node may contain inlines.
+    /// Whether the type the node is of can contain inline nodes.
     pub fn contains_inlines(&self) -> bool {
         matches!(
             *self,
@@ -341,6 +325,13 @@ impl NodeValue {
             _ => None,
         }
     }
+
+    pub(crate) fn accepts_lines(&self) -> bool {
+        matches!(
+            *self,
+            NodeValue::Paragraph | NodeValue::Heading(..) | NodeValue::CodeBlock(..)
+        )
+    }
 }
 
 /// A single node in the CommonMark AST.
@@ -355,12 +346,9 @@ pub struct Ast {
     /// The line in the input document the node starts at.
     pub start_line: u32,
 
-    #[doc(hidden)]
-    pub content: Vec<u8>,
-    #[doc(hidden)]
-    pub open: bool,
-    #[doc(hidden)]
-    pub last_line_blank: bool,
+    pub(crate) content: Vec<u8>,
+    pub(crate) open: bool,
+    pub(crate) last_line_blank: bool,
 }
 
 impl Ast {
@@ -397,13 +385,11 @@ impl<'a> From<NodeValue> for AstNode<'a> {
     }
 }
 
-#[doc(hidden)]
-pub fn last_child_is_open<'a>(node: &'a AstNode<'a>) -> bool {
+pub(crate) fn last_child_is_open<'a>(node: &'a AstNode<'a>) -> bool {
     node.last_child().map_or(false, |n| n.data.borrow().open)
 }
 
-#[doc(hidden)]
-pub fn can_contain_type<'a>(node: &'a AstNode<'a>, child: &NodeValue) -> bool {
+pub(crate) fn can_contain_type<'a>(node: &'a AstNode<'a>, child: &NodeValue) -> bool {
     if let NodeValue::Document = *child {
         return false;
     }
@@ -452,8 +438,7 @@ pub fn can_contain_type<'a>(node: &'a AstNode<'a>, child: &NodeValue) -> bool {
     }
 }
 
-#[doc(hidden)]
-pub fn ends_with_blank_line<'a>(node: &'a AstNode<'a>) -> bool {
+pub(crate) fn ends_with_blank_line<'a>(node: &'a AstNode<'a>) -> bool {
     let mut it = Some(node);
     while let Some(cur) = it {
         if cur.data.borrow().last_line_blank {
@@ -467,8 +452,7 @@ pub fn ends_with_blank_line<'a>(node: &'a AstNode<'a>) -> bool {
     false
 }
 
-#[doc(hidden)]
-pub fn containing_block<'a>(node: &'a AstNode<'a>) -> Option<&'a AstNode<'a>> {
+pub(crate) fn containing_block<'a>(node: &'a AstNode<'a>) -> Option<&'a AstNode<'a>> {
     let mut ch = Some(node);
     while let Some(n) = ch {
         if n.data.borrow().value.block() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -971,3 +971,139 @@ fn description_lists() {
         ),
     );
 }
+
+#[test]
+fn exercise_full_api() {
+    let arena = ::Arena::new();
+    let default_options = ::ComrakOptions::default();
+    let node = ::parse_document(&arena, "# My document\n", &default_options);
+    let mut buffer = vec![];
+
+    // Use every member of the exposed API without any defaults.
+    // Not looking for specific outputs, just want to know if the API changes shape.
+
+    let _: std::io::Result<()> = ::format_commonmark(node, &default_options, &mut buffer);
+
+    let _: std::io::Result<()> = ::format_html(node, &default_options, &mut buffer);
+
+    let _: String = ::Anchorizer::new().anchorize("header".to_string());
+
+    let _: &::nodes::AstNode = ::parse_document(&arena, "document", &default_options);
+
+    let _: &::nodes::AstNode = ::parse_document_with_broken_link_callback(
+        &arena,
+        "document",
+        &default_options,
+        Some(&mut |_: &[u8]| Some((b"abc".to_vec(), b"xyz".to_vec()))),
+    );
+
+    let _ = ::ComrakOptions {
+        extension: ::ComrakExtensionOptions {
+            strikethrough: false,
+            tagfilter: false,
+            table: false,
+            autolink: false,
+            tasklist: false,
+            superscript: false,
+            header_ids: Some("abc".to_string()),
+            footnotes: false,
+            description_lists: false,
+        },
+        parse: ::ComrakParseOptions {
+            smart: false,
+            default_info_string: Some("abc".to_string()),
+        },
+        render: ::ComrakRenderOptions {
+            hardbreaks: false,
+            github_pre_lang: false,
+            width: 123456,
+            unsafe_: false,
+            escape: false,
+        },
+    };
+
+    let _: String = ::markdown_to_html("# Yes", &default_options);
+
+    //
+
+    let ast = node.data.borrow();
+    let _ = ast.start_line;
+    match &ast.value {
+        ::nodes::NodeValue::Document => {}
+        ::nodes::NodeValue::BlockQuote => {}
+        ::nodes::NodeValue::List(nl) | ::nodes::NodeValue::Item(nl) => {
+            match nl.list_type {
+                ::nodes::ListType::Bullet => {}
+                ::nodes::ListType::Ordered => {}
+            }
+            let _: usize = nl.start;
+            match nl.delimiter {
+                ::nodes::ListDelimType::Period => {}
+                ::nodes::ListDelimType::Paren => {}
+            }
+            let _: u8 = nl.bullet_char;
+            let _: bool = nl.tight;
+        }
+        ::nodes::NodeValue::DescriptionList => {}
+        ::nodes::NodeValue::DescriptionItem(_ndi) => {}
+        ::nodes::NodeValue::DescriptionTerm => {}
+        ::nodes::NodeValue::DescriptionDetails => {}
+        ::nodes::NodeValue::CodeBlock(ncb) => {
+            let _: bool = ncb.fenced;
+            let _: u8 = ncb.fence_char;
+            let _: usize = ncb.fence_length;
+            let _: Vec<u8> = ncb.info;
+            let _: Vec<u8> = ncb.literal;
+        }
+        ::nodes::NodeValue::HtmlBlock(nhb) => {
+            let _: Vec<u8> = nhb.literal;
+        }
+        ::nodes::NodeValue::Paragraph => {}
+        ::nodes::NodeValue::Heading(nh) => {
+            let _: u32 = nh.level;
+            let _: bool = nh.setext;
+        }
+        ::nodes::NodeValue::ThematicBreak => {}
+        ::nodes::NodeValue::FootnoteDefinition(name) => {
+            let _: &Vec<u8> = name;
+        }
+        ::nodes::NodeValue::Table(aligns) => {
+            let _: &Vec<::nodes::TableAlignment> = aligns;
+            match aligns[0] {
+                ::nodes::TableAlignment::None => {}
+                ::nodes::TableAlignment::Left => {}
+                ::nodes::TableAlignment::Center => {}
+                ::nodes::TableAlignment::Right => {}
+            }
+        }
+        ::nodes::NodeValue::TableRow(header) => {
+            let _: &bool = header;
+        }
+        ::nodes::NodeValue::TableCell => {}
+        ::nodes::NodeValue::Text(text) => {
+            let _: &Vec<u8> = text;
+        }
+        ::nodes::NodeValue::TaskItem(checked) => {
+            let _: &bool = checked;
+        }
+        ::nodes::NodeValue::SoftBreak => {}
+        ::nodes::NodeValue::LineBreak => {}
+        ::nodes::NodeValue::Code(code) => {
+            let _: &Vec<u8> = code;
+        }
+        ::nodes::NodeValue::HtmlInline(html) => {
+            let _: &Vec<u8> = html;
+        }
+        ::nodes::NodeValue::Emph => {}
+        ::nodes::NodeValue::Strong => {}
+        ::nodes::NodeValue::Strikethrough => {}
+        ::nodes::NodeValue::Superscript => {}
+        ::nodes::NodeValue::Link(nl) | ::nodes::NodeValue::Image(nl) => {
+            let _: Vec<u8> = nl.url;
+            let _: Vec<u8> = nl.title;
+        }
+        ::nodes::NodeValue::FootnoteReference(name) => {
+            let _: &Vec<u8> = name;
+        }
+    }
+}


### PR DESCRIPTION
Catches #167. It's ugly but it should highlight changes that will actually break downstream consumers.

Also changes some `doc(hidden)` to `pub(crate)`.