### PR TITLE
improve tagfilter performance

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -194,11 +194,9 @@ fn tagfilter(literal: &[u8]) -> bool {
         i += 1;
     }
 
+    let lc = unsafe { String::from_utf8_unchecked(literal[i..].to_vec()) }.to_lowercase();
     for t in TAGFILTER_BLACKLIST.iter() {
-        if unsafe { String::from_utf8_unchecked(literal[i..].to_vec()) }
-            .to_lowercase()
-            .starts_with(t)
-        {
+        if lc.starts_with(t) {
             let j = i + t.len();
             return isspace(literal[j])
                 || literal[j] == b'>'


### PR DESCRIPTION
Within tagfilter we currently run the same line for every iteration. Let's move this out of the loop.

fixes #255 