### PR TITLE
Add footnote attributes that mirror cmark-gfm

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 
 jobs:
-  build_test_spec:
+  build_test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -20,7 +20,22 @@ jobs:
       run: rustup override set ${{ matrix.rust }}
     - name: Build and test
       run: env SPEC=false script/cibuild
-    - name: Run spec tests
+  build_spec:
+    runs-on: ubuntu-latest
+    needs: build_test
+    strategy:
+      matrix:
+        rust:
+          - nightly
+          - beta
+          - stable
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Obtain Rust
+      run: rustup override set ${{ matrix.rust }}
+    - name: Build and run spec tests
       run: env SPEC=true script/cibuild
   build_wasm:
     runs-on: ubuntu-latest

--- a/src/html.rs
+++ b/src/html.rs
@@ -814,10 +814,10 @@ impl<'o> HtmlFormatter<'o> {
                 if entering {
                     if self.footnote_ix == 0 {
                         self.output
-                            .write_all(b"<section class=\"footnotes\">\n<ol>\n")?;
+                            .write_all(b"<section class=\"footnotes\" data-footnotes>\n<ol>\n")?;
                     }
                     self.footnote_ix += 1;
-                    writeln!(self.output, "<li id=\"fn{}\">", self.footnote_ix)?;
+                    writeln!(self.output, "<li id=\"fn-{}\">", self.footnote_ix)?;
                 } else {
                     if self.put_footnote_backref()? {
                         self.output.write_all(b"\n")?;
@@ -830,7 +830,7 @@ impl<'o> HtmlFormatter<'o> {
                     let r = str::from_utf8(r).unwrap();
                     write!(
                         self.output,
-                        "<sup class=\"footnote-ref\"><a href=\"#fn{}\" id=\"fnref{}\">{}</a></sup>",
+                        "<sup class=\"footnote-ref\"><a href=\"#fn-{}\" id=\"fnref-{}\" data-footnote-ref>{}</a></sup>",
                         r, r, r
                     )?;
                 }
@@ -859,7 +859,7 @@ impl<'o> HtmlFormatter<'o> {
         self.written_footnote_ix = self.footnote_ix;
         write!(
             self.output,
-            "<a href=\"#fnref{}\" class=\"footnote-backref\">↩</a>",
+            "<a href=\"#fnref-{}\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a>",
             self.footnote_ix
         )?;
         Ok(true)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -244,7 +244,7 @@ pub struct ComrakExtensionOptions {
     /// let mut options = ComrakOptions::default();
     /// options.extension.footnotes = true;
     /// assert_eq!(markdown_to_html("Hi[^x].\n\n[^x]: A greeting.\n", &options),
-    ///            "<p>Hi<sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\">1</a></sup>.</p>\n<section class=\"footnotes\">\n<ol>\n<li id=\"fn1\">\n<p>A greeting. <a href=\"#fnref1\" class=\"footnote-backref\">↩</a></p>\n</li>\n</ol>\n</section>\n");
+    ///            "<p>Hi<sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup>.</p>\n<section class=\"footnotes\" data-footnotes>\n<ol>\n<li id=\"fn-1\">\n<p>A greeting. <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a></p>\n</li>\n</ol>\n</section>\n");
     /// ```
     pub footnotes: bool,
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -982,28 +982,28 @@ fn footnotes() {
             "[^unused]: This is not used.\n"
         ),
         concat!(
-            "<p>Here is a[^nowhere] footnote reference,<sup class=\"footnote-ref\"><a href=\"#fn1\" \
-             id=\"fnref1\">1</a></sup> and another.<sup class=\"footnote-ref\"><a \
-             href=\"#fn2\" id=\"fnref2\">2</a></sup></p>\n",
-            "<p>This is another note.<sup class=\"footnote-ref\"><a href=\"#fn3\" \
-             id=\"fnref3\">3</a></sup></p>\n",
+            "<p>Here is a[^nowhere] footnote reference,<sup class=\"footnote-ref\"><a href=\"#fn-1\" \
+             id=\"fnref-1\" data-footnote-ref>1</a></sup> and another.<sup class=\"footnote-ref\"><a \
+             href=\"#fn-2\" id=\"fnref-2\" data-footnote-ref>2</a></sup></p>\n",
+            "<p>This is another note.<sup class=\"footnote-ref\"><a href=\"#fn-3\" \
+             id=\"fnref-3\" data-footnote-ref>3</a></sup></p>\n",
             "<p>This is regular content.</p>\n",
-            "<section class=\"footnotes\">\n",
+            "<section class=\"footnotes\" data-footnotes>\n",
             "<ol>\n",
-            "<li id=\"fn1\">\n",
-            "<p>Here is the footnote. <a href=\"#fnref1\" \
-             class=\"footnote-backref\">↩</a></p>\n",
+            "<li id=\"fn-1\">\n",
+            "<p>Here is the footnote. <a href=\"#fnref-1\" \
+             class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a></p>\n",
             "</li>\n",
-            "<li id=\"fn2\">\n",
+            "<li id=\"fn-2\">\n",
             "<p>Here's one with multiple blocks.</p>\n",
             "<p>Subsequent paragraphs are indented.</p>\n",
             "<pre><code>code\n",
             "</code></pre>\n",
-            "<a href=\"#fnref2\" class=\"footnote-backref\">↩</a>\n",
+            "<a href=\"#fnref-2\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a>\n",
             "</li>\n",
-            "<li id=\"fn3\">\n",
-            "<p>Hi. <a href=\"#fnref3\" \
-             class=\"footnote-backref\">↩</a></p>\n",
+            "<li id=\"fn-3\">\n",
+            "<p>Hi. <a href=\"#fnref-3\" \
+             class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a></p>\n",
             "</li>\n",
             "</ol>\n",
             "</section>\n"
@@ -1017,12 +1017,12 @@ fn footnote_does_not_eat_exclamation() {
         [extension.footnotes],
         concat!("Here's my footnote![^a]\n", "\n", "[^a]: Yep.\n"),
         concat!(
-            "<p>Here's my footnote!<sup class=\"footnote-ref\"><a href=\"#fn1\" \
-             id=\"fnref1\">1</a></sup></p>\n",
-            "<section class=\"footnotes\">\n",
+            "<p>Here's my footnote!<sup class=\"footnote-ref\"><a href=\"#fn-1\" \
+             id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n",
+            "<section class=\"footnotes\" data-footnotes>\n",
             "<ol>\n",
-            "<li id=\"fn1\">\n",
-            "<p>Yep. <a href=\"#fnref1\" class=\"footnote-backref\">↩</a></p>\n",
+            "<li id=\"fn-1\">\n",
+            "<p>Yep. <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a></p>\n",
             "</li>\n",
             "</ol>\n",
             "</section>\n"
@@ -1043,7 +1043,7 @@ fn footnote_in_table() {
             "\n",
             "[^1]: a footnote\n",
         ), concat!(
-            "<p>A footnote in a paragraph<sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\">1</a></sup></p>\n",
+            "<p>A footnote in a paragraph<sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n",
             "<table>\n",
             "<thead>\n",
             "<tr>\n",
@@ -1053,15 +1053,15 @@ fn footnote_in_table() {
             "</thead>\n",
             "<tbody>\n",
             "<tr>\n",
-            "<td>foot <sup class=\"footnote-ref\"><a href=\"#fn1\" id=\"fnref1\">1</a></sup></td>\n",
+            "<td>foot <sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></td>\n",
             "<td>note</td>\n",
             "</tr>\n",
             "</tbody>\n",
             "</table>\n",
-            "<section class=\"footnotes\">\n",
+            "<section class=\"footnotes\" data-footnotes>\n",
             "<ol>\n",
-            "<li id=\"fn1\">\n",
-            "<p>a footnote <a href=\"#fnref1\" class=\"footnote-backref\">↩</a></p>\n",
+            "<li id=\"fn-1\">\n",
+            "<p>a footnote <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a></p>\n",
             "</li>\n",
             "</ol>\n",
             "</section>\n",

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1083,20 +1083,20 @@ fn footnote_with_superscript() {
             "[^ref]: Here is another footnote.\n",
         ),
         concat!(
-            "<p>Here is a footnote reference.<sup class=\"footnote-ref\"><a href=\"#fn1\" \
-             id=\"fnref1\">1</a></sup></p>\n",
-            "<p>Here is a longer footnote reference.<sup class=\"footnote-ref\"><a href=\"#fn2\" \
-             id=\"fnref2\">2</a></sup></p>\n",
+            "<p>Here is a footnote reference.<sup class=\"footnote-ref\"><a href=\"#fn-1\" \
+             id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n",
+            "<p>Here is a longer footnote reference.<sup class=\"footnote-ref\"><a href=\"#fn-2\" \
+             id=\"fnref-2\" data-footnote-ref>2</a></sup></p>\n",
             "<p>e = mc<sup>2</sup>.</p>\n",
-            "<section class=\"footnotes\">\n",
+            "<section class=\"footnotes\" data-footnotes>\n",
             "<ol>\n",
-            "<li id=\"fn1\">\n",
-            "<p>Here is the footnote. <a href=\"#fnref1\" \
-             class=\"footnote-backref\">↩</a></p>\n",
+            "<li id=\"fn-1\">\n",
+            "<p>Here is the footnote. <a href=\"#fnref-1\" \
+             class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a></p>\n",
             "</li>\n",
-            "<li id=\"fn2\">\n",
-            "<p>Here is another footnote. <a href=\"#fnref2\" \
-             class=\"footnote-backref\">↩</a></p>\n",
+            "<li id=\"fn-2\">\n",
+            "<p>Here is another footnote. <a href=\"#fnref-2\" \
+             class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a></p>\n",
             "</li>\n",
             "</ol>\n",
             "</section>\n"


### PR DESCRIPTION
This aligns the footnote output with `cmark-gfm`. Relates to https://github.com/kivikakk/comrak/issues/259