### PR TITLE
Add in-doc labels for public facing features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ exclude = [
 resolver = "2"
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [profile.release]
 lto = true
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@
 //! # }
 //! ```
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(
     missing_docs,
     missing_debug_implementations,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -329,8 +329,8 @@ pub struct ComrakExtensionOptions {
     pub front_matter_delimiter: Option<String>,
 
     #[cfg(feature = "shortcodes")]
-    /// Available if "shortcodes" feature is enabled.  Phrases wrapped inside of ':' blocks will be
-    /// replaced with emojis.
+    #[cfg_attr(docsrs, doc(cfg(feature = "shortcodes")))]
+    /// Phrases wrapped inside of ':' blocks will be replaced with emojis.
     ///
     /// ```
     /// # use comrak::{markdown_to_html, ComrakOptions};

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,4 +1,5 @@
 //! Plugins for enhancing the default implementation of comrak can be defined in this module.
 
 #[cfg(feature = "syntect")]
+#[cfg_attr(docsrs, doc(cfg(feature = "syntect")))]
 pub mod syntect;


### PR DESCRIPTION
This tweaks the docs.rs setup, so that

- Docs are built with all features active
- The `comrak::plugins::syntect` module and `ComrakExtensionOptions.shortcodes` field are now labeled that they're activated by a feature

You can see the docs locally by running

```sh
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features --open
```

_Motivation: I had to go digging in the source code to figure out how to enable shortcodes since the current docs weren't built with that feature_