### PR TITLE
optimise plugins, used buffered writers

### DIFF
--- a/examples/custom_headings.rs
+++ b/examples/custom_headings.rs
@@ -2,6 +2,7 @@ use comrak::{
     adapters::{HeadingAdapter, HeadingMeta},
     markdown_to_html_with_plugins, ComrakOptions, ComrakPlugins,
 };
+use std::io::{self, Write};
 
 fn main() {
     let adapter = CustomHeadingAdapter;
@@ -30,19 +31,20 @@ fn main() {
 struct CustomHeadingAdapter;
 
 impl HeadingAdapter for CustomHeadingAdapter {
-    fn enter(&self, heading: &HeadingMeta) -> String {
+    fn enter(&self, output: &mut dyn Write, heading: &HeadingMeta) -> io::Result<()> {
         let id = slug::slugify(&heading.content);
 
         let search_include = !&heading.content.contains("hide");
 
-        format!(
+        write!(
+            output,
             "<h{} id=\"{}\" data-search-include=\"{}\">",
             heading.level, id, search_include
         )
     }
 
-    fn exit(&self, heading: &HeadingMeta) -> String {
-        format!("</h{}>", heading.level)
+    fn exit(&self, output: &mut dyn Write, heading: &HeadingMeta) -> io::Result<()> {
+        write!(output, "</h{}>", heading.level)
     }
 }
 

--- a/examples/syntax_highlighter.rs
+++ b/examples/syntax_highlighter.rs
@@ -3,6 +3,7 @@
 use comrak::adapters::SyntaxHighlighterAdapter;
 use comrak::{markdown_to_html_with_plugins, ComrakOptions, ComrakPlugins};
 use std::collections::HashMap;
+use std::io::{self, Write};
 
 #[derive(Debug, Copy, Clone)]
 pub struct PotatoSyntaxAdapter {
@@ -16,8 +17,14 @@ impl PotatoSyntaxAdapter {
 }
 
 impl SyntaxHighlighterAdapter for PotatoSyntaxAdapter {
-    fn highlight(&self, lang: Option<&str>, code: &str) -> String {
-        format!(
+    fn write_highlighted(
+        &self,
+        output: &mut dyn Write,
+        lang: Option<&str>,
+        code: &str,
+    ) -> io::Result<()> {
+        write!(
+            output,
             "<span class=\"potato-{}\">{}</span><span class=\"size-{}\">potato</span>",
             lang.unwrap(),
             code,
@@ -25,19 +32,27 @@ impl SyntaxHighlighterAdapter for PotatoSyntaxAdapter {
         )
     }
 
-    fn build_pre_tag(&self, attributes: &HashMap<String, String>) -> String {
+    fn write_pre_tag(
+        &self,
+        output: &mut dyn Write,
+        attributes: HashMap<String, String>,
+    ) -> io::Result<()> {
         if attributes.contains_key("lang") {
-            format!("<pre lang=\"{}\">", attributes["lang"])
+            write!(output, "<pre lang=\"{}\">", attributes["lang"])
         } else {
-            String::from("<pre>")
+            output.write_all(b"<pre>")
         }
     }
 
-    fn build_code_tag(&self, attributes: &HashMap<String, String>) -> String {
+    fn write_code_tag(
+        &self,
+        output: &mut dyn Write,
+        attributes: HashMap<String, String>,
+    ) -> io::Result<()> {
         if attributes.contains_key("class") {
-            format!("<code class=\"{}\">", attributes["class"])
+            write!(output, "<code class=\"{}\">", attributes["class"])
         } else {
-            String::from("<code>")
+            output.write_all(b"<code>")
         }
     }
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "4f0807fb6f644c83f3e4ec014fec9858c1c8b26a7db8eb5f0bde5817df9c1df7"
 
 [[package]]
 name = "comrak"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "arbitrary",
  "clap",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -30,3 +30,15 @@ name = "fuzz_options"
 path = "fuzz_targets/fuzz_options.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "cli_default"
+path = "fuzz_targets/cli_default.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "gfm"
+path = "fuzz_targets/gfm.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/cli_default.rs
+++ b/fuzz/fuzz_targets/cli_default.rs
@@ -1,0 +1,22 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use comrak::{
+    markdown_to_html_with_plugins, plugins::syntect::SyntectAdapter, ComrakPlugins,
+    ComrakRenderPlugins,
+};
+
+// Note that we end up fuzzing Syntect here.
+
+fuzz_target!(|s: &str| {
+    let adapter = SyntectAdapter::new("base16-ocean.dark");
+    let plugins = ComrakPlugins {
+        render: ComrakRenderPlugins {
+            codefence_syntax_highlighter: Some(&adapter),
+            ..Default::default()
+        },
+    };
+
+    markdown_to_html_with_plugins(s, &Default::default(), &plugins);
+});

--- a/fuzz/fuzz_targets/gfm.rs
+++ b/fuzz/fuzz_targets/gfm.rs
@@ -1,0 +1,31 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use comrak::{markdown_to_html, ComrakExtensionOptions, ComrakOptions, ComrakRenderOptions};
+
+// Note that what I'm targetting here isn't exactly the same
+// as --gfm, but rather an approximation of what cmark-gfm
+// options are routinely used by Commonmarker users.
+
+fuzz_target!(|s: &str| {
+    markdown_to_html(
+        s,
+        &ComrakOptions {
+            extension: ComrakExtensionOptions {
+                strikethrough: true,
+                tagfilter: true,
+                table: true,
+                autolink: true,
+                ..Default::default()
+            },
+            parse: Default::default(),
+            render: ComrakRenderOptions {
+                hardbreaks: true,
+                github_pre_lang: true,
+                unsafe_: true,
+                ..Default::default()
+            },
+        },
+    );
+});

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -3,6 +3,7 @@
 //! Each plugin has to implement one of the traits available in this module.
 
 use std::collections::HashMap;
+use std::io::{self, Write};
 
 /// Implement this adapter for creating a plugin for custom syntax highlighting of codefence blocks.
 pub trait SyntaxHighlighterAdapter {
@@ -10,19 +11,32 @@ pub trait SyntaxHighlighterAdapter {
     ///
     /// lang: Name of the programming language (the info string of the codefence block after the initial "```" part).
     /// code: The source code to be syntax highlighted.
-    fn highlight(&self, lang: Option<&str>, code: &str) -> String;
+    fn write_highlighted(
+        &self,
+        output: &mut dyn Write,
+        lang: Option<&str>,
+        code: &str,
+    ) -> io::Result<()>;
 
     /// Generates the opening `<pre>` tag. Some syntax highlighter libraries might include their own
     /// `<pre>` tag possibly with some HTML attribute pre-filled.
     ///
     /// `attributes`: A map of HTML attributes provided by comrak.
-    fn build_pre_tag(&self, attributes: &HashMap<String, String>) -> String;
+    fn write_pre_tag(
+        &self,
+        output: &mut dyn Write,
+        attributes: HashMap<String, String>,
+    ) -> io::Result<()>;
 
     /// Generates the opening `<code>` tag. Some syntax highlighter libraries might include their own
     /// `<code>` tag possibly with some HTML attribute pre-filled.
     ///
     /// `attributes`: A map of HTML attributes provided by comrak.
-    fn build_code_tag(&self, attributes: &HashMap<String, String>) -> String;
+    fn write_code_tag(
+        &self,
+        output: &mut dyn Write,
+        attributes: HashMap<String, String>,
+    ) -> io::Result<()>;
 }
 
 /// The struct passed to the [`HeadingAdapter`] for custom heading implementations.
@@ -43,8 +57,8 @@ pub struct HeadingMeta {
 /// leave the AST content of the heading unchanged.
 pub trait HeadingAdapter {
     /// Called prior to rendering
-    fn enter(&self, heading: &HeadingMeta) -> String;
+    fn enter(&self, output: &mut dyn Write, heading: &HeadingMeta) -> io::Result<()>;
 
     /// Close tags.
-    fn exit(&self, heading: &HeadingMeta) -> String;
+    fn exit(&self, output: &mut dyn Write, heading: &HeadingMeta) -> io::Result<()>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,8 @@
 )]
 #![allow(unknown_lints, clippy::doc_markdown, cyclomatic_complexity)]
 
+use std::io::BufWriter;
+
 pub mod adapters;
 pub mod arena_tree;
 mod cm;
@@ -113,9 +115,9 @@ pub fn markdown_to_html_with_plugins(
 ) -> String {
     let arena = Arena::new();
     let root = parse_document(&arena, md, options);
-    let mut s = Vec::new();
-    format_html_with_plugins(root, options, &mut s, plugins).unwrap();
-    String::from_utf8(s).unwrap()
+    let mut bw = BufWriter::new(Vec::new());
+    format_html_with_plugins(root, options, &mut bw, plugins).unwrap();
+    String::from_utf8(bw.into_inner().unwrap()).unwrap()
 }
 
 /// Return the version of the crate.
@@ -127,7 +129,7 @@ pub fn version() -> &'static str {
 pub fn markdown_to_commonmark(md: &str, options: &ComrakOptions) -> String {
     let arena = Arena::new();
     let root = parse_document(&arena, md, options);
-    let mut s = Vec::new();
-    format_commonmark(root, options, &mut s).unwrap();
-    String::from_utf8(s).unwrap()
+    let mut bw = BufWriter::new(Vec::new());
+    format_commonmark(root, options, &mut bw).unwrap();
+    String::from_utf8(bw.into_inner().unwrap()).unwrap()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use std::boxed::Box;
 use std::env;
 use std::error::Error;
 use std::fs;
-use std::io::Read;
+use std::io::{BufWriter, Read, Write};
 use std::path::PathBuf;
 use std::process;
 
@@ -264,14 +264,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
 
     if let Some(output_filename) = cli.output {
-        formatter(
-            root,
-            &options,
-            &mut fs::File::create(output_filename)?,
-            &plugins,
-        )?;
+        let mut bw = BufWriter::new(fs::File::create(output_filename)?);
+        formatter(root, &options, &mut bw, &plugins)?;
+        bw.flush()?;
     } else {
-        formatter(root, &options, &mut std::io::stdout(), &plugins)?;
+        let mut bw = BufWriter::new(std::io::stdout().lock());
+        formatter(root, &options, &mut bw, &plugins)?;
+        bw.flush()?;
     };
 
     process::exit(EXIT_SUCCESS);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -512,20 +512,21 @@ pub struct ComrakRenderOptions {
 
 #[derive(Default, Debug)]
 /// Umbrella plugins struct.
-pub struct ComrakPlugins<'a> {
+pub struct ComrakPlugins<'p> {
     /// Configure render-time plugins.
-    pub render: ComrakRenderPlugins<'a>,
+    pub render: ComrakRenderPlugins<'p>,
 }
 
 #[derive(Default)]
 /// Plugins for alternative rendering.
-pub struct ComrakRenderPlugins<'a> {
+pub struct ComrakRenderPlugins<'p> {
     /// Provide a syntax highlighter adapter implementation for syntax
     /// highlighting of codefence blocks.
     /// ```
     /// # use comrak::{markdown_to_html, ComrakOptions, ComrakPlugins, markdown_to_html_with_plugins};
     /// # use comrak::adapters::SyntaxHighlighterAdapter;
     /// use std::collections::HashMap;
+    /// use std::io::{self, Write};
     /// let options = ComrakOptions::default();
     /// let mut plugins = ComrakPlugins::default();
     /// let input = "```rust\nfn main<'a>();\n```";
@@ -535,16 +536,16 @@ pub struct ComrakRenderPlugins<'a> {
     ///
     /// pub struct MockAdapter {}
     /// impl SyntaxHighlighterAdapter for MockAdapter {
-    ///     fn highlight(&self, lang: Option<&str>, code: &str) -> String {
-    ///         String::from(format!("<span class=\"lang-{}\">{}</span>", lang.unwrap(), code))
+    ///     fn write_highlighted(&self, output: &mut dyn Write, lang: Option<&str>, code: &str) -> io::Result<()> {
+    ///         write!(output, "<span class=\"lang-{}\">{}</span>", lang.unwrap(), code)
     ///     }
     ///
-    /// fn build_pre_tag(&self, attributes: &HashMap<String, String>) -> String {
-    ///         String::from("<pre lang=\"rust\">")
+    ///     fn write_pre_tag(&self, output: &mut dyn Write, _attributes: HashMap<String, String>) -> io::Result<()> {
+    ///         output.write_all(b"<pre lang=\"rust\">")
     ///     }
     ///
-    /// fn build_code_tag(&self, attributes: &HashMap<String, String>) -> String {
-    ///         String::from("<code class=\"language-rust\">")
+    ///     fn write_code_tag(&self, output: &mut dyn Write, _attributes: HashMap<String, String>) -> io::Result<()> {
+    ///         output.write_all(b"<code class=\"language-rust\">")
     ///     }
     /// }
     ///
@@ -554,10 +555,10 @@ pub struct ComrakRenderPlugins<'a> {
     /// assert_eq!(markdown_to_html_with_plugins(input, &options, &plugins),
     ///            "<pre lang=\"rust\"><code class=\"language-rust\"><span class=\"lang-rust\">fn main<'a>();\n</span></code></pre>\n");
     /// ```
-    pub codefence_syntax_highlighter: Option<&'a dyn SyntaxHighlighterAdapter>,
+    pub codefence_syntax_highlighter: Option<&'p dyn SyntaxHighlighterAdapter>,
 
     /// Optional heading adapter
-    pub heading_adapter: Option<&'a dyn HeadingAdapter>,
+    pub heading_adapter: Option<&'p dyn HeadingAdapter>,
 }
 
 impl Debug for ComrakRenderPlugins<'_> {

--- a/src/plugins/syntect.rs
+++ b/src/plugins/syntect.rs
@@ -1,52 +1,37 @@
 //! Adapter for the Syntect syntax highlighter plugin.
 
 use crate::adapters::SyntaxHighlighterAdapter;
-use crate::html::build_opening_tag;
-use crate::strings::extract_attributes_from_tag;
-use std::collections::HashMap;
+use crate::html;
+use std::collections::{hash_map, HashMap};
+use std::io::{self, Write};
 use syntect::easy::HighlightLines;
 use syntect::highlighting::{Color, ThemeSet};
-use syntect::html::{
-    append_highlighted_html_for_styled_line, highlighted_html_for_string, IncludeBackground,
-};
+use syntect::html::{append_highlighted_html_for_styled_line, IncludeBackground};
 use syntect::parsing::{SyntaxReference, SyntaxSet};
 use syntect::util::LinesWithEndings;
 use syntect::Error;
 
 #[derive(Debug)]
 /// Syntect syntax highlighter plugin.
-pub struct SyntectAdapter<'a> {
-    theme: &'a str,
+pub struct SyntectAdapter {
+    theme: String,
     syntax_set: SyntaxSet,
     theme_set: ThemeSet,
 }
 
-impl<'a> SyntectAdapter<'a> {
+impl SyntectAdapter {
     /// Construct a new `SyntectAdapter` object and set the syntax highlighting theme.
-    pub fn new(theme: &'a str) -> Self {
+    pub fn new(theme: &str) -> Self {
         SyntectAdapter {
-            theme,
+            theme: theme.into(),
             syntax_set: SyntaxSet::load_defaults_newlines(),
             theme_set: ThemeSet::load_defaults(),
         }
     }
 
-    fn gen_empty_block(&self) -> String {
-        let syntax = self.syntax_set.find_syntax_by_name("Plain Text").unwrap();
-        match highlighted_html_for_string(
-            "",
-            &self.syntax_set,
-            syntax,
-            &self.theme_set.themes[self.theme],
-        ) {
-            Ok(empty_block) => empty_block,
-            Err(_) => "".into(),
-        }
-    }
-
     fn highlight_html(&self, code: &str, syntax: &SyntaxReference) -> Result<String, Error> {
         // syntect::html::highlighted_html_for_string, without the opening/closing <pre>.
-        let theme = &self.theme_set.themes[self.theme];
+        let theme = &self.theme_set.themes[&self.theme];
         let mut highlighter = HighlightLines::new(syntax, theme);
         let mut output = String::new();
         let bg = theme.settings.background.unwrap_or(Color::WHITE);
@@ -63,19 +48,18 @@ impl<'a> SyntectAdapter<'a> {
     }
 }
 
-impl SyntaxHighlighterAdapter for SyntectAdapter<'_> {
-    fn highlight(&self, lang: Option<&str>, code: &str) -> String {
+impl SyntaxHighlighterAdapter for SyntectAdapter {
+    fn write_highlighted(
+        &self,
+        output: &mut dyn Write,
+        lang: Option<&str>,
+        code: &str,
+    ) -> io::Result<()> {
         let fallback_syntax = "Plain Text";
 
         let lang: &str = match lang {
-            None => fallback_syntax,
-            Some(l) => {
-                if l.is_empty() {
-                    fallback_syntax
-                } else {
-                    l
-                }
-            }
+            Some(l) if !l.is_empty() => l,
+            _ => fallback_syntax,
         };
 
         let syntax = self
@@ -88,33 +72,82 @@ impl SyntaxHighlighterAdapter for SyntectAdapter<'_> {
             });
 
         match self.highlight_html(code, syntax) {
-            Ok(highlighted_code) => highlighted_code,
-            Err(_) => code.into(),
+            Ok(highlighted_code) => output.write_all(highlighted_code.as_bytes()),
+            Err(_) => output.write_all(code.as_bytes()),
         }
     }
 
-    fn build_pre_tag(&self, attributes: &HashMap<String, String>) -> String {
-        let mut syntect_attributes = extract_attributes_from_tag(self.gen_empty_block().as_str());
+    fn write_pre_tag(
+        &self,
+        output: &mut dyn Write,
+        attributes: HashMap<String, String>,
+    ) -> io::Result<()> {
+        let theme = &self.theme_set.themes[&self.theme];
+        let colour = theme.settings.background.unwrap_or(Color::WHITE);
 
-        for (comrak_attr, val) in attributes {
-            let mut combined_attr: String = val.clone();
+        let style = format!(
+            "background-color:#{:02x}{:02x}{:02x};",
+            colour.r, colour.g, colour.b
+        );
 
-            if syntect_attributes.contains_key(comrak_attr.as_str()) {
-                combined_attr = format!(
-                    "{} {}",
-                    syntect_attributes.remove(comrak_attr).unwrap(),
-                    val
-                );
+        let mut pre_attributes = SyntectPreAttributes::new(attributes, &style);
+        html::write_opening_tag(output, "pre", pre_attributes.iter_mut())
+    }
+
+    fn write_code_tag(
+        &self,
+        output: &mut dyn Write,
+        attributes: HashMap<String, String>,
+    ) -> io::Result<()> {
+        html::write_opening_tag(output, "code", attributes)
+    }
+}
+
+struct SyntectPreAttributes {
+    syntect_style: String,
+    attributes: HashMap<String, String>,
+}
+
+impl SyntectPreAttributes {
+    fn new(attributes: HashMap<String, String>, syntect_style: &str) -> Self {
+        Self {
+            syntect_style: syntect_style.into(),
+            attributes,
+        }
+    }
+
+    fn iter_mut(&mut self) -> SyntectPreAttributesIter {
+        SyntectPreAttributesIter {
+            iter_mut: self.attributes.iter_mut(),
+            syntect_style: &self.syntect_style,
+            style_written: false,
+        }
+    }
+}
+
+struct SyntectPreAttributesIter<'a> {
+    iter_mut: hash_map::IterMut<'a, String, String>,
+    syntect_style: &'a str,
+    style_written: bool,
+}
+
+impl<'a> Iterator for SyntectPreAttributesIter<'a> {
+    type Item = (&'a str, &'a str);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.iter_mut.next() {
+            Some((k, v)) if k == "style" && !self.style_written => {
+                self.style_written = true;
+                v.insert_str(0, self.syntect_style);
+                Some((k, v))
             }
-
-            syntect_attributes.insert(comrak_attr.clone(), combined_attr);
+            Some((k, v)) => Some((k, v)),
+            None if !self.style_written => {
+                self.style_written = true;
+                Some(("style", self.syntect_style))
+            }
+            None => None,
         }
-
-        build_opening_tag("pre", &syntect_attributes)
-    }
-
-    fn build_code_tag(&self, attributes: &HashMap<String, String>) -> String {
-        build_opening_tag("code", attributes)
     }
 }
 
@@ -122,21 +155,21 @@ impl SyntaxHighlighterAdapter for SyntectAdapter<'_> {
 /// A builder for [`SyntectAdapter`].
 ///
 /// Allows customization of `Theme`, [`ThemeSet`], and [`SyntaxSet`].
-pub struct SyntectAdapterBuilder<'a> {
-    theme: Option<&'a str>,
+pub struct SyntectAdapterBuilder {
+    theme: Option<String>,
     syntax_set: Option<SyntaxSet>,
     theme_set: Option<ThemeSet>,
 }
 
-impl<'a> SyntectAdapterBuilder<'a> {
+impl SyntectAdapterBuilder {
     /// Creates a new empty [`SyntectAdapterBuilder`]
     pub fn new() -> Self {
         Default::default()
     }
 
     /// Sets the theme
-    pub fn theme(mut self, s: &'a str) -> Self {
-        self.theme.replace(s);
+    pub fn theme(mut self, s: &str) -> Self {
+        self.theme.replace(s.into());
         self
     }
 
@@ -156,9 +189,9 @@ impl<'a> SyntectAdapterBuilder<'a> {
     /// - `theme`: `InspiredGitHub`
     /// - `syntax_set`: [`SyntaxSet::load_defaults_newlines()`]
     /// - `theme_set`: [`ThemeSet::load_defaults()`]
-    pub fn build(self) -> SyntectAdapter<'a> {
+    pub fn build(self) -> SyntectAdapter {
         SyntectAdapter {
-            theme: self.theme.unwrap_or("InspiredGitHub"),
+            theme: self.theme.unwrap_or("InspiredGitHub".into()),
             syntax_set: self
                 .syntax_set
                 .unwrap_or_else(SyntaxSet::load_defaults_newlines),

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,8 +1,6 @@
 use crate::ctype::{ispunct, isspace};
 use crate::entity;
 use crate::parser::AutolinkType;
-#[cfg(feature = "syntect")]
-use std::collections::HashMap;
 use std::ptr;
 use std::str;
 
@@ -260,19 +258,6 @@ pub fn normalize_label(i: &str) -> String {
         }
     }
     v
-}
-
-#[cfg(feature = "syntect")]
-pub fn extract_attributes_from_tag(html_tag: &str) -> HashMap<String, String> {
-    let re = regex::Regex::new("([a-zA-Z_:][-a-zA-Z0-9_:.]+)=([\"'])(.*?)([\"'])").unwrap();
-
-    let mut attributes: HashMap<String, String> = HashMap::new();
-
-    for caps in re.captures_iter(html_tag) {
-        attributes.insert(String::from(&caps[1]), String::from(&caps[3]));
-    }
-
-    attributes
 }
 
 pub fn split_off_front_matter<'s>(mut s: &'s str, delimiter: &str) -> Option<(&'s str, &'s str)> {


### PR DESCRIPTION
Currently, the `SyntectAdapter` is slow. Very slow:

```console
$ # cmark-gfm
$ make bench
{ for x in `seq 1 20` ; do \
        /usr/bin/env time -p build/src/cmark-gfm </dev/null >/dev/null ; \
        /usr/bin/env time -p build/src/cmark-gfm bench/benchinput.md >/dev/null ; \
        done \
} 2>&1  | grep 'real' | awk '{print $2}' | python3 'bench/stats.py'
mean = 0.5830, median = 0.5750, stdev = 0.0247

$ # Comrak with highlighting disabled
$ make bench PROG="../../target/release/comrak --syntax-highlighting none"
{ for x in `seq 1 20` ; do \
        /usr/bin/env time -p ../../target/release/comrak --syntax-highlighting none </dev/null >/dev/null ; \
        /usr/bin/env time -p ../../target/release/comrak --syntax-highlighting none bench/benchinput.md >/dev/null ; \
        done \
} 2>&1  | grep 'real' | awk '{print $2}' | python3 'bench/stats.py'
mean = 1.2070, median = 1.2000, stdev = 0.0247

$ # Comrak with highlighting enabled (CLI default)
$ make bench PROG="../../target/release/comrak"
{ for x in `seq 1 20` ; do \
        /usr/bin/env time -p ../../target/release/comrak </dev/null >/dev/null ; \
        /usr/bin/env time -p ../../target/release/comrak bench/benchinput.md >/dev/null ; \
        done \
} 2>&1  | grep 'real' | awk '{print $2}' | python3 'bench/stats.py'
mean = 7.4255, median = 7.3950, stdev = 0.1085
```

Here, I rewrite the plugin interfaces to accept writers, instead of returning their results as `String`s. This allows for less heap churn, which ends up being a major factor in this large (and let's be real, somewhat unrealistic) benchmark.

The actual biggest thing was compiling regexes so many times. The code around here is more generic than it needs to be; I've coupled the Syntect adapter slightly more to the version of Syntect we require by inlining more code (i.e. the style applied to the `<pre>` tag). It's better not to try parsing HTML from it at all.

I'll continue to look for some more optimisations and fuzz this a bit, but for now we have the following result:

```console
$ # Comrak with highlighting enabled (CLI default) -- as of this PR
$ make bench PROG="../../target/release/comrak"
{ for x in `seq 1 20` ; do \
        /usr/bin/env time -p ../../target/release/comrak </dev/null >/dev/null ; \
        /usr/bin/env time -p ../../target/release/comrak bench/benchinput.md >/dev/null ; \
        done \
} 2>&1  | grep 'real' | awk '{print $2}' | python3 'bench/stats.py'
mean = 2.0195, median = 2.0150, stdev = 0.0265
```