### PR TITLE
Improve handling of newline in inline code block

### DIFF
--- a/src/cm.rs
+++ b/src/cm.rs
@@ -549,13 +549,13 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
                 write!(self, "`").unwrap();
             }
 
-            let all_space = literal.iter().all(|&c| c==b' ' || c==b'\r' || c==b'\n');
+            let all_space = literal
+                .iter()
+                .all(|&c| c == b' ' || c == b'\r' || c == b'\n');
             let has_edge_space = literal[0] == b' ' || literal[literal.len() - 1] == b' ';
-            let has_edge_backtick =  literal[0] == b'`' || literal[literal.len() - 1] == b'`';
+            let has_edge_backtick = literal[0] == b'`' || literal[literal.len() - 1] == b'`';
 
-            let pad = literal.is_empty()
-                || has_edge_backtick
-                || (!all_space && has_edge_space);
+            let pad = literal.is_empty() || has_edge_backtick || (!all_space && has_edge_space);
             if pad {
                 write!(self, " ").unwrap();
             }

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -548,11 +548,14 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
             for _ in 0..numticks {
                 write!(self, "`").unwrap();
             }
+
+            let all_space = literal.iter().all(|&c| c==b' ' || c==b'\r' || c==b'\n');
+            let has_edge_space = literal[0] == b' ' || literal[literal.len() - 1] == b' ';
+            let has_edge_backtick =  literal[0] == b'`' || literal[literal.len() - 1] == b'`';
+
             let pad = literal.is_empty()
-                || literal[0] == b'`'
-                || literal[literal.len() - 1] == b'`'
-                || literal[0] == b' '
-                || literal[literal.len() - 1] == b' ';
+                || has_edge_backtick
+                || (!all_space && has_edge_space);
             if pad {
                 write!(self, " ").unwrap();
             }

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -65,7 +65,7 @@ pub fn normalize_code(v: &[u8]) -> Vec<u8> {
             }
             c => r.push(c),
         }
-        if v[i] != b' ' {
+        if v[i] != b' ' && v[i] != b'\r' && v[i] != b'\n' {
             contains_nonspace = true;
         }
 
@@ -273,4 +273,19 @@ pub fn extract_attributes_from_tag(html_tag: &str) -> HashMap<String, String> {
     }
 
     attributes
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::normalize_code;
+
+    #[test]
+    pub fn normalize_code_handles_lone_newline() {
+        assert_eq!(normalize_code(&[b'\n']), vec![b' ']);
+    }
+
+    #[test]
+    pub fn normalize_code_handles_lone_space() {
+        assert_eq!(normalize_code(&[b' ']), vec![b' ']);
+    }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -45,6 +45,7 @@ fn fuzz_doesnt_crash(md: String) {
     parse_document(&Arena::new(), &md, &options);
 }
 
+#[track_caller]
 fn compare_strs(output: &str, expected: &str, kind: &str) {
     if output != expected {
         println!("Running {} test", kind);
@@ -62,10 +63,12 @@ fn compare_strs(output: &str, expected: &str, kind: &str) {
     assert_eq!(output, expected);
 }
 
+#[track_caller]
 fn html(input: &str, expected: &str) {
     html_opts(input, expected, |_| ());
 }
 
+#[track_caller]
 fn html_opts<F>(input: &str, expected: &str, opts: F)
 where
     F: Fn(&mut ComrakOptions),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -404,6 +404,11 @@ fn backticks() {
 }
 
 #[test]
+fn backticks_empty_with_newline_should_be_space() {
+    html("`\n`", "<p><code> </code></p>\n");
+}
+
+#[test]
 fn backticks_num() {
     let input = "Some `code1`. More ``` code2 ```.\n";
 


### PR DESCRIPTION
This case ``` `\n` ``` was getting parsed as `<code></code>` rather than `<code> </code>` due to the `\n` getting flagged as a non-space character. Change is pretty simple

There's actually an unrelated commit with this that changes error reporting to use `#[track_callers]` that makes test failures point to the right line (rather than inside the `compare_strings` helper function)

I can break this into two PRs if you want -- but they seemed trivial enough to review together.