### PR TITLE
refactor: extract arms of format_node into functions

### DIFF
--- a/src/cm.rs
+++ b/src/cm.rs
@@ -320,9 +320,7 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
             NodeValue::TaskItem(checked) => self.format_task_item(checked, entering),
             NodeValue::Strikethrough => self.format_strikethrough(),
             NodeValue::Superscript => self.format_superscript(),
-            NodeValue::Link(ref nl) => {
-                return self.format_link(node, nl, entering) 
-            }
+            NodeValue::Link(ref nl) => return self.format_link(node, nl, entering),
             NodeValue::Image(ref nl) => self.format_image(nl, allow_wrap, entering),
             NodeValue::Table(..) => self.format_table(entering),
             NodeValue::TableRow(..) => self.format_table_row(entering),


### PR DESCRIPTION
I am currently trying to understand the codebase in order to make some real contributions down the line (I'm really excited about the project). While I'm at it I might as well do some small refactorings to make the code easier to understand for myself and the next person who reads it. 

In this one I just extract the arms of a big match statement into functions which makes it easier to see in one glance.

Please let me know if those kinds of PRs are a welcome or more of a hassle on your end.