### PR TITLE
Add support for full_info_string render option

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -512,17 +512,24 @@ impl<'o> HtmlFormatter<'o> {
                             first_tag += 1;
                         }
 
+                        let lang_str = str::from_utf8(&ncb.info[..first_tag]).unwrap();
+                        let info_str = str::from_utf8(&ncb.info[first_tag..]).unwrap().trim();
+
                         if self.options.render.github_pre_lang {
-                            pre_attributes.insert(
-                                String::from("lang"),
-                                String::from_utf8(Vec::from(&ncb.info[..first_tag])).unwrap(),
-                            );
+                            pre_attributes.insert(String::from("lang"), lang_str.to_string());
+
+                            if self.options.render.full_info_string && !info_str.is_empty() {
+                                pre_attributes
+                                    .insert(String::from("data-meta"), info_str.trim().to_string());
+                            }
                         } else {
-                            code_attr = format!(
-                                "language-{}",
-                                str::from_utf8(&ncb.info[..first_tag]).unwrap()
-                            );
+                            code_attr = format!("language-{}", lang_str);
                             code_attributes.insert(String::from("class"), code_attr);
+
+                            if self.options.render.full_info_string && !info_str.is_empty() {
+                                code_attributes
+                                    .insert(String::from("data-meta"), info_str.to_string());
+                            }
                         }
                     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,10 @@ struct Cli {
     #[arg(long)]
     github_pre_lang: bool,
 
+    /// Enable full info strings for code blocks
+    #[arg(long)]
+    full_info_string: bool,
+
     /// Enable GitHub-flavored markdown extensions: strikethrough, tagfilter, table, autolink, and tasklist.
     /// Also enables --github-pre-lang.
     #[arg(long)]
@@ -218,6 +222,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         render: ComrakRenderOptions {
             hardbreaks: cli.hardbreaks,
             github_pre_lang: cli.github_pre_lang || cli.gfm,
+            full_info_string: cli.full_info_string,
             width: cli.width,
             unsafe_: cli.unsafe_,
             escape: cli.escape,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -398,6 +398,21 @@ pub struct ComrakRenderOptions {
     /// ```
     pub github_pre_lang: bool,
 
+    /// Enable full info strings for code blocks
+    ///
+    /// ```
+    /// # use comrak::{markdown_to_html, ComrakOptions};
+    /// let mut options = ComrakOptions::default();
+    /// assert_eq!(markdown_to_html("``` rust extra info\nfn hello();\n```\n", &options),
+    ///            "<pre><code class=\"language-rust\">fn hello();\n</code></pre>\n");
+    ///
+    /// options.render.full_info_string = true;
+    /// let html = markdown_to_html("``` rust extra info\nfn hello();\n```\n", &options);
+    /// let re = regex::Regex::new(r#"data-meta="extra info""#).unwrap();
+    /// assert!(re.is_match(&html));
+    /// ```
+    pub full_info_string: bool,
+
     /// The wrap column when outputting CommonMark.
     ///
     /// ```

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -40,6 +40,7 @@ fn fuzz_doesnt_crash(md: String) {
         render: ::ComrakRenderOptions {
             hardbreaks: true,
             github_pre_lang: true,
+            full_info_string: true,
             width: 80,
             unsafe_: true,
             escape: false,
@@ -1442,6 +1443,7 @@ fn exercise_full_api<'a>() {
         render: ::ComrakRenderOptions {
             hardbreaks: false,
             github_pre_lang: false,
+            full_info_string: false,
             width: 123456,
             unsafe_: false,
             escape: false,


### PR DESCRIPTION
Add support for an option, `full-info-string`, that `cmark-gfm` supports which allows anything beyond the language specifier on a code block to be added as the `data-meta` attribute.

Related to https://github.com/kivikakk/comrak/issues/275