### PR TITLE
Cargo.toml: remove timebomb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atom"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ff149ed9780025acfdb36862d35b28856bb693ceb451259a7164442f22fdc3"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +132,7 @@ dependencies = [
  "emojis",
  "entities",
  "memchr",
+ "ntest",
  "once_cell",
  "pest",
  "pest_derive",
@@ -145,7 +140,6 @@ dependencies = [
  "regex",
  "shell-words",
  "syntect",
- "timebomb",
  "typed-arena",
  "unicode_categories",
  "xdg",
@@ -429,6 +423,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da8ec6d2b73d45307e926f5af46809768581044384637af6b3f3fe7c3c88f512"
+dependencies = [
+ "ntest_test_cases",
+ "ntest_timeout",
+]
+
+[[package]]
+name = "ntest_test_cases"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be7d33be719c6f4d09e64e27c1ef4e73485dc4cc1f4d22201f89860a7fe22e22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ntest_timeout"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "066b468120587a402f0b47d8f80035c921f6a46f8209efd0632a89a16f5188a4"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,7 +576,7 @@ dependencies = [
  "indexmap",
  "line-wrap",
  "serde",
- "time 0.3.17",
+ "time",
  "xml-rs",
 ]
 
@@ -558,6 +585,17 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
+dependencies = [
+ "once_cell",
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -631,16 +669,6 @@ dependencies = [
  "regex-syntax",
  "rusty-fork",
  "tempfile",
-]
-
-[[package]]
-name = "pulse"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655612b6c8d96a8a02f331fe296cb4f925b68e87c1d195544675abca2d9b9af0"
-dependencies = [
- "atom",
- "time 0.1.45",
 ]
 
 [[package]]
@@ -948,17 +976,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
@@ -985,13 +1002,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "timebomb"
-version = "0.1.2"
+name = "toml"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f0886f4b637067027d8c9a038a9249d95648689d1a91009d9abb895625f883a"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
- "pulse",
- "time 0.3.17",
+ "serde",
 ]
 
 [[package]]
@@ -1055,12 +1071,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ shell-words = { version = "1.0", optional = true }
 emojis = { version = "0.5.2", optional = true }
 
 [dev-dependencies]
-timebomb = "0.1.2"
+ntest = "*"
 
 [target.'cfg(not(target_arch="wasm32"))'.dev-dependencies]
 propfuzz = "0.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@ extern crate pest;
 #[macro_use]
 extern crate pest_derive;
 extern crate memchr;
+#[cfg(test)]
+extern crate ntest;
 extern crate once_cell;
 #[cfg(all(test, not(target_arch = "wasm32")))]
 extern crate propfuzz;
@@ -84,8 +86,6 @@ extern crate regex;
 extern crate syntect;
 #[cfg(feature = "benchmarks")]
 extern crate test;
-#[cfg(test)]
-extern crate timebomb;
 extern crate typed_arena;
 extern crate unicode_categories;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,11 +2,11 @@ use crate::nodes::{AstNode, NodeCode, NodeValue};
 use adapters::SyntaxHighlighterAdapter;
 use cm;
 use html;
+use ntest::timeout;
 #[cfg(feature = "syntect")]
 use plugins::syntect::SyntectAdapter;
 use std::collections::HashMap;
 use strings::build_opening_tag;
-use timebomb::timeout_ms;
 
 #[cfg(not(target_arch = "wasm32"))]
 use propfuzz::prelude::*;
@@ -1042,6 +1042,7 @@ fn regression_back_to_back_ranges() {
 }
 
 #[test]
+#[timeout(4000)]
 fn pathological_emphases() {
     let mut s = String::with_capacity(50000 * 4);
     for _ in 0..50000 {
@@ -1053,7 +1054,7 @@ fn pathological_emphases() {
     exp.pop();
     exp += "</p>\n";
 
-    timeout_ms(move || html(&s, &exp), 4000);
+    html(&s, &exp);
 }
 
 #[test]


### PR DESCRIPTION
Really old and depends on a version of "time" that has active advisories.  Not super relevant given it's only used in test, but.