### PR TITLE
table: fix start_line of Table itself

### DIFF
--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -69,7 +69,7 @@ fn try_opening_header<'a, 'o, 'c>(
     }
 
     let mut child = Ast::new(NodeValue::Table(alignments));
-    child.start_line = parser.line_number;
+    child.start_line = container.data.borrow().start_line;
     let table = parser.arena.alloc(Node::new(RefCell::new(child)));
     container.append(table);
 


### PR DESCRIPTION
This way matches cmark-gfm, pointing to the header row, which makes a lot more sense than pointing to the line of the marker row.

Labelled with `api breaking change` because people may be relying on this number.

Fixes #230. Thanks to @SamWilsn for the report!