### PR TITLE
cleanup: tasklist, front matter

### DIFF
--- a/src/cm.rs
+++ b/src/cm.rs
@@ -8,6 +8,7 @@ use crate::nodes::{
 use crate::parser::shortcodes::NodeShortCode;
 use crate::parser::ComrakOptions;
 use crate::scanners;
+use crate::strings::trim_start_match;
 use crate::{nodes, ComrakPlugins};
 
 use std::cmp::max;
@@ -628,7 +629,7 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
     fn format_link(&mut self, node: &'a AstNode<'a>, nl: &NodeLink, entering: bool) -> bool {
         if is_autolink(node, nl) {
             if entering {
-                write!(self, "<{}>", nl.url.trim_start_matches("mailto:")).unwrap();
+                write!(self, "<{}>", trim_start_match(&nl.url, "mailto:")).unwrap();
                 return false;
             }
         } else if entering {
@@ -811,7 +812,7 @@ fn is_autolink<'a>(node: &'a AstNode<'a>, nl: &NodeLink) -> bool {
         },
     };
 
-    nl.url.trim_start_matches("mailto:") == link_text
+    trim_start_match(&nl.url, "mailto:") == link_text
 }
 
 fn table_escape<'a>(node: &'a AstNode<'a>, c: u8) -> bool {

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -865,7 +865,6 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
         self.pos += 1;
         if self.peek_char().map_or(false, |&c| ispunct(c)) {
             self.pos += 1;
-            // TODO
             make_inline(
                 self.arena,
                 NodeValue::Text(String::from_utf8(vec![self.input[self.pos - 1]]).unwrap()),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -608,19 +608,16 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
     }
 
     fn feed(&mut self, linebuf: &mut Vec<u8>, mut s: &str, eof: bool) {
-        match (
+        if let (0, Some(delimiter)) = (
             self.total_size,
             &self.options.extension.front_matter_delimiter,
         ) {
-            (0, Some(delimiter)) => {
-                if let Some((front_matter, rest)) = split_off_front_matter(s, delimiter) {
-                    let node =
-                        self.add_child(self.root, NodeValue::FrontMatter(front_matter.to_string()));
-                    s = rest;
-                    self.finalize(node).unwrap();
-                }
+            if let Some((front_matter, rest)) = split_off_front_matter(s, delimiter) {
+                let node =
+                    self.add_child(self.root, NodeValue::FrontMatter(front_matter.to_string()));
+                s = rest;
+                self.finalize(node).unwrap();
             }
-            _ => {}
         }
 
         let s = s.as_bytes();

--- a/src/scanners.re
+++ b/src/scanners.re
@@ -376,4 +376,24 @@ pub fn shortcode(s: &[u8]) -> Option<usize> {
 */
 }
 
+// Returns both the length of the match, and the tasklist character.
+pub fn tasklist(s: &[u8]) -> Option<(usize, u8)> {
+    let mut cursor = 0;
+    let mut marker = 0;
+    let len = s.len();
+
+    let t1;
+/*!stags:re2c format = 'let mut @@{tag} = 0;'; */
+
+/*!local:re2c
+    re2c:define:YYSTAGP = "@@{tag} = cursor;";
+    re2c:tags = 1;
+
+    spacechar* [[] @t1 [^\x00\r\n] [\]] (spacechar | [\x00]) {
+        return Some((cursor, s[t1]));
+    }
+    * { return None; }
+*/
+}
+
 // vim: set ft=rust:

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -22543,4 +22543,427 @@ pub fn shortcode(s: &[u8]) -> Option<usize> {
     }
 }
 
+// Returns both the length of the match, and the tasklist character.
+pub fn tasklist(s: &[u8]) -> Option<(usize, u8)> {
+    let mut cursor = 0;
+    let mut marker = 0;
+    let len = s.len();
+
+    let t1;
+    let mut yyt1 = 0;
+
+    {
+        #[allow(unused_assignments)]
+        let mut yych: u8 = 0;
+        let mut yystate: usize = 0;
+        'yyl: loop {
+            match yystate {
+                0 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    cursor += 1;
+                    match yych {
+                        0x09..=0x0D | 0x20 => {
+                            yystate = 3;
+                            continue 'yyl;
+                        }
+                        0x5B => {
+                            yystate = 4;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 1;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                1 => {
+                    yystate = 2;
+                    continue 'yyl;
+                }
+                2 => {
+                    return None;
+                }
+                3 => {
+                    marker = cursor;
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x09..=0x0D | 0x20 => {
+                            cursor += 1;
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                        0x5B => {
+                            cursor += 1;
+                            yystate = 7;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 2;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                4 => {
+                    marker = cursor;
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x01..=0x09 | 0x0B..=0x0C | 0x0E..=0x7F => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 8;
+                            continue 'yyl;
+                        }
+                        0xC2..=0xDF => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 9;
+                            continue 'yyl;
+                        }
+                        0xE0 => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 10;
+                            continue 'yyl;
+                        }
+                        0xE1..=0xEC | 0xEE..=0xEF => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 11;
+                            continue 'yyl;
+                        }
+                        0xED => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 12;
+                            continue 'yyl;
+                        }
+                        0xF0 => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 13;
+                            continue 'yyl;
+                        }
+                        0xF1..=0xF3 => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 14;
+                            continue 'yyl;
+                        }
+                        0xF4 => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 15;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 2;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                5 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x09..=0x0D | 0x20 => {
+                            cursor += 1;
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                        0x5B => {
+                            cursor += 1;
+                            yystate = 7;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 6;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                6 => {
+                    cursor = marker;
+                    yystate = 2;
+                    continue 'yyl;
+                }
+                7 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x01..=0x09 | 0x0B..=0x0C | 0x0E..=0x7F => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 8;
+                            continue 'yyl;
+                        }
+                        0xC2..=0xDF => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 9;
+                            continue 'yyl;
+                        }
+                        0xE0 => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 10;
+                            continue 'yyl;
+                        }
+                        0xE1..=0xEC | 0xEE..=0xEF => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 11;
+                            continue 'yyl;
+                        }
+                        0xED => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 12;
+                            continue 'yyl;
+                        }
+                        0xF0 => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 13;
+                            continue 'yyl;
+                        }
+                        0xF1..=0xF3 => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 14;
+                            continue 'yyl;
+                        }
+                        0xF4 => {
+                            yyt1 = cursor;
+                            cursor += 1;
+                            yystate = 15;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 6;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                8 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x5D => {
+                            cursor += 1;
+                            yystate = 16;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 6;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                9 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x80..=0xBF => {
+                            cursor += 1;
+                            yystate = 8;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 6;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                10 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0xA0..=0xBF => {
+                            cursor += 1;
+                            yystate = 9;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 6;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                11 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x80..=0xBF => {
+                            cursor += 1;
+                            yystate = 9;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 6;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                12 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x80..=0x9F => {
+                            cursor += 1;
+                            yystate = 9;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 6;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                13 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x90..=0xBF => {
+                            cursor += 1;
+                            yystate = 11;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 6;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                14 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x80..=0xBF => {
+                            cursor += 1;
+                            yystate = 11;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 6;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                15 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x80..=0x8F => {
+                            cursor += 1;
+                            yystate = 11;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 6;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                16 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x00 | 0x09..=0x0D | 0x20 => {
+                            cursor += 1;
+                            yystate = 17;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 6;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                17 => {
+                    t1 = yyt1;
+                    {
+                        return Some((cursor, s[t1]));
+                    }
+                }
+                _ => {
+                    panic!("internal lexer error")
+                }
+            }
+        }
+    }
+}
+
 // vim: set ft=rust:

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -282,7 +282,7 @@ pub fn split_off_front_matter<'s>(mut s: &'s str, delimiter: &str) -> Option<(&'
         return None;
     }
     let mut start = delimiter.len();
-    if s[start..].starts_with("\n") {
+    if s[start..].starts_with('\n') {
         start += 1;
     } else if s[start..].starts_with("\r\n") {
         start += 2;
@@ -298,7 +298,7 @@ pub fn split_off_front_matter<'s>(mut s: &'s str, delimiter: &str) -> Option<(&'
         None => return None,
     };
 
-    start += if s[start..].starts_with("\n") {
+    start += if s[start..].starts_with('\n') {
         1
     } else if s[start..].starts_with("\r\n") {
         2
@@ -306,7 +306,7 @@ pub fn split_off_front_matter<'s>(mut s: &'s str, delimiter: &str) -> Option<(&'
         return None;
     };
 
-    start += if s[start..].starts_with("\n") {
+    start += if s[start..].starts_with('\n') {
         1
     } else if s[start..].starts_with("\r\n") {
         2
@@ -318,11 +318,7 @@ pub fn split_off_front_matter<'s>(mut s: &'s str, delimiter: &str) -> Option<(&'
 }
 
 pub fn trim_start_match<'s>(s: &'s str, pat: &str) -> &'s str {
-    if s.starts_with(pat) {
-        &s[pat.len()..]
-    } else {
-        s
-    }
+    s.strip_prefix(pat).unwrap_or(s)
 }
 
 #[cfg(test)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1395,7 +1395,7 @@ fn case_insensitive_safety() {
 }
 
 #[test]
-fn exercise_full_api<'a>() {
+fn exercise_full_api() {
     let arena = Arena::new();
     let default_options = ComrakOptions::default();
     let default_plugins = ComrakPlugins::default();


### PR DESCRIPTION
* Use re2c instead of regexes for tasklists.
* Manually scan instead of compiling a regex for front matter.
  * Only check for it once, at the very first feed.
    * This is still suboptimal; frontmatter is only recognised if it's all in the first feed. A slight improvement from "recognised in every feed". As before, frontmatter split across feeds will not be seen.