### PR TITLE
Builders for options

### DIFF
--- a/examples/s-expr.rs
+++ b/examples/s-expr.rs
@@ -16,7 +16,7 @@ const INDENT: usize = 4;
 const CLOSE_NEWLINE: bool = false;
 
 use comrak::nodes::{AstNode, NodeValue};
-use comrak::{parse_document, Arena, ComrakExtensionOptions, ComrakOptions};
+use comrak::{parse_document, Arena, ComrakOptions};
 use std::env;
 use std::error::Error;
 use std::fs::File;
@@ -77,20 +77,16 @@ fn iter_nodes<'a, W: Write>(
 fn dump(source: &str) -> io::Result<()> {
     let arena = Arena::new();
 
-    let opts = ComrakOptions {
-        extension: ComrakExtensionOptions {
-            strikethrough: true,
-            tagfilter: true,
-            table: true,
-            autolink: true,
-            tasklist: true,
-            superscript: true,
-            footnotes: true,
-            description_lists: true,
-            ..ComrakExtensionOptions::default()
-        },
-        ..ComrakOptions::default()
-    };
+    let mut opts = ComrakOptions::new();
+    opts.extension()
+        .strikethrough(true)
+        .tagfilter(true)
+        .table(true)
+        .autolink(true)
+        .tasklist(true)
+        .superscript(true)
+        .footnotes(true)
+        .description_lists(true);
 
     let doc = parse_document(&arena, source, &opts);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,7 @@ extern crate shell_words;
 #[cfg(not(windows))]
 extern crate xdg;
 
-use comrak::{
-    Arena, ComrakExtensionOptions, ComrakOptions, ComrakParseOptions, ComrakRenderOptions,
-};
+use comrak::{Arena, ComrakOptions};
 
 use std::boxed::Box;
 use std::collections::BTreeSet;
@@ -170,39 +168,44 @@ if the file does not exist.\
         .values_of("extension")
         .map_or(BTreeSet::new(), |vals| vals.collect());
 
-    let options = ComrakOptions {
-        extension: ComrakExtensionOptions {
-            strikethrough: exts.remove("strikethrough") || matches.is_present("gfm"),
-            tagfilter: exts.remove("tagfilter") || matches.is_present("gfm"),
-            table: exts.remove("table") || matches.is_present("gfm"),
-            autolink: exts.remove("autolink") || matches.is_present("gfm"),
-            tasklist: exts.remove("tasklist") || matches.is_present("gfm"),
-            superscript: exts.remove("superscript"),
-            header_ids: matches.value_of("header-ids").map(|s| s.to_string()),
-            footnotes: exts.remove("footnotes"),
-            description_lists: exts.remove("description-lists"),
-            front_matter_delimiter: matches
+    let mut options = ComrakOptions::new();
+    options
+        .extension()
+        .strikethrough(exts.remove("strikethrough") || matches.is_present("gfm"))
+        .tagfilter(exts.remove("tagfilter") || matches.is_present("gfm"))
+        .table(exts.remove("table") || matches.is_present("gfm"))
+        .autolink(exts.remove("autolink") || matches.is_present("gfm"))
+        .tasklist(exts.remove("tasklist") || matches.is_present("gfm"))
+        .superscript(exts.remove("superscript"))
+        .header_ids(matches.value_of("header-ids").map(|s| s.to_string()))
+        .footnotes(exts.remove("footnotes"))
+        .description_lists(exts.remove("description-lists"))
+        .front_matter_delimiter(
+            matches
                 .value_of("front-matter-delimiter")
                 .map(|s| s.to_string()),
-        },
-        parse: ComrakParseOptions {
-            smart: matches.is_present("smart"),
-            default_info_string: matches
+        );
+    options
+        .parse()
+        .smart(matches.is_present("smart"))
+        .default_info_string(
+            matches
                 .value_of("default-info-string")
                 .map(|e| e.to_owned()),
-        },
-        render: ComrakRenderOptions {
-            hardbreaks: matches.is_present("hardbreaks"),
-            github_pre_lang: matches.is_present("github-pre-lang") || matches.is_present("gfm"),
-            width: matches
+        );
+    options
+        .render()
+        .hardbreaks(matches.is_present("hardbreaks"))
+        .github_pre_lang(matches.is_present("github-pre-lang") || matches.is_present("gfm"))
+        .width(
+            matches
                 .value_of("width")
                 .unwrap_or("0")
                 .parse()
                 .unwrap_or(0),
-            unsafe_: matches.is_present("unsafe"),
-            escape: matches.is_present("escape"),
-        },
-    };
+        )
+        .unsafe_(matches.is_present("unsafe"))
+        .escape(matches.is_present("escape"));
 
     if !exts.is_empty() {
         eprintln!("unknown extensions: {:?}", exts);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -134,21 +134,18 @@ impl ComrakOptions {
     }
 
     /// Enable CommonMark extensions.
-    pub fn extension(&mut self, extension: ComrakExtensionOptions) -> &mut ComrakOptions {
-        self.extension = extension;
-        self
+    pub fn extension(&mut self) -> &mut ComrakExtensionOptions {
+        &mut self.extension
     }
 
     /// Configure parse-time options.
-    pub fn parse(&mut self, parse: ComrakParseOptions) -> &mut ComrakOptions {
-        self.parse = parse;
-        self
+    pub fn parse(&mut self) -> &mut ComrakParseOptions {
+        &mut self.parse
     }
 
     /// Configure render-time options.
-    pub fn render(&mut self, render: ComrakRenderOptions) -> &mut ComrakOptions {
-        self.render = render;
-        self
+    pub fn render(&mut self) -> &mut ComrakRenderOptions {
+        &mut self.render
     }
 }
 
@@ -444,8 +441,8 @@ impl ComrakRenderOptions {
     /// * default fenced code block style is used with info tags
     /// * CommonMark output is not wrapped
     /// * raw HTML and potentially unsafe links are filtered out
-    pub fn new() -> ComrakParseOptions {
-        ComrakParseOptions::default()
+    pub fn new() -> ComrakRenderOptions {
+        ComrakRenderOptions::default()
     }
 
     /// [Soft line breaks](http://spec.commonmark.org/0.27/#soft-line-breaks) in the input
@@ -461,7 +458,7 @@ impl ComrakRenderOptions {
     /// assert_eq!(markdown_to_html("Hello.\nWorld.\n", &options),
     ///            "<p>Hello.<br />\nWorld.</p>\n");
     /// ```
-    pub fn hardbreaks(&mut self, value: bool) -> &mut ComrakParseOptions {
+    pub fn hardbreaks(&mut self, value: bool) -> &mut ComrakRenderOptions {
         self.hardbreaks = value;
         self
     }
@@ -478,7 +475,7 @@ impl ComrakRenderOptions {
     /// assert_eq!(markdown_to_html("``` rust\nfn hello();\n```\n", &options),
     ///            "<pre lang=\"rust\"><code>fn hello();\n</code></pre>\n");
     /// ```
-    pub fn github_pre_lang(&mut self, value: bool) -> &mut ComrakParseOptions {
+    pub fn github_pre_lang(&mut self, value: bool) -> &mut ComrakRenderOptions {
         self.github_pre_lang = value;
         self
     }
@@ -505,7 +502,7 @@ impl ComrakRenderOptions {
     ///            "hello hello hello\nhello hello hello\n");
     /// # }
     /// ```
-    pub fn width(&mut self, value: usize) -> &mut ComrakParseOptions {
+    pub fn width(&mut self, value: usize) -> &mut ComrakRenderOptions {
         self.width = value;
         self
     }
@@ -533,7 +530,7 @@ impl ComrakRenderOptions {
     ///             <p><a href=\"javascript:alert(document.cookie)\">Dangerous</a>.</p>\n\
     ///             <p><a href=\"http://commonmark.org\">Safe</a>.</p>\n");
     /// ```
-    pub fn unsafe_(&mut self, value: bool) -> &mut ComrakParseOptions {
+    pub fn unsafe_(&mut self, value: bool) -> &mut ComrakRenderOptions {
         self.unsafe_ = value;
         self
     }
@@ -551,7 +548,7 @@ impl ComrakRenderOptions {
     /// assert_eq!(markdown_to_html(input, &options),
     ///            "<p>&lt;i&gt;italic text&lt;/i&gt;</p>\n");
     /// ```
-    pub fn escape(&mut self, value: bool) -> &mut ComrakParseOptions {
+    pub fn escape(&mut self, value: bool) -> &mut ComrakRenderOptions {
         self.escape = value;
         self
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -122,19 +122,57 @@ pub struct Parser<'a, 'o, 'c> {
 #[derive(Default, Debug, Clone)]
 /// Umbrella options struct.
 pub struct ComrakOptions {
+    extension: ComrakExtensionOptions,
+    parse: ComrakParseOptions,
+    render: ComrakRenderOptions,
+}
+
+impl ComrakOptions {
+    /// Initialize default options.
+    pub fn new() -> ComrakOptions {
+        ComrakOptions::default()
+    }
+
     /// Enable CommonMark extensions.
-    pub extension: ComrakExtensionOptions,
+    pub fn extension(&mut self, extension: ComrakExtensionOptions) -> &mut ComrakOptions {
+        self.extension = extension;
+        self
+    }
 
     /// Configure parse-time options.
-    pub parse: ComrakParseOptions,
+    pub fn parse(&mut self, parse: ComrakParseOptions) -> &mut ComrakOptions {
+        self.parse = parse;
+        self
+    }
 
     /// Configure render-time options.
-    pub render: ComrakRenderOptions,
+    pub fn render(&mut self, render: ComrakRenderOptions) -> &mut ComrakOptions {
+        self.render = render;
+        self
+    }
 }
 
 #[derive(Default, Debug, Clone)]
 /// Options to select extensions.
 pub struct ComrakExtensionOptions {
+    strikethrough: bool,
+    tagfilter: bool,
+    table: bool,
+    autolink: bool,
+    tasklist: bool,
+    superscript: bool,
+    header_ids: Option<String>,
+    footnotes: bool,
+    description_lists: bool,
+    front_matter_delimiter: Option<String>,
+}
+
+impl ComrakExtensionOptions {
+    /// Initialize default options.
+    pub fn new() -> ComrakParseOptions {
+        ComrakParseOptions::default()
+    }
+
     /// Enables the
     /// [strikethrough extension](https://github.github.com/gfm/#strikethrough-extension-)
     /// from the GFM spec.
@@ -146,7 +184,10 @@ pub struct ComrakExtensionOptions {
     /// assert_eq!(markdown_to_html("Hello ~world~ there.\n", &options),
     ///            "<p>Hello <del>world</del> there.</p>\n");
     /// ```
-    pub strikethrough: bool,
+    pub fn strikethrough(&mut self, value: bool) -> &mut ComrakExtensionOptions {
+        self.strikethrough = value;
+        self
+    }
 
     /// Enables the
     /// [tagfilter extension](https://github.github.com/gfm/#disallowed-raw-html-extension-)
@@ -160,7 +201,10 @@ pub struct ComrakExtensionOptions {
     /// assert_eq!(markdown_to_html("Hello <xmp>.\n\n<xmp>", &options),
     ///            "<p>Hello &lt;xmp>.</p>\n&lt;xmp>\n");
     /// ```
-    pub tagfilter: bool,
+    pub fn tagfilter(&mut self, value: bool) -> &mut ComrakExtensionOptions {
+        self.tagfilter = value;
+        self
+    }
 
     /// Enables the [table extension](https://github.github.com/gfm/#tables-extension-)
     /// from the GFM spec.
@@ -173,7 +217,10 @@ pub struct ComrakExtensionOptions {
     ///            "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n\
     ///             <tbody>\n<tr>\n<td>c</td>\n<td>d</td>\n</tr>\n</tbody>\n</table>\n");
     /// ```
-    pub table: bool,
+    pub fn table(&mut self, value: bool) -> &mut ComrakExtensionOptions {
+        self.table = value;
+        self
+    }
 
     /// Enables the [autolink extension](https://github.github.com/gfm/#autolinks-extension-)
     /// from the GFM spec.
@@ -185,7 +232,10 @@ pub struct ComrakExtensionOptions {
     /// assert_eq!(markdown_to_html("Hello www.github.com.\n", &options),
     ///            "<p>Hello <a href=\"http://www.github.com\">www.github.com</a>.</p>\n");
     /// ```
-    pub autolink: bool,
+    pub fn autolink(&mut self, value: bool) -> &mut ComrakExtensionOptions {
+        self.autolink = value;
+        self
+    }
 
     /// Enables the
     /// [task list items extension](https://github.github.com/gfm/#task-list-items-extension-)
@@ -203,7 +253,10 @@ pub struct ComrakExtensionOptions {
     ///            "<ul>\n<li><input type=\"checkbox\" disabled=\"\" checked=\"\" /> Done</li>\n\
     ///            <li><input type=\"checkbox\" disabled=\"\" /> Not done</li>\n</ul>\n");
     /// ```
-    pub tasklist: bool,
+    pub fn tasklist(&mut self, value: bool) -> &mut ComrakExtensionOptions {
+        self.tasklist = value;
+        self
+    }
 
     /// Enables the superscript Comrak extension.
     ///
@@ -214,7 +267,10 @@ pub struct ComrakExtensionOptions {
     /// assert_eq!(markdown_to_html("e = mc^2^.\n", &options),
     ///            "<p>e = mc<sup>2</sup>.</p>\n");
     /// ```
-    pub superscript: bool,
+    pub fn superscript(&mut self, value: bool) -> &mut ComrakExtensionOptions {
+        self.superscript = value;
+        self
+    }
 
     /// Enables the header IDs Comrak extension.
     ///
@@ -225,7 +281,10 @@ pub struct ComrakExtensionOptions {
     /// assert_eq!(markdown_to_html("# README\n", &options),
     ///            "<h1><a href=\"#readme\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-readme\"></a>README</h1>\n");
     /// ```
-    pub header_ids: Option<String>,
+    pub fn header_ids(&mut self, value: Option<String>) -> &mut ComrakExtensionOptions {
+        self.header_ids = value;
+        self
+    }
 
     /// Enables the footnotes extension per `cmark-gfm`.
     ///
@@ -239,7 +298,10 @@ pub struct ComrakExtensionOptions {
     /// assert_eq!(markdown_to_html("Hi[^x].\n\n[^x]: A greeting.\n", &options),
     ///            "<p>Hi<sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\">1</a></sup>.</p>\n<section class=\"footnotes\">\n<ol>\n<li id=\"fn1\">\n<p>A greeting. <a href=\"#fnref1\" class=\"footnote-backref\">↩</a></p>\n</li>\n</ol>\n</section>\n");
     /// ```
-    pub footnotes: bool,
+    pub fn footnotes(&mut self, value: bool) -> &mut ComrakExtensionOptions {
+        self.footnotes = value;
+        self
+    }
 
     /// Enables the description lists extension.
     ///
@@ -265,7 +327,10 @@ pub struct ComrakExtensionOptions {
     /// assert_eq!(markdown_to_html("Term\n\n: Definition", &options),
     ///            "<dl><dt>Term</dt>\n<dd>\n<p>Definition</p>\n</dd>\n</dl>\n");
     /// ```
-    pub description_lists: bool,
+    pub fn description_lists(&mut self, value: bool) -> &mut ComrakExtensionOptions {
+        self.description_lists = value;
+        self
+    }
 
     /// Enables the front matter extension.
     ///
@@ -305,12 +370,28 @@ pub struct ComrakExtensionOptions {
     /// format_commonmark(&root, &options, &mut buf);
     /// assert_eq!(&String::from_utf8(buf).unwrap(), input);
     /// ```
-    pub front_matter_delimiter: Option<String>,
+    pub fn front_matter_delimiter(&mut self, value: Option<String>) -> &mut ComrakExtensionOptions {
+        self.front_matter_delimiter = value;
+        self
+    }
 }
 
 #[derive(Default, Debug, Clone)]
 /// Options for parser functions.
 pub struct ComrakParseOptions {
+    smart: bool,
+    default_info_string: Option<String>,
+}
+
+impl ComrakParseOptions {
+    /// Initialize default parse-time options:
+    ///
+    /// * smart punctuation disabled
+    /// * no info string prefix in fenced code blocks
+    pub fn new() -> ComrakParseOptions {
+        ComrakParseOptions::default()
+    }
+
     /// Punctuation (quotes, full-stops and hyphens) are converted into 'smart' punctuation.
     ///
     /// ```
@@ -323,7 +404,10 @@ pub struct ComrakParseOptions {
     /// assert_eq!(markdown_to_html("'Hello,' \"world\" ...", &options),
     ///            "<p>‘Hello,’ “world” …</p>\n");
     /// ```
-    pub smart: bool,
+    pub fn smart(&mut self, value: bool) -> &mut ComrakParseOptions {
+        self.smart = value;
+        self
+    }
 
     /// The default info string for fenced code blocks.
     ///
@@ -337,12 +421,33 @@ pub struct ComrakParseOptions {
     /// assert_eq!(markdown_to_html("```\nfn hello();\n```\n", &options),
     ///            "<pre><code class=\"language-rust\">fn hello();\n</code></pre>\n");
     /// ```
-    pub default_info_string: Option<String>,
+    pub fn default_info_string(&mut self, value: Option<String>) -> &mut ComrakParseOptions {
+        self.default_info_string = value;
+        self
+    }
 }
 
 #[derive(Default, Debug, Clone, Copy)]
 /// Options for formatter functions.
 pub struct ComrakRenderOptions {
+    hardbreaks: bool,
+    github_pre_lang: bool,
+    width: usize,
+    unsafe_: bool,
+    escape: bool,
+}
+
+impl ComrakRenderOptions {
+    /// Initialize default render-time options:
+    ///
+    /// * soft line breaks are not translated into hard line breaks
+    /// * default fenced code block style is used with info tags
+    /// * CommonMark output is not wrapped
+    /// * raw HTML and potentially unsafe links are filtered out
+    pub fn new() -> ComrakParseOptions {
+        ComrakParseOptions::default()
+    }
+
     /// [Soft line breaks](http://spec.commonmark.org/0.27/#soft-line-breaks) in the input
     /// translate into hard line breaks in the output.
     ///
@@ -356,7 +461,10 @@ pub struct ComrakRenderOptions {
     /// assert_eq!(markdown_to_html("Hello.\nWorld.\n", &options),
     ///            "<p>Hello.<br />\nWorld.</p>\n");
     /// ```
-    pub hardbreaks: bool,
+    pub fn hardbreaks(&mut self, value: bool) -> &mut ComrakParseOptions {
+        self.hardbreaks = value;
+        self
+    }
 
     /// GitHub-style `<pre lang="xyz">` is used for fenced code blocks with info tags.
     ///
@@ -370,7 +478,10 @@ pub struct ComrakRenderOptions {
     /// assert_eq!(markdown_to_html("``` rust\nfn hello();\n```\n", &options),
     ///            "<pre lang=\"rust\"><code>fn hello();\n</code></pre>\n");
     /// ```
-    pub github_pre_lang: bool,
+    pub fn github_pre_lang(&mut self, value: bool) -> &mut ComrakParseOptions {
+        self.github_pre_lang = value;
+        self
+    }
 
     /// The wrap column when outputting CommonMark.
     ///
@@ -394,7 +505,10 @@ pub struct ComrakRenderOptions {
     ///            "hello hello hello\nhello hello hello\n");
     /// # }
     /// ```
-    pub width: usize,
+    pub fn width(&mut self, value: usize) -> &mut ComrakParseOptions {
+        self.width = value;
+        self
+    }
 
     /// Allow rendering of raw HTML and potentially dangerous links.
     ///
@@ -419,7 +533,10 @@ pub struct ComrakRenderOptions {
     ///             <p><a href=\"javascript:alert(document.cookie)\">Dangerous</a>.</p>\n\
     ///             <p><a href=\"http://commonmark.org\">Safe</a>.</p>\n");
     /// ```
-    pub unsafe_: bool,
+    pub fn unsafe_(&mut self, value: bool) -> &mut ComrakParseOptions {
+        self.unsafe_ = value;
+        self
+    }
 
     /// Escape raw HTML instead of clobbering it.
     /// ```
@@ -434,7 +551,10 @@ pub struct ComrakRenderOptions {
     /// assert_eq!(markdown_to_html(input, &options),
     ///            "<p>&lt;i&gt;italic text&lt;/i&gt;</p>\n");
     /// ```
-    pub escape: bool,
+    pub fn escape(&mut self, value: bool) -> &mut ComrakParseOptions {
+        self.escape = value;
+        self
+    }
 }
 
 #[derive(Clone)]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -122,9 +122,9 @@ pub struct Parser<'a, 'o, 'c> {
 #[derive(Default, Debug, Clone)]
 /// Umbrella options struct.
 pub struct ComrakOptions {
-    extension: ComrakExtensionOptions,
-    parse: ComrakParseOptions,
-    render: ComrakRenderOptions,
+    pub(crate) extension: ComrakExtensionOptions,
+    pub(crate) parse: ComrakParseOptions,
+    pub(crate) render: ComrakRenderOptions,
 }
 
 impl ComrakOptions {
@@ -152,16 +152,16 @@ impl ComrakOptions {
 #[derive(Default, Debug, Clone)]
 /// Options to select extensions.
 pub struct ComrakExtensionOptions {
-    strikethrough: bool,
-    tagfilter: bool,
-    table: bool,
-    autolink: bool,
-    tasklist: bool,
-    superscript: bool,
-    header_ids: Option<String>,
-    footnotes: bool,
-    description_lists: bool,
-    front_matter_delimiter: Option<String>,
+    pub(crate) strikethrough: bool,
+    pub(crate) tagfilter: bool,
+    pub(crate) table: bool,
+    pub(crate) autolink: bool,
+    pub(crate) tasklist: bool,
+    pub(crate) superscript: bool,
+    pub(crate) header_ids: Option<String>,
+    pub(crate) footnotes: bool,
+    pub(crate) description_lists: bool,
+    pub(crate) front_matter_delimiter: Option<String>,
 }
 
 impl ComrakExtensionOptions {
@@ -177,7 +177,7 @@ impl ComrakExtensionOptions {
     /// ```
     /// # use comrak::{markdown_to_html, ComrakOptions};
     /// let mut options = ComrakOptions::default();
-    /// options.extension.strikethrough = true;
+    /// options.extension().strikethrough(true);
     /// assert_eq!(markdown_to_html("Hello ~world~ there.\n", &options),
     ///            "<p>Hello <del>world</del> there.</p>\n");
     /// ```
@@ -193,8 +193,8 @@ impl ComrakExtensionOptions {
     /// ```
     /// # use comrak::{markdown_to_html, ComrakOptions};
     /// let mut options = ComrakOptions::default();
-    /// options.extension.tagfilter = true;
-    /// options.render.unsafe_ = true;
+    /// options.extension().tagfilter(true);
+    /// options.render().unsafe_(true);
     /// assert_eq!(markdown_to_html("Hello <xmp>.\n\n<xmp>", &options),
     ///            "<p>Hello &lt;xmp>.</p>\n&lt;xmp>\n");
     /// ```
@@ -209,7 +209,7 @@ impl ComrakExtensionOptions {
     /// ```
     /// # use comrak::{markdown_to_html, ComrakOptions};
     /// let mut options = ComrakOptions::default();
-    /// options.extension.table = true;
+    /// options.extension().table(true);
     /// assert_eq!(markdown_to_html("| a | b |\n|---|---|\n| c | d |\n", &options),
     ///            "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n\
     ///             <tbody>\n<tr>\n<td>c</td>\n<td>d</td>\n</tr>\n</tbody>\n</table>\n");
@@ -225,7 +225,7 @@ impl ComrakExtensionOptions {
     /// ```
     /// # use comrak::{markdown_to_html, ComrakOptions};
     /// let mut options = ComrakOptions::default();
-    /// options.extension.autolink = true;
+    /// options.extension().autolink(true);
     /// assert_eq!(markdown_to_html("Hello www.github.com.\n", &options),
     ///            "<p>Hello <a href=\"http://www.github.com\">www.github.com</a>.</p>\n");
     /// ```
@@ -244,8 +244,8 @@ impl ComrakExtensionOptions {
     /// ```
     /// # use comrak::{markdown_to_html, ComrakOptions};
     /// let mut options = ComrakOptions::default();
-    /// options.extension.tasklist = true;
-    /// options.render.unsafe_ = true;
+    /// options.extension().tasklist(true);
+    /// options.render().unsafe_(true);
     /// assert_eq!(markdown_to_html("* [x] Done\n* [ ] Not done\n", &options),
     ///            "<ul>\n<li><input type=\"checkbox\" disabled=\"\" checked=\"\" /> Done</li>\n\
     ///            <li><input type=\"checkbox\" disabled=\"\" /> Not done</li>\n</ul>\n");
@@ -260,7 +260,7 @@ impl ComrakExtensionOptions {
     /// ```
     /// # use comrak::{markdown_to_html, ComrakOptions};
     /// let mut options = ComrakOptions::default();
-    /// options.extension.superscript = true;
+    /// options.extension().superscript(true);
     /// assert_eq!(markdown_to_html("e = mc^2^.\n", &options),
     ///            "<p>e = mc<sup>2</sup>.</p>\n");
     /// ```
@@ -274,7 +274,7 @@ impl ComrakExtensionOptions {
     /// ```
     /// # use comrak::{markdown_to_html, ComrakOptions};
     /// let mut options = ComrakOptions::default();
-    /// options.extension.header_ids = Some("user-content-".to_string());
+    /// options.extension().header_ids(Some("user-content-".to_string()));
     /// assert_eq!(markdown_to_html("# README\n", &options),
     ///            "<h1><a href=\"#readme\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-readme\"></a>README</h1>\n");
     /// ```
@@ -291,7 +291,7 @@ impl ComrakExtensionOptions {
     /// ```
     /// # use comrak::{markdown_to_html, ComrakOptions};
     /// let mut options = ComrakOptions::default();
-    /// options.extension.footnotes = true;
+    /// options.extension().footnotes(true);
     /// assert_eq!(markdown_to_html("Hi[^x].\n\n[^x]: A greeting.\n", &options),
     ///            "<p>Hi<sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\">1</a></sup>.</p>\n<section class=\"footnotes\">\n<ol>\n<li id=\"fn1\">\n<p>A greeting. <a href=\"#fnref1\" class=\"footnote-backref\">↩</a></p>\n</li>\n</ol>\n</section>\n");
     /// ```
@@ -320,7 +320,7 @@ impl ComrakExtensionOptions {
     /// ```
     /// # use comrak::{markdown_to_html, ComrakOptions};
     /// let mut options = ComrakOptions::default();
-    /// options.extension.description_lists = true;
+    /// options.extension().description_lists(true);
     /// assert_eq!(markdown_to_html("Term\n\n: Definition", &options),
     ///            "<dl><dt>Term</dt>\n<dd>\n<p>Definition</p>\n</dd>\n</dl>\n");
     /// ```
@@ -349,7 +349,7 @@ impl ComrakExtensionOptions {
     /// ```
     /// # use comrak::{markdown_to_html, ComrakOptions};
     /// let mut options = ComrakOptions::default();
-    /// options.extension.front_matter_delimiter = Some("---".to_owned());
+    /// options.extension().front_matter_delimiter(Some("---".to_owned()));
     /// assert_eq!(
     ///     markdown_to_html("---\nlayout: post\n---\nText\n", &options),
     ///     markdown_to_html("Text\n", &ComrakOptions::default()));
@@ -359,7 +359,7 @@ impl ComrakExtensionOptions {
     /// # use comrak::{format_commonmark, Arena, ComrakOptions};
     /// use comrak::parse_document;
     /// let mut options = ComrakOptions::default();
-    /// options.extension.front_matter_delimiter = Some("---".to_owned());
+    /// options.extension().front_matter_delimiter(Some("---".to_owned()));
     /// let arena = Arena::new();
     /// let input ="---\nlayout: post\n---\nText\n";
     /// let root = parse_document(&arena, input, &options);
@@ -376,8 +376,8 @@ impl ComrakExtensionOptions {
 #[derive(Default, Debug, Clone)]
 /// Options for parser functions.
 pub struct ComrakParseOptions {
-    smart: bool,
-    default_info_string: Option<String>,
+    pub(crate) smart: bool,
+    pub(crate) default_info_string: Option<String>,
 }
 
 impl ComrakParseOptions {
@@ -397,7 +397,7 @@ impl ComrakParseOptions {
     /// assert_eq!(markdown_to_html("'Hello,' \"world\" ...", &options),
     ///            "<p>'Hello,' &quot;world&quot; ...</p>\n");
     ///
-    /// options.parse.smart = true;
+    /// options.parse().smart(true);
     /// assert_eq!(markdown_to_html("'Hello,' \"world\" ...", &options),
     ///            "<p>‘Hello,’ “world” …</p>\n");
     /// ```
@@ -414,7 +414,7 @@ impl ComrakParseOptions {
     /// assert_eq!(markdown_to_html("```\nfn hello();\n```\n", &options),
     ///            "<pre><code>fn hello();\n</code></pre>\n");
     ///
-    /// options.parse.default_info_string = Some("rust".into());
+    /// options.parse().default_info_string(Some("rust".into()));
     /// assert_eq!(markdown_to_html("```\nfn hello();\n```\n", &options),
     ///            "<pre><code class=\"language-rust\">fn hello();\n</code></pre>\n");
     /// ```
@@ -427,11 +427,11 @@ impl ComrakParseOptions {
 #[derive(Default, Debug, Clone, Copy)]
 /// Options for formatter functions.
 pub struct ComrakRenderOptions {
-    hardbreaks: bool,
-    github_pre_lang: bool,
-    width: usize,
-    unsafe_: bool,
-    escape: bool,
+    pub(crate) hardbreaks: bool,
+    pub(crate) github_pre_lang: bool,
+    pub(crate) width: usize,
+    pub(crate) unsafe_: bool,
+    pub(crate) escape: bool,
 }
 
 impl ComrakRenderOptions {
@@ -454,7 +454,7 @@ impl ComrakRenderOptions {
     /// assert_eq!(markdown_to_html("Hello.\nWorld.\n", &options),
     ///            "<p>Hello.\nWorld.</p>\n");
     ///
-    /// options.render.hardbreaks = true;
+    /// options.render().hardbreaks(true);
     /// assert_eq!(markdown_to_html("Hello.\nWorld.\n", &options),
     ///            "<p>Hello.<br />\nWorld.</p>\n");
     /// ```
@@ -471,7 +471,7 @@ impl ComrakRenderOptions {
     /// assert_eq!(markdown_to_html("``` rust\nfn hello();\n```\n", &options),
     ///            "<pre><code class=\"language-rust\">fn hello();\n</code></pre>\n");
     ///
-    /// options.render.github_pre_lang = true;
+    /// options.render().github_pre_lang(true);
     /// assert_eq!(markdown_to_html("``` rust\nfn hello();\n```\n", &options),
     ///            "<pre lang=\"rust\"><code>fn hello();\n</code></pre>\n");
     /// ```
@@ -495,7 +495,7 @@ impl ComrakRenderOptions {
     /// assert_eq!(String::from_utf8(output).unwrap(),
     ///            "hello hello hello hello hello hello\n");
     ///
-    /// options.render.width = 20;
+    /// options.render().width(20);
     /// let mut output = vec![];
     /// format_commonmark(node, &options, &mut output).unwrap();
     /// assert_eq!(String::from_utf8(output).unwrap(),
@@ -523,7 +523,7 @@ impl ComrakRenderOptions {
     ///             <p><a href=\"\">Dangerous</a>.</p>\n\
     ///             <p><a href=\"http://commonmark.org\">Safe</a>.</p>\n");
     ///
-    /// options.render.unsafe_ = true;
+    /// options.render().unsafe_(true);
     /// assert_eq!(markdown_to_html(input, &options),
     ///            "<script>\nalert(\'xyz\');\n</script>\n\
     ///             <p>Possibly <marquee>annoying</marquee>.</p>\n\
@@ -544,7 +544,7 @@ impl ComrakRenderOptions {
     /// assert_eq!(markdown_to_html(input, &options),
     ///            "<p><!-- raw HTML omitted -->italic text<!-- raw HTML omitted --></p>\n");
     ///
-    /// options.render.escape = true;
+    /// options.render().escape(true);
     /// assert_eq!(markdown_to_html(input, &options),
     ///            "<p>&lt;i&gt;italic text&lt;/i&gt;</p>\n");
     /// ```

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -581,7 +581,7 @@ fn header_ids() {
             "<h6><a href=\"#hello-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello-1\"></a>Hello.</h6>\n",
             "<h1><a href=\"#isnt-it-grand\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-isnt-it-grand\"></a>Isn't it grand?</h1>\n"
         ),
-        |opts| opts.extension.header_ids = Some("user-content-".to_owned()),
+        |opts| opts.extension().header_ids(Some("user-content-".to_owned())),
     );
 }
 
@@ -1005,31 +1005,31 @@ fn exercise_full_api() {
         Some(&mut |_: &[u8]| Some((b"abc".to_vec(), b"xyz".to_vec()))),
     );
 
-    let _ = ::ComrakOptions {
-        extension: ::ComrakExtensionOptions {
-            strikethrough: false,
-            tagfilter: false,
-            table: false,
-            autolink: false,
-            tasklist: false,
-            superscript: false,
-            header_ids: Some("abc".to_string()),
-            footnotes: false,
-            description_lists: false,
-            front_matter_delimiter: None,
-        },
-        parse: ::ComrakParseOptions {
-            smart: false,
-            default_info_string: Some("abc".to_string()),
-        },
-        render: ::ComrakRenderOptions {
-            hardbreaks: false,
-            github_pre_lang: false,
-            width: 123456,
-            unsafe_: false,
-            escape: false,
-        },
-    };
+    let _ = ::ComrakOptions::new()
+        .extension()
+                .strikethrough(false)
+                .tagfilter(false)
+                .table(false)
+                .autolink(false)
+                .tasklist(false)
+                .superscript(false)
+                .header_ids(Some("abc".to_string()))
+                .footnotes(false)
+                .description_lists(false)
+                .front_matter_delimiter(None);
+
+    let _ = ::ComrakOptions::new()
+        .parse()
+                .smart(false)
+                .default_info_string(Some("abc".to_string()));
+
+    let _ = ::ComrakOptions::new()
+        .render()
+                .hardbreaks(false)
+                .github_pre_lang(false)
+                .width(123456)
+                .unsafe_(false)
+                .escape(false);
 
     let _: String = ::markdown_to_html("# Yes", &default_options);
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -55,7 +55,7 @@ macro_rules! html_opts {
     };
     ([$($optclass:ident.$optname:ident),*], $lhs:expr, $rhs:expr) => {
         html_opts($lhs, $rhs, |opts| {
-            $(opts.$optclass.$optname = true;)*
+            $(opts.$optclass().$optname(true);)*
         });
     };
 }
@@ -581,7 +581,7 @@ fn header_ids() {
             "<h6><a href=\"#hello-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello-1\"></a>Hello.</h6>\n",
             "<h1><a href=\"#isnt-it-grand\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-isnt-it-grand\"></a>Isn't it grand?</h1>\n"
         ),
-        |opts| opts.extension().header_ids(Some("user-content-".to_owned())),
+        |opts| { opts.extension().header_ids(Some("user-content-".to_owned())); },
     );
 }
 
@@ -1007,29 +1007,29 @@ fn exercise_full_api() {
 
     let _ = ::ComrakOptions::new()
         .extension()
-                .strikethrough(false)
-                .tagfilter(false)
-                .table(false)
-                .autolink(false)
-                .tasklist(false)
-                .superscript(false)
-                .header_ids(Some("abc".to_string()))
-                .footnotes(false)
-                .description_lists(false)
-                .front_matter_delimiter(None);
+        .strikethrough(false)
+        .tagfilter(false)
+        .table(false)
+        .autolink(false)
+        .tasklist(false)
+        .superscript(false)
+        .header_ids(Some("abc".to_string()))
+        .footnotes(false)
+        .description_lists(false)
+        .front_matter_delimiter(None);
 
     let _ = ::ComrakOptions::new()
         .parse()
-                .smart(false)
-                .default_info_string(Some("abc".to_string()));
+        .smart(false)
+        .default_info_string(Some("abc".to_string()));
 
     let _ = ::ComrakOptions::new()
         .render()
-                .hardbreaks(false)
-                .github_pre_lang(false)
-                .width(123456)
-                .unsafe_(false)
-                .escape(false);
+        .hardbreaks(false)
+        .github_pre_lang(false)
+        .width(123456)
+        .unsafe_(false)
+        .escape(false);
 
     let _: String = ::markdown_to_html("# Yes", &default_options);
 


### PR DESCRIPTION
I keep breaking semver compatibility by adding options. Change public-facing options to builders so adding an option is backwards-compatible.

I'm not super sold on this variety of builder, namely the way you need to call `options.x` for several `x`s if you want to modify multiple kinds. Maybe I could roll all the builder functions into one impl.