### PR TITLE
Add bullet list style options

### DIFF
--- a/src/cm.rs
+++ b/src/cm.rs
@@ -411,7 +411,8 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
 
         if entering {
             if parent.list_type == ListType::Bullet {
-                write!(self, "- ").unwrap();
+                let bullet = char::from(self.options.render.list_style as u8);
+                write!(self, "{} ", bullet).unwrap();
             } else {
                 self.write_all(&listmarker).unwrap();
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ pub use html::Anchorizer;
 pub use parser::{
     parse_document, parse_document_with_broken_link_callback, ComrakExtensionOptions,
     ComrakOptions, ComrakParseOptions, ComrakPlugins, ComrakRenderOptions, ComrakRenderPlugins,
+    ListStyleType,
 };
 pub use typed_arena::Arena;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ extern crate xdg;
 
 use comrak::{
     Arena, ComrakExtensionOptions, ComrakOptions, ComrakParseOptions, ComrakPlugins,
-    ComrakRenderOptions,
+    ComrakRenderOptions, ListStyleType,
 };
 
 use comrak::adapters::SyntaxHighlighterAdapter;
@@ -161,6 +161,15 @@ if the file does not exist.\
                 .value_name("THEME")
                 .help("Syntax highlighting for codefence blocks. Choose a theme or 'none' for disabling.")
                 .default_value("base16-ocean.dark"),
+        )
+        .arg(
+            clap::Arg::with_name("list-style")
+                .long("list-style")
+                .takes_value(true)
+                .possible_values(&["dash", "plus", "star"])
+                .default_value("dash")
+                .value_name("LIST_STYLE")
+                .help("Specify bullet character for lists (-, +, *) in CommonMark ouput"),
         );
 
     let mut matches = app.clone().get_matches();
@@ -220,6 +229,11 @@ if the file does not exist.\
                 .unwrap_or(0),
             unsafe_: matches.is_present("unsafe"),
             escape: matches.is_present("escape"),
+            list_style: matches
+                .value_of("list-style")
+                .unwrap_or("dash")
+                .parse::<ListStyleType>()
+                .expect("unknown list style"),
         },
     };
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -18,7 +18,7 @@ use std::cmp::min;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::mem;
-use std::str;
+use std::str::{self, FromStr};
 use strings;
 use typed_arena::Arena;
 
@@ -437,6 +437,29 @@ pub struct ComrakRenderOptions {
     ///            "<p>&lt;i&gt;italic text&lt;/i&gt;</p>\n");
     /// ```
     pub escape: bool,
+
+    /// Set the type of [bullet list marker](https://spec.commonmark.org/0.30/#bullet-list-marker) to use. Options are:
+    ///
+    /// * `ListStyleType::Dash` to use `-` (default)
+    /// * `ListStyleType::Plus` to use `+`
+    /// * `ListStyleType::Star` to use `*`
+    ///
+    /// ```rust
+    /// # use comrak::{markdown_to_commonmark, ComrakOptions, ListStyleType};
+    /// let mut options = ComrakOptions::default();
+    /// let input = "- one\n- two\n- three";
+    /// assert_eq!(markdown_to_commonmark(input, &options),
+    ///            "- one\n- two\n- three\n"); // default is Dash
+    ///
+    /// options.render.list_style = ListStyleType::Plus;
+    /// assert_eq!(markdown_to_commonmark(input, &options),
+    ///            "+ one\n+ two\n+ three\n");
+    ///
+    /// options.render.list_style = ListStyleType::Star;
+    /// assert_eq!(markdown_to_commonmark(input, &options),
+    ///            "* one\n* two\n* three\n");
+    /// ```
+    pub list_style: ListStyleType,
 }
 
 #[derive(Default, Debug)]
@@ -1890,4 +1913,34 @@ fn reopen_ast_nodes<'a>(mut ast: &'a AstNode<'a>) {
 pub enum AutolinkType {
     URI,
     Email,
+}
+
+#[derive(Debug, Clone, Copy)]
+/// Options for bulleted list redering in markdown. See `link_style` in [ComrakRenderOptions] for more details.
+pub enum ListStyleType {
+    /// The `-` character
+    Dash = 45,
+    /// The `+` character
+    Plus = 43,
+    /// The `*` character
+    Star = 42,
+}
+
+impl Default for ListStyleType {
+    fn default() -> Self {
+        ListStyleType::Dash
+    }
+}
+
+impl FromStr for ListStyleType {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<ListStyleType, Self::Err> {
+        match input {
+            "dash" => Ok(ListStyleType::Dash),
+            "plus" => Ok(ListStyleType::Plus),
+            "star" => Ok(ListStyleType::Star),
+            _ => Err(()),
+        }
+    }
 }


### PR DESCRIPTION
Hi! I know this repository practices [Optimistic Merging](http://hintjens.com/blog:106) but I've put this in draft-form for for a few reasons:

1. It's not done. It still need to fill out documentation for new options and enums.
2. I'm not sure if this is a feature you want to support and I didn't want to do `1` without knowing
3. This is my second ever rust contribution and I'd love some feedback as I'm sure there are things that could be improved.

Original change description below:

---

This change adds a new option `--list-style` so users can choose which
character all bulleted lists use for their marker. The [commonmark
spec] supports three options for bullet markers: `-`, `*`, `+` which is
also now the case here. Previously, when comrak (or cmark-gfm) rendered
markdown, it would pick `-` which is now the default.

This also adds the ability to optionally provide custom ComrakOptions
when testing. If the defaults are fine, you can pass `None`.

[commonmark spec]: https://spec.commonmark.org/0.30/#bullet-list-marker