### PR TITLE
Make sure to test build with current lock file

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,5 +1,5 @@
 * [ ] `rustup update stable`
-* [ ] ensure `cargo +stable build --release --all-features` works
+* [ ] ensure `cargo +stable build --locked --release --all-features` works
 * [ ] bump version in Cargo.toml
   * [ ] did `tests::exercise_full_api` change? if so, it's a semver-breaking change.
 * [ ] update changelog


### PR DESCRIPTION
The last release (0.11.0) does not build with the included lock file, it needs `cargo update` first which kind of defeats the purpose of a lock file. Adding it to the checklist so maybe it gets done next time.