### PR TITLE
syntect: find by token

### DIFF
--- a/src/plugins/syntect.rs
+++ b/src/plugins/syntect.rs
@@ -60,16 +60,14 @@ impl SyntaxHighlighterAdapter for SyntectAdapter<'_> {
             }
         };
 
-        let syntax = match self.syntax_set.find_syntax_by_name(lang) {
-            None => match self.syntax_set.find_syntax_by_first_line(code) {
-                Some(s) => s,
-                None => self
-                    .syntax_set
-                    .find_syntax_by_name(fallback_syntax)
-                    .unwrap(),
-            },
-            Some(s) => s,
-        };
+        let syntax = self
+            .syntax_set
+            .find_syntax_by_token(lang)
+            .unwrap_or_else(|| {
+                self.syntax_set
+                    .find_syntax_by_first_line(code)
+                    .unwrap_or_else(|| self.syntax_set.find_syntax_plain_text())
+            });
 
         self.remove_pre_tag(highlighted_html_for_string(
             code,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -208,9 +208,9 @@ fn syntax_highlighter_plugin() {
 fn syntect_plugin() {
     let adapter = SyntectAdapter::new("base16-ocean.dark");
 
-    let input = concat!("```Rust\n", "fn main<'a>();\n", "```\n");
+    let input = concat!("```rust\n", "fn main<'a>();\n", "```\n");
     let expected = concat!(
-        "<pre style=\"background-color:#2b303b;\"><code class=\"language-Rust\">\n",
+        "<pre style=\"background-color:#2b303b;\"><code class=\"language-rust\">\n",
         "<span style=\"color:#b48ead;\">fn </span><span style=\"color:#8fa1b3;\">main</span><span style=\"color:#c0c5ce;\">",
         "&lt;</span><span style=\"color:#b48ead;\">&#39;a</span><span style=\"color:#c0c5ce;\">&gt;();\n</span>\n",
         "</code></pre>\n"


### PR DESCRIPTION
https://docs.rs/syntect/3.0.0/syntect/parsing/struct.SyntaxSet.html#method.find_syntax_by_token

Makes it so ```` ```rust ```` works as expected.