### PR TITLE
Add builder derive and non_exhaustive for option structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,6 +130,7 @@ version = "0.18.0"
 dependencies = [
  "arbitrary",
  "clap",
+ "derive_builder",
  "emojis",
  "entities",
  "memchr",
@@ -155,6 +156,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +198,37 @@ checksum = "f3cdeb9ec472d588e539a818b2dee436825730da08ad0017c4b1a17676bdc8b7"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
  "syn",
 ]
 
@@ -304,6 +371,12 @@ checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ shell-words = { version = "1.0", optional = true }
 slug = "0.1.4"
 emojis = { version = "0.5.2", optional = true }
 arbitrary = { version = "1", optional = true, features = ["derive"] }
+derive_builder = "0.12.0"
 
 [dev-dependencies]
 ntest = "0.9"

--- a/examples/s-expr.rs
+++ b/examples/s-expr.rs
@@ -14,7 +14,7 @@ const INDENT: usize = 4;
 const CLOSE_NEWLINE: bool = false;
 
 use comrak::nodes::{AstNode, NodeValue};
-use comrak::{parse_document, Arena, ExtensionOptions, Options};
+use comrak::{parse_document, Arena, ExtensionOptionsBuilder, Options};
 use std::env;
 use std::error::Error;
 use std::fs::File;
