### PR TITLE
Demonstrate that strikethrough works erroneously, maybe

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -635,11 +635,13 @@ fn strikethrough() {
         concat!(
             "This is ~strikethrough~.\n",
             "\n",
-            "As is ~~this, okay~~?\n"
+            "As is ~~this, okay~~?\n",
+            "But not ~this~.\n"
         ),
         concat!(
             "<p>This is <del>strikethrough</del>.</p>\n",
-            "<p>As is <del>this, okay</del>?</p>\n"
+            "<p>As is <del>this, okay</del>?</p>\n",
+            "<p>But not this.</p>\n"
         ),
     );
 }


### PR DESCRIPTION
The GFM spec [states](https://github.github.com/gfm/#strikethrough-extension-) that

> Strikethrough text is any text wrapped in two tildes (~).

But as I show in this failing text, a single tilde is enough to trigger a strikethrough. 

_But the plot thickens!_ Because in a GitHub comment box, a single tilde also triggers a strikethrough:

```
Hello **world** -- how are _you_ today? I'm ~~fine~~, ~yourself~?
```

Hello **world** -- how are _you_ today? I'm ~~fine~~, ~yourself~?

* * *

I'm not sure who is correct and who isn't here. 