### PR TITLE
Add the NodeCode struct to expose number of backticks from inline code spans

### DIFF
--- a/examples/headers.rs
+++ b/examples/headers.rs
@@ -3,7 +3,7 @@
 extern crate comrak;
 
 use comrak::{
-    nodes::{AstNode, NodeValue},
+    nodes::{AstNode, NodeCode, NodeValue},
     parse_document, Arena, ComrakOptions,
 };
 
@@ -40,7 +40,7 @@ fn get_document_title(document: &str) -> String {
 
 fn collect_text<'a>(node: &'a AstNode<'a>, output: &mut Vec<u8>) {
     match node.data.borrow().value {
-        NodeValue::Text(ref literal) | NodeValue::Code(ref literal) => {
+        NodeValue::Text(ref literal) | NodeValue::Code(NodeCode { ref literal, .. }) => {
             output.extend_from_slice(literal)
         }
         NodeValue::LineBreak | NodeValue::SoftBreak => output.push(b' '),

--- a/examples/s-expr.rs
+++ b/examples/s-expr.rs
@@ -44,10 +44,18 @@ fn iter_nodes<'a, W: Write>(
     match &node.data.borrow().value {
         Text(t) => write!(writer, "{:?}", String::from_utf8_lossy(&t))?,
         value => {
-            try_node_inline!(value, Code);
             try_node_inline!(value, FootnoteDefinition);
             try_node_inline!(value, FootnoteReference);
             try_node_inline!(value, HtmlInline);
+
+            if let Code(code) = value {
+                return write!(
+                    writer,
+                    "Code({:?}, {})",
+                    String::from_utf8_lossy(&code.literal),
+                    code.num_backticks
+                );
+            }
 
             let has_blocks = node.children().any(|c| c.data.borrow().value.block());
 

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -313,7 +313,7 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
             NodeValue::Text(ref literal) => self.format_text(literal, allow_wrap, entering),
             NodeValue::LineBreak => self.format_line_break(entering),
             NodeValue::SoftBreak => self.format_soft_break(allow_wrap, entering),
-            NodeValue::Code(ref literal) => self.format_code(literal, allow_wrap, entering),
+            NodeValue::Code(ref code) => self.format_code(&code.literal, allow_wrap, entering),
             NodeValue::HtmlInline(ref literal) => self.format_html_inline(literal, entering),
             NodeValue::Strong => self.format_strong(),
             NodeValue::Emph => self.format_emph(node),

--- a/src/html.rs
+++ b/src/html.rs
@@ -1,5 +1,5 @@
 use ctype::isspace;
-use nodes::{AstNode, ListType, NodeValue, TableAlignment};
+use nodes::{AstNode, ListType, NodeCode, NodeValue, TableAlignment};
 use parser::ComrakOptions;
 use regex::Regex;
 use scanners;
@@ -338,7 +338,7 @@ impl<'o> HtmlFormatter<'o> {
                     if plain {
                         match node.data.borrow().value {
                             NodeValue::Text(ref literal)
-                            | NodeValue::Code(ref literal)
+                            | NodeValue::Code(NodeCode { ref literal, .. })
                             | NodeValue::HtmlInline(ref literal) => {
                                 self.escape(literal)?;
                             }
@@ -369,7 +369,7 @@ impl<'o> HtmlFormatter<'o> {
 
     fn collect_text<'a>(&self, node: &'a AstNode<'a>, output: &mut Vec<u8>) {
         match node.data.borrow().value {
-            NodeValue::Text(ref literal) | NodeValue::Code(ref literal) => {
+            NodeValue::Text(ref literal) | NodeValue::Code(NodeCode { ref literal, .. }) => {
                 output.extend_from_slice(literal)
             }
             NodeValue::LineBreak | NodeValue::SoftBreak => output.push(b' '),
@@ -563,7 +563,7 @@ impl<'o> HtmlFormatter<'o> {
                     }
                 }
             }
-            NodeValue::Code(ref literal) => {
+            NodeValue::Code(NodeCode { ref literal, .. }) => {
                 if entering {
                     self.output.write_all(b"<code>")?;
                     self.escape(literal)?;

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -114,7 +114,7 @@ pub enum NodeValue {
     LineBreak,
 
     /// **Inline**.  A [code span](https://github.github.com/gfm/#code-spans).
-    Code(Vec<u8>),
+    Code(NodeCode),
 
     /// **Inline**.  [Raw HTML](https://github.github.com/gfm/#raw-html) contained inline.
     HtmlInline(Vec<u8>),
@@ -158,6 +158,19 @@ pub enum TableAlignment {
 
     /// Cell content is aligned right.
     Right,
+}
+
+/// An inline [code span](https://github.github.com/gfm/#code-spans).
+#[derive(Debug, Clone)]
+pub struct NodeCode {
+    /// The URL for the link destination or image source.
+    pub num_backticks: usize,
+
+    /// The content of the inline code span.
+    /// As the contents are not interpreted as Markdown at all,
+    /// they are contained within this structure,
+    /// rather than inserted into a child inline of any kind.
+    pub literal: Vec<u8>,
 }
 
 /// The details of a link's destination, or an image's source.

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1,7 +1,7 @@
 use arena_tree::Node;
 use ctype::{ispunct, isspace};
 use entity;
-use nodes::{Ast, AstNode, NodeLink, NodeValue};
+use nodes::{Ast, AstNode, NodeCode, NodeLink, NodeValue};
 use parser::{unwrap_into_2, unwrap_into_copy, AutolinkType, Callback, ComrakOptions, Reference};
 use scanners;
 use std::cell::{Cell, RefCell};
@@ -518,7 +518,11 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
             Some(endpos) => {
                 let buf = &self.input[startpos..endpos - openticks];
                 let buf = strings::normalize_code(buf);
-                make_inline(self.arena, NodeValue::Code(buf))
+                let code = NodeCode {
+                    num_backticks: openticks,
+                    literal: buf,
+                };
+                make_inline(self.arena, NodeValue::Code(code))
             }
         }
     }


### PR DESCRIPTION
I would like to use the information how many backtics are used for a code span,
ie. being able to tell whether `` `foo` `` or ` ``foo`` ` was used.
This adds the code to expose that information in the API.

I'm not too happy about it being a breaking change, but didn't see how it could be done otherwise.
Let me know if this is acceptable at all...

Edit: Test included.

Thanks for a nice md parser :slightly_smiling_face:
