### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/strings.rs
+++ b/src/strings.rs
@@ -176,11 +176,11 @@ pub fn trim_slice(mut i: &[u8]) -> &[u8] {
 fn shift_buf_left(buf: &mut [u8], n: usize) {
     assert!(n <= buf.len());
     let keep = buf.len() - n;
-    unsafe {
-        let dst = buf.as_mut_ptr();
-        let src = dst.add(n);
-        ptr::copy(src, dst, keep);
-    }
+
+    let dst = buf.as_mut_ptr();
+    let src = unsafe { dst.add(n) };
+    unsafe { ptr::copy(src, dst, keep) };
+    
 }
 
 pub fn clean_url(url: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions. However, I found that only 2 functions are real unsafe operations (see the list below).

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

**Real unsafe operation list:**
1. the add()\copy() function(these are unsafe functions)

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html