### PR TITLE
Use footnote name for reference id

### DIFF
--- a/src/cm.rs
+++ b/src/cm.rs
@@ -357,7 +357,7 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
             NodeValue::TableCell => self.format_table_cell(node, entering),
             NodeValue::FootnoteDefinition(ref nfd) => {
                 self.format_footnote_definition(&nfd.name, entering)
-            },
+            }
             NodeValue::FootnoteReference(ref nfr) => {
                 self.format_footnote_reference(nfr.name.as_bytes(), entering)
             }

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -356,7 +356,7 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
             NodeValue::TableRow(..) => self.format_table_row(entering),
             NodeValue::TableCell => self.format_table_cell(node, entering),
             NodeValue::FootnoteDefinition(_) => self.format_footnote_definition(entering),
-            NodeValue::FootnoteReference(ref r) => {
+            NodeValue::FootnoteReference(ref r, _) => {
                 self.format_footnote_reference(r.as_bytes(), entering)
             }
         };

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -355,7 +355,9 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
             NodeValue::Table(..) => self.format_table(entering),
             NodeValue::TableRow(..) => self.format_table_row(entering),
             NodeValue::TableCell => self.format_table_cell(node, entering),
-            NodeValue::FootnoteDefinition(ref name) => self.format_footnote_definition(name, entering),
+            NodeValue::FootnoteDefinition(ref nfd) => {
+                self.format_footnote_definition(&nfd.name, entering)
+            },
             NodeValue::FootnoteReference(ref nfr) => {
                 self.format_footnote_reference(nfr.name.as_bytes(), entering)
             }

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -740,7 +740,7 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
             }
         }
     }
-    fn format_footnote_definition(&mut self, name: &String, entering: bool) {
+    fn format_footnote_definition(&mut self, name: &str, entering: bool) {
         if entering {
             self.footnote_ix += 1;
             writeln!(self, "[^{}]:", name).unwrap();

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -355,7 +355,7 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
             NodeValue::Table(..) => self.format_table(entering),
             NodeValue::TableRow(..) => self.format_table_row(entering),
             NodeValue::TableCell => self.format_table_cell(node, entering),
-            NodeValue::FootnoteDefinition(_) => self.format_footnote_definition(entering),
+            NodeValue::FootnoteDefinition(ref name) => self.format_footnote_definition(name, entering),
             NodeValue::FootnoteReference(ref nfr) => {
                 self.format_footnote_reference(nfr.name.as_bytes(), entering)
             }
@@ -738,11 +738,10 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
             }
         }
     }
