### PR TITLE
Allow "image/" prefix on data URIs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,18 @@ jobs:
       run: env SPEC=false script/cibuild
     - name: Run spec tests
       run: env SPEC=true script/cibuild
+  clippy_format:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Obtain Rust
+      run: rustup override set ${{ matrix.rust }}
     - name: Check clippy
       run: rustup component add clippy && cargo clippy
     - name: Check formatting

--- a/src/lexer.pest
+++ b/src/lexer.pest
@@ -55,4 +55,4 @@ table_start = { "|"? ~ table_marker ~ ("|" ~ table_marker)* ~ "|"? ~ table_space
 table_cell_end = { "|" ~ table_spacechar* ~ table_newline? }
 table_row_end = { table_spacechar* ~ table_newline }
 
-dangerous_url = { "data:" ~ !("png" | "gif" | "jpeg" | "webp") | "javascript:" | "vbscript:" | "file:" }
+dangerous_url = { "data:" ~ "image/"? ~ !("png" | "gif" | "jpeg" | "webp") | "javascript:" | "vbscript:" | "file:" }

--- a/src/lexer.pest
+++ b/src/lexer.pest
@@ -55,4 +55,4 @@ table_start = { "|"? ~ table_marker ~ ("|" ~ table_marker)* ~ "|"? ~ table_space
 table_cell_end = { "|" ~ table_spacechar* ~ table_newline? }
 table_row_end = { table_spacechar* ~ table_newline }
 
-dangerous_url = { "data:" ~ "image/"? ~ !("png" | "gif" | "jpeg" | "webp") | "javascript:" | "vbscript:" | "file:" }
+dangerous_url = { "data:" ~ !("image/" ~ ("png" | "gif" | "jpeg" | "webp")) | "javascript:" | "vbscript:" | "file:" }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -859,20 +859,20 @@ fn cm_autolink_regression() {
 fn safety() {
     html(
         concat!(
-            "[data:png](data:png/x)\n\n",
-            "[data:gif](data:gif/x)\n\n",
-            "[data:jpeg](data:jpeg/x)\n\n",
-            "[data:webp](data:webp/x)\n\n",
+            "[data:image/png](data:image/png/x)\n\n",
+            "[data:image/gif](data:image/gif/x)\n\n",
+            "[data:image/jpeg](data:image/jpeg/x)\n\n",
+            "[data:image/webp](data:image/webp/x)\n\n",
             "[data:malicious](data:malicious/x)\n\n",
             "[javascript:malicious](javascript:malicious)\n\n",
             "[vbscript:malicious](vbscript:malicious)\n\n",
             "[file:malicious](file:malicious)\n\n",
         ),
         concat!(
-            "<p><a href=\"data:png/x\">data:png</a></p>\n",
-            "<p><a href=\"data:gif/x\">data:gif</a></p>\n",
-            "<p><a href=\"data:jpeg/x\">data:jpeg</a></p>\n",
-            "<p><a href=\"data:webp/x\">data:webp</a></p>\n",
+            "<p><a href=\"data:image/png/x\">data:image/png</a></p>\n",
+            "<p><a href=\"data:image/gif/x\">data:image/gif</a></p>\n",
+            "<p><a href=\"data:image/jpeg/x\">data:image/jpeg</a></p>\n",
+            "<p><a href=\"data:image/webp/x\">data:image/webp</a></p>\n",
             "<p><a href=\"\">data:malicious</a></p>\n",
             "<p><a href=\"\">javascript:malicious</a></p>\n",
             "<p><a href=\"\">vbscript:malicious</a></p>\n",


### PR DESCRIPTION
Update the `dangerous_url` grammar rule to allow URIs that begin with `data:image/`, followed by a valid media type. This is an optional modifier and does not affect URIs that do not contain this prefix.

I'd like to add this because this is the default behavior of [Toast UI's Editor](https://ui.toast.com/tui-editor/) when adding images and outputting Markdown code.

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs), Data URIs consist of the following format:

```
data:[<mediatype>][;base64],<data>
```

This documentation then states:

> The mediatype is a MIME type string, such as 'image/jpeg' for a JPEG image file.