### PR TITLE
Make `comrak --help` readable on my terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim",
+ "term_size",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -806,11 +807,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "term_size",
  "unicode-width",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ regex = "1.5.5"
 once_cell = "1.13.0"
 entities = "1.0.1"
 unicode_categories = "0.1.1"
-clap = { version = "2.32.0", optional = true }
+clap = { version = "2.32.0", optional = true, features = ["wrap_help"] }
 memchr = "2"
 pest = "2"
 pest_derive = "2"


### PR DESCRIPTION
When I run `comrak --help` on my terminal, I see unwrapped and very hard-to-read output.

This is what I see:

![image](https://user-images.githubusercontent.com/89623/189873381-275f109c-e3ca-4e45-aa44-7500f52362ff.png)

The output is similar with a 100 columns terminal:

![image](https://user-images.githubusercontent.com/89623/189873538-9c936007-d1df-4995-9f73-a8af5afe6d18.png)

With the `wrap_help` Cargo option for Clap, we can make it produce much more readable output. The output will even adapt to the terminal width (similar to man(1)) and thus look good in many situations:

![image](https://user-images.githubusercontent.com/89623/189873674-2dc46239-df3e-4252-ba4b-acbf85ffeb5b.png)
