### PR TITLE
Adding functionality to build SyntectAdapters with custom themes, syntax sets, etc.

### DIFF
--- a/src/plugins/syntect.rs
+++ b/src/plugins/syntect.rs
@@ -119,21 +119,33 @@ pub struct SyntectAdapterBuilder<'a> {
 }
 
 impl<'a> SyntectAdapterBuilder<'a> {
+    /// Creates a new empty [`SyntectAdapterBuilder`]
     pub fn new() -> Self {
         Default::default()
     }
+
+    /// Sets the theme
     pub fn theme(mut self, s: &'a str) -> Self {
         self.theme.replace(s);
         self
     }
+
+    /// Sets the syntax set
     pub fn syntax_set(mut self, s: SyntaxSet) -> Self {
         self.syntax_set.replace(s);
         self
     }
+
+    /// Sets the theme set
     pub fn theme_set(mut self, s: ThemeSet) -> Self {
         self.theme_set.replace(s);
         self
     }
+
+    /// Builds the [`SyntectAdapter`]. Default values:
+    /// - `theme`: `InspiredGitHub`
+    /// - `syntax_set`: [`SyntaxSet::load_defaults_newlines()`]
+    /// - `theme_set`: [`ThemeSet::load_defaults()`]
     pub fn build(self) -> SyntectAdapter<'a> {
         SyntectAdapter {
             theme: self.theme.unwrap_or("InspiredGitHub"),

--- a/src/plugins/syntect.rs
+++ b/src/plugins/syntect.rs
@@ -119,22 +119,22 @@ pub struct SyntectAdapterBuilder<'a> {
 }
 
 impl<'a> SyntectAdapterBuilder<'a> {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Default::default()
     }
-    fn theme(mut self, s: &'a str) -> Self {
+    pub fn theme(mut self, s: &'a str) -> Self {
         self.theme.replace(s);
         self
     }
-    fn syntax_set(mut self, s: SyntaxSet) -> Self {
+    pub fn syntax_set(mut self, s: SyntaxSet) -> Self {
         self.syntax_set.replace(s);
         self
     }
-    fn theme_set(mut self, s: ThemeSet) -> Self {
+    pub fn theme_set(mut self, s: ThemeSet) -> Self {
         self.theme_set.replace(s);
         self
     }
-    fn build(self) -> SyntectAdapter<'a> {
+    pub fn build(self) -> SyntectAdapter<'a> {
         SyntectAdapter {
             theme: self.theme.unwrap_or("InspiredGitHub"),
             syntax_set: self

--- a/src/plugins/syntect.rs
+++ b/src/plugins/syntect.rs
@@ -107,3 +107,40 @@ impl SyntaxHighlighterAdapter for SyntectAdapter<'_> {
         build_opening_tag("code", attributes)
     }
 }
+
+#[derive(Debug, Default)]
+/// A builder for [`SyntectAdapter`].
+///
+/// Allows customization of `Theme`, [`ThemeSet`], and [`SyntaxSet`].
+pub struct SyntectAdapterBuilder<'a> {
+    theme: Option<&'a str>,
+    syntax_set: Option<SyntaxSet>,
+    theme_set: Option<ThemeSet>,
+}
+
+impl<'a> SyntectAdapterBuilder<'a> {
+    fn new() -> Self {
+        Default::default()
+    }
+    fn theme(mut self, s: &'a str) -> Self {
+        self.theme.replace(s);
+        self
+    }
+    fn syntax_set(mut self, s: SyntaxSet) -> Self {
+        self.syntax_set.replace(s);
+        self
+    }
+    fn theme_set(mut self, s: ThemeSet) -> Self {
+        self.theme_set.replace(s);
+        self
+    }
+    fn build(self) -> SyntectAdapter<'a> {
+        SyntectAdapter {
+            theme: self.theme.unwrap_or("InspiredGitHub"),
+            syntax_set: self
+                .syntax_set
+                .unwrap_or_else(SyntaxSet::load_defaults_newlines),
+            theme_set: self.theme_set.unwrap_or_else(ThemeSet::load_defaults),
+        }
+    }
+}


### PR DESCRIPTION
I came across the issue of being unable to add custom themes to SyntectAdapters, so to avoid making the internals of SyntectAdapters public, I made a small builder to let users build custom SyntectAdapters.

Thank you for your time!