### PR TITLE
Fix wrapping on lines succeeded by unwrappable lines

### DIFF
--- a/src/cm.rs
+++ b/src/cm.rs
@@ -108,6 +108,7 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
                 }
             }
             self.column = 0;
+            self.last_breakable = 0;
             self.begin_line = true;
             self.begin_content = true;
             self.need_cr -= 1;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -62,6 +62,18 @@ fn compare_strs(output: &str, expected: &str, kind: &str) {
 }
 
 #[track_caller]
+fn commonmark(input: &str, expected: &str) {
+    let arena = ::Arena::new();
+    let mut options = ::ComrakOptions::default();
+    options.render.width = 72;
+
+    let root = ::parse_document(&arena, input, &options);
+    let mut output = vec![];
+    cm::format_document(root, &options, &mut output).unwrap();
+    compare_strs(&String::from_utf8(output).unwrap(), expected, "regular");
+}
+
+#[track_caller]
 fn html(input: &str, expected: &str) {
     html_opts(input, expected, |_| ());
 }
@@ -247,6 +259,27 @@ fn thematic_breaks() {
         concat!("---\n", "\n", "- - -\n", "\n", "\n", "_        _   _\n"),
         concat!("<hr />\n", "<hr />\n", "<hr />\n"),
     );
+}
+
+#[test]
+fn width_breaks() {
+    let input = concat!(
+        "this should break because it has breakable characters. break right here newline\n",
+        "\n",
+        "don't break\n",
+        "\n",
+        "a-long-line-that-won't-break-because-there-is-no-character-it-can-break-on\n"
+    );
+    let output = concat!(
+        "this should break because it has breakable characters. break right here\n",
+        "newline\n",
+        "\n",
+        "don't break\n",
+        "\n",
+        "a-long-line-that-won't-break-because-there-is-no-character-it-can-break-on\n"
+    );
+
+    commonmark(input, output);
 }
 
 #[test]


### PR DESCRIPTION
When outputting as `commonmark` lines followed by a long, unwrappable
section would wrap incorrectly. For example:

```md
item that doesn't need wrapping

a-long-line-that-won't-be-wrapped-because-there-is-no-character-it-can-break-on
```

When running this with the `--to commonmark` and `--width 72` options:

```sh
comrak --to commonmark --width 72 some-markdown.md
```

It outputs the following:

```md
item that doesn't need
wrapping

a-long-line-that-won't-be-wrapped-because-there-is-no-character-it-can-break-on
```

What was happening is that when a new line is needed, the algorithm
resets a bunch of variables like the current column, if we're at the
beginning of a line, etc. One of those variables is the position of the
last place we can break a line: the last non-space character. This is
stored in `CommonMarkFormatter`s `last_breakable` field.

cmark-gfm [resets this][cmark-gfm-render] in `render.c`, and now so does comrak.

This also adds a new `commonmark` test type that doesn't write to HTML
to test commonmark specific features or bugs.

[cmark-gfm-render]: https://github.com/github/cmark-gfm/blob/f26f75ce5dbfeddf8c3e3df10a6f238f65f8d6ba/src/render.c#L60

Fixes #227 