### PR TITLE
Add support for WASM compilation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,20 @@ jobs:
       run: env SPEC=false script/cibuild
     - name: Run spec tests
       run: env SPEC=true script/cibuild
+  build_wasm:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Obtain Rust
+      run: rustup override set stable
+    - name: Setup for wasm
+      run: rustup target add wasm32-unknown-unknown
+    - name: Build
+      run: cargo build --verbose --target wasm32-unknown-unknown
+    - name: Build examples
+      run: cargo build --verbose --target wasm32-unknown-unknown --examples
   no_features_build_test:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "fancy-regex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +321,12 @@ checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
 dependencies = [
  "safemem",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "maplit"
@@ -754,6 +770,7 @@ checksum = "8b20815bbe80ee0be06e6957450a841185fcf690fe0178f14d77a05ce2caa031"
 dependencies = [
  "bincode",
  "bitflags",
+ "fancy-regex",
  "flate2",
  "fnv",
  "lazy_static",
@@ -765,6 +782,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "walkdir",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -951,3 +969,12 @@ name = "xml-rs"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ shell-words = "1.0"
 
 [dev-dependencies]
 timebomb = "0.1.2"
+
+[target.'cfg(not(target_arch="wasm32"))'.dev-dependencies]
 propfuzz = "0.0.1"
 
 [features]
@@ -43,7 +45,6 @@ default = ["clap", "syntect"]
 [target.'cfg(all(not(windows), not(target_arch="wasm32")))'.dependencies]
 xdg = "^2.1"
 syntect = { version = "4.6", optional = true, default-features = false, features = ["assets", "dump-load", "html", "regex-onig"] }
-
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 syntect = { version = "4.6", optional = true, default-features = false, features = ["default-fancy"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["markdown", "commonmark"]
 license = "BSD-2-Clause"
 categories = ["text-processing", "parsing", "command-line-utilities"]
 exclude = ["/hooks/*", "/script/*", "/vendor/*", "/.travis.yml", "/Makefile", "/spec_out.txt"]
+resolver = "2"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ twoway = "0.2"
 pest = "2"
 pest_derive = "2"
 shell-words = "1.0"
-syntect = { version = "4.6", optional = true, default-features = false, features = ["assets", "dump-load", "html", "regex-onig"] }
 
 [dev-dependencies]
 timebomb = "0.1.2"
@@ -40,5 +39,10 @@ propfuzz = "0.0.1"
 [features]
 default = ["clap", "syntect"]
 
-[target.'cfg(not(windows))'.dependencies]
+[target.'cfg(all(not(windows), not(target_arch="wasm32")))'.dependencies]
 xdg = "^2.1"
+syntect = { version = "4.6", optional = true, default-features = false, features = ["assets", "dump-load", "html", "regex-onig"] }
+
+
+[target.'cfg(target_arch="wasm32")'.dependencies]
+syntect = { version = "4.6", optional = true, default-features = false, features = ["default-fancy"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ extern crate lazy_static;
 extern crate pest;
 #[macro_use]
 extern crate pest_derive;
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 extern crate propfuzz;
 extern crate regex;
 #[cfg(feature = "syntect")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ extern crate comrak;
 extern crate clap;
 extern crate shell_words;
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), not(target_arch = "wasm32")))]
 extern crate xdg;
 
 use comrak::{
@@ -291,7 +291,7 @@ if the file does not exist.\
     process::exit(EXIT_SUCCESS);
 }
 
-#[cfg(not(windows))]
+#[cfg(all(not(windows), not(target_arch = "wasm32")))]
 fn get_default_config_path() -> String {
     if let Ok(xdg_dirs) = xdg::BaseDirectories::with_prefix("comrak") {
         if let Ok(path) = xdg_dirs.place_config_file("config") {
@@ -303,8 +303,8 @@ fn get_default_config_path() -> String {
 
     "comrak.config".into()
 }
-
-#[cfg(windows)]
+// If on Windows or compiling to wasm, disable default config file check
+#[cfg(any(windows, target_arch = "wasm32"))]
 fn get_default_config_path() -> String {
     "none".into()
 }


### PR DESCRIPTION
I wanted to use comrak on the web, and I needed a couple small tweaks to compile to WASM.

Mostly I needed to modify the dependencies to reduce the number of features for syntect, as regex-onig is not portable. Also, there's no way to have a default config file in WASM.

I am not using most of the features of comrak, so I am really not sure what depends on syntect's features, but compiling markdown to syntax highlighted HTML is working with these changes.