-    fn format_footnote_definition(&mut self, entering: bool) {
+    fn format_footnote_definition(&mut self, name: &String, entering: bool) {
         if entering {
             self.footnote_ix += 1;
-            let footnote_ix = self.footnote_ix;
-            writeln!(self, "[^{}]:", footnote_ix).unwrap();
+            writeln!(self, "[^{}]:", name).unwrap();
             write!(self.prefix, "    ").unwrap();
         } else {
             let new_len = self.prefix.len() - 4;

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -356,8 +356,8 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
             NodeValue::TableRow(..) => self.format_table_row(entering),
             NodeValue::TableCell => self.format_table_cell(node, entering),
             NodeValue::FootnoteDefinition(_) => self.format_footnote_definition(entering),
-            NodeValue::FootnoteReference(ref r, _) => {
-                self.format_footnote_reference(r.as_bytes(), entering)
+            NodeValue::FootnoteReference(ref nfr) => {
+                self.format_footnote_reference(nfr.name.as_bytes(), entering)
             }
         };
         true

--- a/src/html.rs
+++ b/src/html.rs
@@ -1,6 +1,8 @@
 //! The HTML renderer for the CommonMark AST, as well as helper functions.
 use crate::ctype::isspace;
-use crate::nodes::{AstNode, ListType, NodeCode, NodeFootnoteDefinition, NodeValue, TableAlignment};
+use crate::nodes::{
+    AstNode, ListType, NodeCode, NodeFootnoteDefinition, NodeValue, TableAlignment,
+};
 use crate::parser::{ComrakOptions, ComrakPlugins};
 use crate::scanners;
 use once_cell::sync::Lazy;
@@ -701,14 +703,13 @@ impl<'o> HtmlFormatter<'o> {
                         self.render_sourcepos(node)?;
                         self.output.write_all(b">")?;
                     } else {
-                        match &node.parent().unwrap().data.borrow().value {
-                            NodeValue::FootnoteDefinition(nfd) => {
-                                if node.next_sibling().is_none() {
-                                    self.output.write_all(b" ")?;
-                                    self.put_footnote_backref(&nfd)?;
-                                }
+                        if let NodeValue::FootnoteDefinition(nfd) =
+                            &node.parent().unwrap().data.borrow().value
+                        {
+                            if node.next_sibling().is_none() {
+                                self.output.write_all(b" ")?;
+                                self.put_footnote_backref(nfd)?;
                             }
-                            _ => {}
                         }
                         self.output.write_all(b"</p>\n")?;
                     }
@@ -945,7 +946,7 @@ impl<'o> HtmlFormatter<'o> {
                     self.render_sourcepos(node)?;
                     writeln!(self.output, " id=\"fn-{}\">", nfd.name)?;
                 } else {
-                    if self.put_footnote_backref(&nfd)? {
+                    if self.put_footnote_backref(nfd)? {
                         self.output.write_all(b"\n")?;
                     }
                     self.output.write_all(b"</li>\n")?;

--- a/src/html.rs
+++ b/src/html.rs
@@ -951,13 +951,13 @@ impl<'o> HtmlFormatter<'o> {
                     self.output.write_all(b"</li>\n")?;
                 }
             }
-            NodeValue::FootnoteReference(ref r, ix) => {
+            NodeValue::FootnoteReference(ref nfr) => {
                 if entering {
                     self.output.write_all(b"<sup")?;
                     self.render_sourcepos(node)?;
                     write!(
                         self.output, " class=\"footnote-ref\"><a href=\"#fn-{}\" id=\"fnref-{}\" data-footnote-ref>{}</a></sup>",
-                        r, r, ix
+                        nfr.name, nfr.name, nfr.ix,
                     )?;
                 }
             }

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -145,8 +145,8 @@ pub enum NodeValue {
     /// **Inline**.  An [image](https://github.github.com/gfm/#images).
     Image(NodeLink),
 
-    /// **Inline**.  A footnote reference; the `String` is the referent footnote's name.
-    FootnoteReference(String, u32),
+    /// **Inline**.  A footnote reference.
+    FootnoteReference(NodeFootnoteReference),
 
     #[cfg(feature = "shortcodes")]
     /// **Inline**. An Emoji character generated from a shortcode. Enable with feature "shortcodes".
@@ -329,6 +329,16 @@ pub struct NodeHtmlBlock {
     pub literal: String,
 }
 
+/// The metadata of a footnote reference.
+#[derive(Debug, Default, Clone)]
+pub struct NodeFootnoteReference {
+    /// The name of the footnote.
+    pub name: String,
+
+    /// The index of the footnote in the document.
+    pub ix: u32,
+}
+
 impl NodeValue {
     /// Indicates whether this node is a block node or inline node.
     pub fn block(&self) -> bool {
@@ -422,7 +432,7 @@ impl NodeValue {
             NodeValue::FrontMatter(_) => "frontmatter",
             NodeValue::TaskItem { .. } => "taskitem",
             NodeValue::Superscript => "superscript",
-            NodeValue::FootnoteReference(_, _) => "footnote_reference",
+            NodeValue::FootnoteReference(..) => "footnote_reference",
             #[cfg(feature = "shortcodes")]
             NodeValue::ShortCode(_) => "shortcode",
         }

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -146,7 +146,7 @@ pub enum NodeValue {
     Image(NodeLink),
 
     /// **Inline**.  A footnote reference; the `String` is the referent footnote's name.
-    FootnoteReference(String),
+    FootnoteReference(String, u32),
 
     #[cfg(feature = "shortcodes")]
     /// **Inline**. An Emoji character generated from a shortcode. Enable with feature "shortcodes".
@@ -422,7 +422,7 @@ impl NodeValue {
             NodeValue::FrontMatter(_) => "frontmatter",
             NodeValue::TaskItem { .. } => "taskitem",
             NodeValue::Superscript => "superscript",
-            NodeValue::FootnoteReference(_) => "footnote_reference",
+            NodeValue::FootnoteReference(_, _) => "footnote_reference",
             #[cfg(feature = "shortcodes")]
             NodeValue::ShortCode(_) => "shortcode",
         }

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -88,7 +88,7 @@ pub enum NodeValue {
 
     /// **Block**. A footnote definition.  The `String` is the footnote's name.
     /// Contains other **blocks**.
-    FootnoteDefinition(String),
+    FootnoteDefinition(NodeFootnoteDefinition),
 
     /// **Block**. A [table](https://github.github.com/gfm/#tables-extension-) per the GFM spec.
     /// Contains table rows.
@@ -329,11 +329,24 @@ pub struct NodeHtmlBlock {
     pub literal: String,
 }
 
+/// The metadata of a footnote definition.
+#[derive(Debug, Default, Clone)]
+pub struct NodeFootnoteDefinition {
+    /// The name of the footnote.
+    pub name: String,
+
+    /// Total number of references to this footnote
+    pub total_references: u32,
+}
+
 /// The metadata of a footnote reference.
 #[derive(Debug, Default, Clone)]
 pub struct NodeFootnoteReference {
     /// The name of the footnote.
     pub name: String,
+
+    /// The index of reference to the same footnote
+    pub ref_num: u32,
 
     /// The index of the footnote in the document.
     pub ix: u32,

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1231,6 +1231,7 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
                 let inl = self.make_inline(
                     NodeValue::FootnoteReference(NodeFootnoteReference {
                         name: text[1..].to_string(),
+                        ref_num: 0,
                         ix: 0,
                     }),
                     // Overridden immediately below.

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1229,7 +1229,7 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
             let text = text.unwrap();
             if text.len() > 1 && text.as_bytes()[0] == b'^' {
                 let inl = self.make_inline(
-                    NodeValue::FootnoteReference(text[1..].to_string()),
+                    NodeValue::FootnoteReference(text[1..].to_string(), 0),
                     // Overridden immediately below.
                     self.pos,
                     self.pos,

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1,7 +1,7 @@
 use crate::arena_tree::Node;
 use crate::ctype::{ispunct, isspace};
 use crate::entity;
-use crate::nodes::{Ast, AstNode, NodeCode, NodeLink, NodeValue, Sourcepos};
+use crate::nodes::{Ast, AstNode, NodeCode, NodeFootnoteReference, NodeLink, NodeValue, Sourcepos};
 #[cfg(feature = "shortcodes")]
 use crate::parser::shortcodes::NodeShortCode;
 use crate::parser::{
@@ -1229,7 +1229,10 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
             let text = text.unwrap();
             if text.len() > 1 && text.as_bytes()[0] == b'^' {
                 let inl = self.make_inline(
-                    NodeValue::FootnoteReference(text[1..].to_string(), 0),
+                    NodeValue::FootnoteReference(NodeFootnoteReference {
+                        name: text[1..].to_string(),
+                        ix: 0,
+                    }),
                     // Overridden immediately below.
                     self.pos,
                     self.pos,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -600,7 +600,8 @@ pub struct Reference {
 struct FootnoteDefinition<'a> {
     ix: Option<u32>,
     node: &'a AstNode<'a>,
-}
+    name: String,
+ }
 
 impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
     fn new(
@@ -1761,7 +1762,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
                 if let Some(ix) = f.ix {
                     match f.node.data.borrow_mut().value {
                         NodeValue::FootnoteDefinition(ref mut name) => {
-                            *name = format!("{}", ix);
+                            *name = format!("{}", f.name);
                         }
                         _ => unreachable!(),
                     }
@@ -1780,7 +1781,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
                 node.detach();
                 map.insert(
                     strings::normalize_label(name),
-                    FootnoteDefinition { ix: None, node },
+                    FootnoteDefinition { ix: None, node, name: strings::normalize_label(name) },
                 );
             }
             _ => {
@@ -1799,7 +1800,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
         let mut ast = node.data.borrow_mut();
         let mut replace = None;
         match ast.value {
-            NodeValue::FootnoteReference(ref mut name) => {
+            NodeValue::FootnoteReference(ref mut name, ref mut index) => {
                 if let Some(ref mut footnote) = map.get_mut(name) {
                     let ix = match footnote.ix {
                         Some(ix) => ix,
@@ -1809,7 +1810,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
                             *ixp
                         }
                     };
-                    *name = format!("{}", ix);
+                    *index = ix;
                 } else {
                     replace = Some(name.clone());
                 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1766,7 +1766,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
                 if f.ix.is_some() {
                     match f.node.data.borrow_mut().value {
                         NodeValue::FootnoteDefinition(ref mut nfd) => {
-                            nfd.name = format!("{}", f.name);
+                            nfd.name = f.name.to_string();
                             nfd.total_references = f.total_references;
                         }
                         _ => unreachable!(),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -256,7 +256,7 @@ pub struct ComrakExtensionOptions {
     /// let mut options = ComrakOptions::default();
     /// options.extension.footnotes = true;
     /// assert_eq!(markdown_to_html("Hi[^x].\n\n[^x]: A greeting.\n", &options),
-    ///            "<p>Hi<sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup>.</p>\n<section class=\"footnotes\" data-footnotes>\n<ol>\n<li id=\"fn-1\">\n<p>A greeting. <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a></p>\n</li>\n</ol>\n</section>\n");
+    ///            "<p>Hi<sup class=\"footnote-ref\"><a href=\"#fn-x\" id=\"fnref-x\" data-footnote-ref>1</a></sup>.</p>\n<section class=\"footnotes\" data-footnotes>\n<ol>\n<li id=\"fn-x\">\n<p>A greeting. <a href=\"#fnref-x\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n</li>\n</ol>\n</section>\n");
     /// ```
     pub footnotes: bool,
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -601,7 +601,7 @@ struct FootnoteDefinition<'a> {
     ix: Option<u32>,
     node: &'a AstNode<'a>,
     name: String,
- }
+}
 
 impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
     fn new(
@@ -1759,7 +1759,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
             let mut v = map.into_values().collect::<Vec<_>>();
             v.sort_unstable_by(|a, b| a.ix.cmp(&b.ix));
             for f in v {
-                if let Some(ix) = f.ix {
+                if f.ix.is_some() {
                     match f.node.data.borrow_mut().value {
                         NodeValue::FootnoteDefinition(ref mut name) => {
                             *name = format!("{}", f.name);
@@ -1781,7 +1781,11 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
                 node.detach();
                 map.insert(
                     strings::normalize_label(name),
-                    FootnoteDefinition { ix: None, node, name: strings::normalize_label(name) },
+                    FootnoteDefinition {
+                        ix: None,
+                        node,
+                        name: strings::normalize_label(name),
+                    },
                 );
             }
             _ => {
@@ -1800,8 +1804,8 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
         let mut ast = node.data.borrow_mut();
         let mut replace = None;
         match ast.value {
-            NodeValue::FootnoteReference(ref mut name, ref mut index) => {
-                if let Some(ref mut footnote) = map.get_mut(name) {
+            NodeValue::FootnoteReference(ref mut nfr) => {
+                if let Some(ref mut footnote) = map.get_mut(&nfr.name) {
                     let ix = match footnote.ix {
                         Some(ix) => ix,
                         None => {
@@ -1810,9 +1814,9 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
                             *ixp
                         }
                     };
-                    *index = ix;
+                    nfr.ix = ix;
                 } else {
-                    replace = Some(name.clone());
+                    replace = Some(nfr.name.clone());
                 }
             }
             _ => {

--- a/src/tests/api.rs
+++ b/src/tests/api.rs
@@ -207,8 +207,9 @@ fn exercise_full_api() {
         nodes::NodeValue::ShortCode(ne) => {
             let _: &str = ne.shortcode();
         }
-        nodes::NodeValue::FootnoteReference(name, _) => {
-            let _: &String = name;
+        nodes::NodeValue::FootnoteReference(nfr) => {
+            let _: String = nfr.name;
+            let _: u32 = nfr.ix;
         }
     }
 }

--- a/src/tests/api.rs
+++ b/src/tests/api.rs
@@ -207,7 +207,7 @@ fn exercise_full_api() {
         nodes::NodeValue::ShortCode(ne) => {
             let _: &str = ne.shortcode();
         }
-        nodes::NodeValue::FootnoteReference(name) => {
+        nodes::NodeValue::FootnoteReference(name, _) => {
             let _: &String = name;
         }
     }

--- a/src/tests/api.rs
+++ b/src/tests/api.rs
@@ -164,8 +164,9 @@ fn exercise_full_api() {
             let _: bool = nh.setext;
         }
         nodes::NodeValue::ThematicBreak => {}
-        nodes::NodeValue::FootnoteDefinition(name) => {
-            let _: &String = name;
+        nodes::NodeValue::FootnoteDefinition(nfd) => {
+            let _: &String = &nfd.name;
+            let _: u32 = nfd.total_references;
         }
         nodes::NodeValue::Table(aligns) => {
             let _: &Vec<nodes::TableAlignment> = aligns;

--- a/src/tests/footnotes.rs
+++ b/src/tests/footnotes.rs
@@ -7,7 +7,7 @@ fn footnotes() {
         concat!(
             "Here is a[^nowhere] footnote reference,[^1] and another.[^longnote]\n",
             "\n",
-            "This is another note.[^note]\n",
+            "This is another note.[^note] And footnote[^longnote] is referenced again.\n",
             "\n",
             "[^note]: Hi.\n",
             "\n",
@@ -27,8 +27,9 @@ fn footnotes() {
             "<p>Here is a[^nowhere] footnote reference,<sup class=\"footnote-ref\"><a href=\"#fn-1\" \
              id=\"fnref-1\" data-footnote-ref>1</a></sup> and another.<sup class=\"footnote-ref\"><a \
              href=\"#fn-longnote\" id=\"fnref-longnote\" data-footnote-ref>2</a></sup></p>\n",
-            "<p>This is another note.<sup class=\"footnote-ref\"><a href=\"#fn-note\" \
-             id=\"fnref-note\" data-footnote-ref>3</a></sup></p>\n",
+            "<p>This is another note.<sup class=\"footnote-ref\"><a \
+             href=\"#fn-note\" id=\"fnref-note\" data-footnote-ref>3</a></sup> And footnote<sup class=\"footnote-ref\"><a \
+             href=\"#fn-longnote\" id=\"fnref-longnote-2\" data-footnote-ref>2</a></sup> is referenced again.</p>\n",
             "<p>This is regular content.</p>\n",
             "<section class=\"footnotes\" data-footnotes>\n",
             "<ol>\n",
@@ -41,7 +42,8 @@ fn footnotes() {
             "<p>Subsequent paragraphs are indented.</p>\n",
             "<pre><code>code\n",
             "</code></pre>\n",
-            "<a href=\"#fnref-longnote\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a>\n",
+            "<a href=\"#fnref-longnote\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a> \
+             <a href=\"#fnref-longnote-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2-2\" aria-label=\"Back to reference 2-2\">↩<sup class=\"footnote-ref\">2</sup></a>\n",
             "</li>\n",
             "<li id=\"fn-note\">\n",
             "<p>Hi. <a href=\"#fnref-note\" \
@@ -94,7 +96,7 @@ fn footnote_in_table() {
             "</thead>\n",
             "<tbody>\n",
             "<tr>\n",
-            "<td>foot <sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1\" data-footnote-ref>1</a></sup></td>\n",
+            "<td>foot <sup class=\"footnote-ref\"><a href=\"#fn-1\" id=\"fnref-1-2\" data-footnote-ref>1</a></sup></td>\n",
             "<td>note</td>\n",
             "</tr>\n",
             "</tbody>\n",
@@ -102,7 +104,7 @@ fn footnote_in_table() {
             "<section class=\"footnotes\" data-footnotes>\n",
             "<ol>\n",
             "<li id=\"fn-1\">\n",
-            "<p>a footnote <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n",
+            "<p>a footnote <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a> <a href=\"#fnref-1-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1-2\" aria-label=\"Back to reference 1-2\">↩<sup class=\"footnote-ref\">2</sup></a></p>\n",
             "</li>\n",
             "</ol>\n",
             "</section>\n",

--- a/src/tests/footnotes.rs
+++ b/src/tests/footnotes.rs
@@ -26,26 +26,26 @@ fn footnotes() {
         concat!(
             "<p>Here is a[^nowhere] footnote reference,<sup class=\"footnote-ref\"><a href=\"#fn-1\" \
              id=\"fnref-1\" data-footnote-ref>1</a></sup> and another.<sup class=\"footnote-ref\"><a \
-             href=\"#fn-2\" id=\"fnref-2\" data-footnote-ref>2</a></sup></p>\n",
-            "<p>This is another note.<sup class=\"footnote-ref\"><a href=\"#fn-3\" \
-             id=\"fnref-3\" data-footnote-ref>3</a></sup></p>\n",
+             href=\"#fn-longnote\" id=\"fnref-longnote\" data-footnote-ref>2</a></sup></p>\n",
+            "<p>This is another note.<sup class=\"footnote-ref\"><a href=\"#fn-note\" \
+             id=\"fnref-note\" data-footnote-ref>3</a></sup></p>\n",
             "<p>This is regular content.</p>\n",
             "<section class=\"footnotes\" data-footnotes>\n",
             "<ol>\n",
             "<li id=\"fn-1\">\n",
             "<p>Here is the footnote. <a href=\"#fnref-1\" \
-             class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a></p>\n",
+             class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n",
             "</li>\n",
-            "<li id=\"fn-2\">\n",
+            "<li id=\"fn-longnote\">\n",
             "<p>Here's one with multiple blocks.</p>\n",
             "<p>Subsequent paragraphs are indented.</p>\n",
             "<pre><code>code\n",
             "</code></pre>\n",
-            "<a href=\"#fnref-2\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a>\n",
+            "<a href=\"#fnref-longnote\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a>\n",
             "</li>\n",
-            "<li id=\"fn-3\">\n",
-            "<p>Hi. <a href=\"#fnref-3\" \
-             class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a></p>\n",
+            "<li id=\"fn-note\">\n",
+            "<p>Hi. <a href=\"#fnref-note\" \
+             class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"3\" aria-label=\"Back to reference 3\">↩</a></p>\n",
             "</li>\n",
             "</ol>\n",
             "</section>\n"
@@ -59,12 +59,11 @@ fn footnote_does_not_eat_exclamation() {
         [extension.footnotes],
         concat!("Here's my footnote![^a]\n", "\n", "[^a]: Yep.\n"),
         concat!(
-            "<p>Here's my footnote!<sup class=\"footnote-ref\"><a href=\"#fn-1\" \
-             id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n",
+            "<p>Here's my footnote!<sup class=\"footnote-ref\"><a href=\"#fn-a\" id=\"fnref-a\" data-footnote-ref>1</a></sup></p>\n",
             "<section class=\"footnotes\" data-footnotes>\n",
             "<ol>\n",
-            "<li id=\"fn-1\">\n",
-            "<p>Yep. <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a></p>\n",
+            "<li id=\"fn-a\">\n",
+            "<p>Yep. <a href=\"#fnref-a\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n",
             "</li>\n",
             "</ol>\n",
             "</section>\n"
@@ -103,7 +102,7 @@ fn footnote_in_table() {
             "<section class=\"footnotes\" data-footnotes>\n",
             "<ol>\n",
             "<li id=\"fn-1\">\n",
-            "<p>a footnote <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a></p>\n",
+            "<p>a footnote <a href=\"#fnref-1\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n",
             "</li>\n",
             "</ol>\n",
             "</section>\n",
@@ -127,18 +126,18 @@ fn footnote_with_superscript() {
         concat!(
             "<p>Here is a footnote reference.<sup class=\"footnote-ref\"><a href=\"#fn-1\" \
              id=\"fnref-1\" data-footnote-ref>1</a></sup></p>\n",
-            "<p>Here is a longer footnote reference.<sup class=\"footnote-ref\"><a href=\"#fn-2\" \
-             id=\"fnref-2\" data-footnote-ref>2</a></sup></p>\n",
+            "<p>Here is a longer footnote reference.<sup class=\"footnote-ref\"><a href=\"#fn-ref\" \
+             id=\"fnref-ref\" data-footnote-ref>2</a></sup></p>\n",
             "<p>e = mc<sup>2</sup>.</p>\n",
             "<section class=\"footnotes\" data-footnotes>\n",
             "<ol>\n",
             "<li id=\"fn-1\">\n",
             "<p>Here is the footnote. <a href=\"#fnref-1\" \
-             class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a></p>\n",
+             class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n",
             "</li>\n",
-            "<li id=\"fn-2\">\n",
-            "<p>Here is another footnote. <a href=\"#fnref-2\" \
-             class=\"footnote-backref\" data-footnote-backref aria-label=\"Back to content\">↩</a></p>\n",
+            "<li id=\"fn-ref\">\n",
+            "<p>Here is another footnote. <a href=\"#fnref-ref\" \
+             class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a></p>\n",
             "</li>\n",
             "</ol>\n",
             "</section>\n"

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -233,7 +233,7 @@ impl<'o> XmlFormatter<'o> {
                     self.escape(fd.as_bytes())?;
                     self.output.write_all(b"\"")?;
                 }
-                NodeValue::FootnoteReference(ref fr) => {
+                NodeValue::FootnoteReference(ref fr, _) => {
                     self.output.write_all(b" label=\"")?;
                     self.escape(fr.as_bytes())?;
                     self.output.write_all(b"\"")?;

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -230,7 +230,7 @@ impl<'o> XmlFormatter<'o> {
                 }
                 NodeValue::FootnoteDefinition(ref fd) => {
                     self.output.write_all(b" label=\"")?;
-                    self.escape(fd.as_bytes())?;
+                    self.escape(fd.name.as_bytes())?;
                     self.output.write_all(b"\"")?;
                 }
                 NodeValue::FootnoteReference(ref nfr) => {

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -233,9 +233,9 @@ impl<'o> XmlFormatter<'o> {
                     self.escape(fd.as_bytes())?;
                     self.output.write_all(b"\"")?;
                 }
-                NodeValue::FootnoteReference(ref fr, _) => {
+                NodeValue::FootnoteReference(ref nfr) => {
                     self.output.write_all(b" label=\"")?;
-                    self.escape(fr.as_bytes())?;
+                    self.escape(nfr.name.as_bytes())?;
                     self.output.write_all(b"\"")?;
                 }
                 NodeValue::TaskItem(Some(_)) => {


### PR DESCRIPTION
For example

```
one[^zz]
[^zz]: two
```

should generate 

```
<p>one<sup class="footnote-ref"><a href="#fn-zz" id="fnref-zz" data-footnote-ref>1</a></sup></p>
<section class="footnotes" data-footnotes>
<ol>
<li id="fn-zz">
<p>two <a href="#fnref-zz" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
</li>
</ol>
</section>
```