@@ -74,15 +74,17 @@ fn iter_nodes<'a, W: Write>(
 fn dump(source: &str) -> io::Result<()> {
     let arena = Arena::new();
 
-    let mut extension = ExtensionOptions::default();
-    extension.strikethrough = true;
-    extension.tagfilter = true;
-    extension.table = true;
-    extension.autolink = true;
-    extension.tasklist = true;
-    extension.superscript = true;
-    extension.footnotes = true;
-    extension.description_lists = true;
+    let extension = ExtensionOptionsBuilder::default()
+        .strikethrough(true)
+        .tagfilter(true)
+        .table(true)
+        .autolink(true)
+        .tasklist(true)
+        .superscript(true)
+        .footnotes(true)
+        .description_lists(true)
+        .build()
+        .unwrap();
 
     let opts = Options {
         extension,

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -132,6 +132,7 @@ version = "0.18.0"
 dependencies = [
  "arbitrary",
  "clap",
+ "derive_builder",
  "emojis",
  "entities",
  "memchr",
@@ -164,6 +165,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +207,37 @@ checksum = "f3cdeb9ec472d588e539a818b2dee436825730da08ad0017c4b1a17676bdc8b7"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
  "syn 1.0.109",
 ]
 
@@ -290,6 +357,12 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,8 +100,9 @@ pub use html::format_document as format_html;
 pub use html::format_document_with_plugins as format_html_with_plugins;
 pub use html::Anchorizer;
 pub use parser::{
-    parse_document, parse_document_with_broken_link_callback, ExtensionOptions, ListStyleType,
-    Options, ParseOptions, Plugins, RenderOptions, RenderPlugins,
+    parse_document, parse_document_with_broken_link_callback, ExtensionOptions,
+    ExtensionOptionsBuilder, ListStyleType, Options, ParseOptions, ParseOptionsBuilder, Plugins,
+    PluginsBuilder, RenderOptions, RenderOptionsBuilder, RenderPlugins, RenderPluginsBuilder,
 };
 pub use typed_arena::Arena;
 pub use xml::format_document as format_xml;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 //! The `comrak` binary.
 
 use comrak::{
-    adapters::SyntaxHighlighterAdapter, plugins::syntect::SyntectAdapter, Arena, ExtensionOptions,
-    ListStyleType, Options, ParseOptions, Plugins, RenderOptions,
+    adapters::SyntaxHighlighterAdapter, plugins::syntect::SyntectAdapter, Arena,
+    ExtensionOptionsBuilder, ListStyleType, Options, ParseOptionsBuilder, Plugins,
+    RenderOptionsBuilder,
 };
 use std::boxed::Box;
 use std::env;
@@ -194,36 +195,42 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let exts = &cli.extensions;
 
-    let mut extension = ExtensionOptions::default();
-    extension.strikethrough = exts.contains(&Extension::Strikethrough) || cli.gfm;
-    extension.tagfilter = exts.contains(&Extension::Tagfilter) || cli.gfm;
-    extension.table = exts.contains(&Extension::Table) || cli.gfm;
-    extension.autolink = exts.contains(&Extension::Autolink) || cli.gfm;
-    extension.tasklist = exts.contains(&Extension::Tasklist) || cli.gfm;
-    extension.superscript = exts.contains(&Extension::Superscript);
-    extension.header_ids = cli.header_ids;
-    extension.footnotes = exts.contains(&Extension::Footnotes);
-    extension.description_lists = exts.contains(&Extension::DescriptionLists);
-    extension.front_matter_delimiter = cli.front_matter_delimiter;
+    let mut extension = ExtensionOptionsBuilder::default();
+    extension
+        .strikethrough(exts.contains(&Extension::Strikethrough) || cli.gfm)
+        .tagfilter(exts.contains(&Extension::Tagfilter) || cli.gfm)
+        .table(exts.contains(&Extension::Table) || cli.gfm)
+        .autolink(exts.contains(&Extension::Autolink) || cli.gfm)
+        .tasklist(exts.contains(&Extension::Tasklist) || cli.gfm)
+        .superscript(exts.contains(&Extension::Superscript))
+        .header_ids(cli.header_ids)
+        .footnotes(exts.contains(&Extension::Footnotes))
+        .description_lists(exts.contains(&Extension::DescriptionLists))
+        .front_matter_delimiter(cli.front_matter_delimiter);
+
     #[cfg(feature = "shortcodes")]
     {
-        extension.shortcodes = cli.gemojis;
+        extension.shortcodes(cli.gemojis);
     }
 
-    let mut parse = ParseOptions::default();
-    parse.smart = cli.smart;
-    parse.default_info_string = cli.default_info_string;
-    parse.relaxed_tasklist_matching = cli.relaxed_tasklist_character;
+    let extension = extension.build()?;
 
-    let mut render = RenderOptions::default();
-    render.hardbreaks = cli.hardbreaks;
-    render.github_pre_lang = cli.github_pre_lang || cli.gfm;
-    render.full_info_string = cli.full_info_string;
-    render.width = cli.width;
-    render.unsafe_ = cli.unsafe_;
-    render.escape = cli.escape;
-    render.list_style = cli.list_style.into();
-    render.sourcepos = cli.sourcepos;
+    let parse = ParseOptionsBuilder::default()
+        .smart(cli.smart)
+        .default_info_string(cli.default_info_string)
+        .relaxed_tasklist_matching(cli.relaxed_tasklist_character)
+        .build()?;
+
+    let render = RenderOptionsBuilder::default()
+        .hardbreaks(cli.hardbreaks)
+        .github_pre_lang(cli.github_pre_lang || cli.gfm)
+        .full_info_string(cli.full_info_string)
+        .width(cli.width)
+        .unsafe_(cli.unsafe_)
+        .escape(cli.escape)
+        .list_style(cli.list_style.into())
+        .sourcepos(cli.sourcepos)
+        .build()?;
 
     let options = Options {
         extension,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -15,6 +15,7 @@ use crate::nodes::{
 };
 use crate::scanners;
 use crate::strings::{self, split_off_front_matter, Case};
+use derive_builder::Builder;
 use std::cell::RefCell;
 use std::cmp::min;
 use std::collections::HashMap;
@@ -151,7 +152,8 @@ pub struct Options {
 }
 
 #[non_exhaustive]
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Builder)]
+#[builder(default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// Options to select extensions.
 pub struct ExtensionOptions {
@@ -347,7 +349,8 @@ pub struct ExtensionOptions {
 }
 
 #[non_exhaustive]
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Builder)]
+#[builder(default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// Options for parser functions.
 pub struct ParseOptions {
@@ -384,7 +387,8 @@ pub struct ParseOptions {
 }
 
 #[non_exhaustive]
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy, Builder)]
+#[builder(default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// Options for formatter functions.
 pub struct RenderOptions {
@@ -533,7 +537,8 @@ pub struct RenderOptions {
 }
 
 #[non_exhaustive]
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, Builder)]
+#[builder(default)]
 /// Umbrella plugins struct.
 pub struct Plugins<'p> {
     /// Configure render-time plugins.
@@ -541,7 +546,8 @@ pub struct Plugins<'p> {
 }
 
 #[non_exhaustive]
-#[derive(Default)]
+#[derive(Default, Clone, Builder)]
+#[builder(default)]
 /// Plugins for alternative rendering.
 pub struct RenderPlugins<'p> {
     /// Provide a syntax highlighter adapter implementation for syntax


### PR DESCRIPTION
This implements the suggestions from https://github.com/kivikakk/comrak/pull/174#issuecomment-950273881

This adds builder for each of the option structs and a `non_exhaustive` annotations on all of them.

It goes without saying that this is a breaking change due to the `non_exhaustive`.