### PR TITLE
Allow `c_char` options to be NULL

### DIFF
--- a/c-api/src/comrak_options.rs
+++ b/c-api/src/comrak_options.rs
@@ -31,9 +31,14 @@ macro_rules! make_c_char_option_func {
                 v_len: size_t,
             ) {
                 let comrak_options = to_ref_mut!(c_comrak_options);
-                let value = unwrap_or_ret_err_code! { to_str!(v, v_len) };
 
-                comrak_options.$opt_type.$name = Some(value.to_string());
+                if v.is_null() {
+                    comrak_options.$opt_type.$name = None;
+                } else {
+                    let value = unwrap_or_ret_err_code! { to_str!(v, v_len) };
+
+                    comrak_options.$opt_type.$name = Some(value.to_string());
+                }
             }
         }
     };
@@ -55,7 +60,6 @@ macro_rules! make_size_t_option_func {
     };
 }
 
-
 #[no_mangle]
 pub extern "C" fn comrak_options_new() -> *mut ComrakOptions {
     to_ptr_mut(ComrakOptions::default())
@@ -66,7 +70,6 @@ pub extern "C" fn comrak_options_free(options: *mut ComrakOptions) {
     assert!(!options.is_null());
     drop(unsafe { Box::from_raw(options) });
 }
-
 
 make_bool_option_func!(extension, strikethrough);
 make_bool_option_func!(extension, tagfilter);

--- a/c-api/tests/src/test_comrak_extension_options.c
+++ b/c-api/tests/src/test_comrak_extension_options.c
@@ -134,11 +134,22 @@ void test_commonmark_render_works_with_header_ids() {
     comrak_set_extension_option_header_ids(comrak_options, "user-content-", 13);
     comrak_str_t html = comrak_commonmark_to_html(commonmark, comrak_options);
     const char* expected = "<h1><a href=\"#hi\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi\"></a>Hi.</h1>\n<h2><a href=\"#hi-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-1\"></a>Hi 1.</h2>\n<h3><a href=\"#hi-2\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-2\"></a>Hi.</h3>\n<h4><a href=\"#hello\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello\"></a>Hello.</h4>\n<h5><a href=\"#hi-3\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-3\"></a>Hi.</h5>\n<h6><a href=\"#hello-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello-1\"></a>Hello.</h6>\n<h1><a href=\"#isnt-it-grand\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-isnt-it-grand\"></a>Isn't it grand?</h1>\n";
-
     str_eq(html, expected);
+
+    comrak_set_extension_option_header_ids(comrak_options, "", 0);
+    comrak_str_t no_prefix_id_html = comrak_commonmark_to_html(commonmark, comrak_options);
+    const char* no_prefix_id_expected = "<h1><a href=\"#hi\" aria-hidden=\"true\" class=\"anchor\" id=\"hi\"></a>Hi.</h1>\n<h2><a href=\"#hi-1\" aria-hidden=\"true\" class=\"anchor\" id=\"hi-1\"></a>Hi 1.</h2>\n<h3><a href=\"#hi-2\" aria-hidden=\"true\" class=\"anchor\" id=\"hi-2\"></a>Hi.</h3>\n<h4><a href=\"#hello\" aria-hidden=\"true\" class=\"anchor\" id=\"hello\"></a>Hello.</h4>\n<h5><a href=\"#hi-3\" aria-hidden=\"true\" class=\"anchor\" id=\"hi-3\"></a>Hi.</h5>\n<h6><a href=\"#hello-1\" aria-hidden=\"true\" class=\"anchor\" id=\"hello-1\"></a>Hello.</h6>\n<h1><a href=\"#isnt-it-grand\" aria-hidden=\"true\" class=\"anchor\" id=\"isnt-it-grand\"></a>Isn't it grand?</h1>\n";
+    str_eq(no_prefix_id_html, no_prefix_id_expected);
+
+    comrak_set_extension_option_header_ids(comrak_options, NULL, 0);
+    comrak_str_t no_id_html = comrak_commonmark_to_html(commonmark, comrak_options);
+    const char* no_id_expected = "<h1>Hi.</h1>\n<h2>Hi 1.</h2>\n<h3>Hi.</h3>\n<h4>Hello.</h4>\n<h5>Hi.</h5>\n<h6>Hello.</h6>\n<h1>Isn't it grand?</h1>\n";
+    str_eq(no_id_html, no_id_expected);
 
     comrak_options_free(comrak_options);
     comrak_str_free(html);
+    comrak_str_free(no_prefix_id_html);
+    comrak_str_free(no_id_html);
 }
 
 void test_commonmark_render_works_with_footnotes() {


### PR DESCRIPTION
What the title says! 

`ComrakOptions::default()` sets the `header_ids` option of `extensions` to `""`; this means that, by default, headers are always given anchor tags (with an ID matching the text content of the header).

In C, there's currently no way of implementing the removal of the `header_ids` option. This won't work:

```c
comrak_set_extension_option_header_ids(comrak_options, "", 0);
```

Because it reads just as `default` does: add the header IDs, but don't add any prefix.

This PR introduces (and tests) a different possibility:

```c
comrak_set_extension_option_header_ids(comrak_options, NULL, 0);
```

Passing this ☝️ will effectively "turn off" header ID generation by checking to see if the incoming value is `NULL`. (Some kind of `NULL` check is necessary here, with or without this change. I was able to segfault the FFI.)

I'm happy to expose a different function to configure this if it doesn't look good!