### PR TITLE
Make AST node content public outside of the crate

### DIFF
--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -282,23 +282,26 @@ pub struct NodeHtmlBlock {
 impl NodeValue {
     /// Indicates whether this node is a block node or inline node.
     pub fn block(&self) -> bool {
-        matches!(*self, NodeValue::Document
-            | NodeValue::BlockQuote
-            | NodeValue::FootnoteDefinition(_)
-            | NodeValue::List(..)
-            | NodeValue::DescriptionList
-            | NodeValue::DescriptionItem(_)
-            | NodeValue::DescriptionTerm
-            | NodeValue::DescriptionDetails
-            | NodeValue::Item(..)
-            | NodeValue::CodeBlock(..)
-            | NodeValue::HtmlBlock(..)
-            | NodeValue::Paragraph
-            | NodeValue::Heading(..)
-            | NodeValue::ThematicBreak
-            | NodeValue::Table(..)
-            | NodeValue::TableRow(..)
-            | NodeValue::TableCell)
+        matches!(
+            *self,
+            NodeValue::Document
+                | NodeValue::BlockQuote
+                | NodeValue::FootnoteDefinition(_)
+                | NodeValue::List(..)
+                | NodeValue::DescriptionList
+                | NodeValue::DescriptionItem(_)
+                | NodeValue::DescriptionTerm
+                | NodeValue::DescriptionDetails
+                | NodeValue::Item(..)
+                | NodeValue::CodeBlock(..)
+                | NodeValue::HtmlBlock(..)
+                | NodeValue::Paragraph
+                | NodeValue::Heading(..)
+                | NodeValue::ThematicBreak
+                | NodeValue::Table(..)
+                | NodeValue::TableRow(..)
+                | NodeValue::TableCell
+        )
     }
 
     /// Whether the type the node is of can contain inline nodes.

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -349,7 +349,9 @@ pub struct Ast {
     /// The line in the input document the node starts at.
     pub start_line: u32,
 
-    pub(crate) content: Vec<u8>,
+    /// The content of the node.
+    pub content: Vec<u8>,
+
     pub(crate) open: bool,
     pub(crate) last_line_blank: bool,
 }


### PR DESCRIPTION
I'm currently building a static site generator, for some representational stuff i'm parsing the headers out of the document. Unfortunately the content on the AST node is internal to the crate, which prevents me from getting the data i need.

This change, making it public, would be much appreciated, but regardless if you decide to or not, thank you for maintaining the crate.

