### PR TITLE
Add `comrak_set_parse_option_smart`

### DIFF
--- a/c-api/include/comrak_ffi.h
+++ b/c-api/include/comrak_ffi.h
@@ -27,7 +27,7 @@ void comrak_set_extension_option_footnotes(comrak_options_t *options, bool value
 void comrak_set_extension_option_description_lists(comrak_options_t *options, bool value);
 void comrak_set_extension_option_front_matter_delimiter(comrak_options_t *options, const char *front_matter_delimiter, size_t front_matter_delimiter_len);
 
-void comrak_set_parse_option_superscript(comrak_options_t *options, bool value);
+void comrak_set_parse_option_smart(comrak_options_t *options, bool value);
 void comrak_set_parse_option_default_info_string(comrak_options_t *options, const char *default_info_string, size_t default_info_string_len);
 
 void comrak_set_render_option_hardbreaks(comrak_options_t *options, bool value);

--- a/c-api/tests/src/test_comrak_parse_options.c
+++ b/c-api/tests/src/test_comrak_parse_options.c
@@ -7,18 +7,18 @@
 #include "test_util.h"
 
 void test_commonmark_render_works_with_smart() {
-    const char* commonmark = "Hello ~~world~~ 世界!";
+    const char* commonmark = "'Hello,' \"world\" ...";
     comrak_options_t * comrak_options = comrak_options_new();
 
-    comrak_set_extension_option_strikethrough(comrak_options, false);
+    comrak_set_parse_option_smart(comrak_options, false);
     comrak_str_t html = comrak_commonmark_to_html(commonmark, comrak_options);
-    const char* expected = "<p>Hello ~~world~~ 世界!</p>\n";
+    const char* expected = "<p>'Hello,' &quot;world&quot; ...</p>\n";
 
     str_eq(html, expected);
 
-    comrak_set_extension_option_strikethrough(comrak_options, true);
+    comrak_set_parse_option_smart(comrak_options, true);
     comrak_str_t html_w_extension = comrak_commonmark_to_html(commonmark, comrak_options);
-    const char* expected_w_extension = "<p>Hello <del>world</del> 世界!</p>\n";
+    const char* expected_w_extension = "<p>‘Hello,’ “world” …</p>\n";
 
     str_eq(html_w_extension, expected_w_extension);
 


### PR DESCRIPTION
Gah! I am fairly sure this is the last error. I've mapped all the options exposed _except_ this one. Turns out the header file never exposed the method, and the test didn't mind because it was completely wrong! 😓 Sorry for the trouble!




xref https://github.com/gjtorikian/commonmarker/pull/185