### PR TITLE
Escape footnote name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 comrak-*
 .vscode
+.idea

--- a/src/html.rs
+++ b/src/html.rs
@@ -944,7 +944,9 @@ impl<'o> HtmlFormatter<'o> {
                     self.footnote_ix += 1;
                     self.output.write_all(b"<li")?;
                     self.render_sourcepos(node)?;
-                    writeln!(self.output, " id=\"fn-{}\">", nfd.name)?;
+                    self.output.write_all(b" id=\"fn-")?;
+                    self.escape_href(nfd.name.as_bytes())?;
+                    self.output.write_all(b"\">")?;
                 } else {
                     if self.put_footnote_backref(nfd)? {
                         self.output.write_all(b"\n")?;
@@ -962,10 +964,13 @@ impl<'o> HtmlFormatter<'o> {
                     if nfr.ref_num > 1 {
                         ref_id = format!("{}-{}", ref_id, nfr.ref_num);
                     }
-                    write!(
-                        self.output, " class=\"footnote-ref\"><a href=\"#fn-{}\" id=\"{}\" data-footnote-ref>{}</a></sup>",
-                        nfr.name, ref_id, nfr.ix,
-                    )?;
+
+                    self.output
+                        .write_all(b" class=\"footnote-ref\"><a href=\"#fn-")?;
+                    self.escape_href(nfr.name.as_bytes())?;
+                    self.output.write_all(b"\" id=\"")?;
+                    self.escape_href(ref_id.as_bytes())?;
+                    write!(self.output, "\" data-footnote-ref>{}</a></sup>", nfr.ix)?;
                 }
             }
             NodeValue::TaskItem(symbol) => {
@@ -1018,10 +1023,12 @@ impl<'o> HtmlFormatter<'o> {
                 write!(self.output, " ")?;
             }
 
+            self.output.write_all(b"<a href=\"#fnref-")?;
+            self.escape_href(nfd.name.as_bytes())?;
             write!(
                 self.output,
-                "<a href=\"#fnref-{}{}\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"{}{}\" aria-label=\"Back to reference {}{}\">↩{}</a>",
-                nfd.name, ref_suffix, self.footnote_ix, ref_suffix, self.footnote_ix, ref_suffix, superscript
+                "{}\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"{}{}\" aria-label=\"Back to reference {}{}\">↩{}</a>",
+                ref_suffix, self.footnote_ix, ref_suffix, self.footnote_ix, ref_suffix, superscript
             )?;
         }
         Ok(true)

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1197,7 +1197,7 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
         }
 
         // Need to normalize both to lookup in refmap and to call callback
-        let lab = strings::normalize_label(&lab);
+        let lab = strings::normalize_label(&lab, false);
         let mut reff = if found_label {
             self.refmap.lookup(&lab)
         } else {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1785,11 +1785,11 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
             NodeValue::FootnoteDefinition(ref nfd) => {
                 node.detach();
                 map.insert(
-                    strings::normalize_label(&nfd.name),
+                    strings::normalize_label(&nfd.name, false),
                     FootnoteDefinition {
                         ix: None,
                         node,
-                        name: strings::normalize_label(&nfd.name),
+                        name: strings::normalize_label(&nfd.name, true),
                         total_references: 0,
                     },
                 );
@@ -1811,7 +1811,8 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
         let mut replace = None;
         match ast.value {
             NodeValue::FootnoteReference(ref mut nfr) => {
-                if let Some(ref mut footnote) = map.get_mut(&nfr.name) {
+                let normalized = strings::normalize_label(&nfr.name, false);
+                if let Some(ref mut footnote) = map.get_mut(&normalized) {
                     let ix = match footnote.ix {
                         Some(ix) => ix,
                         None => {
@@ -1823,6 +1824,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
                     footnote.total_references += 1;
                     nfr.ref_num = footnote.total_references;
                     nfr.ix = ix;
+                    nfr.name = strings::normalize_label(&footnote.name, true);
                 } else {
                     replace = Some(nfr.name.clone());
                 }
@@ -2023,7 +2025,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
             }
         }
 
-        lab = strings::normalize_label(&lab);
+        lab = strings::normalize_label(&lab, false);
         if !lab.is_empty() {
             subj.refmap.map.entry(lab).or_insert(Reference {
                 url: String::from_utf8(strings::clean_url(url)).unwrap(),

--- a/src/tests/footnotes.rs
+++ b/src/tests/footnotes.rs
@@ -148,6 +148,28 @@ fn footnote_with_superscript() {
 }
 
 #[test]
+fn footnote_escapes_name() {
+    html_opts!(
+        [extension.footnotes],
+        concat!(
+            "Here is a footnote reference.[^😄ref]\n",
+            "\n",
+            "[^😄ref]: Here is the footnote.\n",
+        ),
+        concat!(
+            "<p>Here is a footnote reference.<sup class=\"footnote-ref\"><a href=\"#fn-%F0%9F%98%84ref\" id=\"fnref-%F0%9F%98%84ref\" data-footnote-ref>1</a></sup></p>\n",
+            "<section class=\"footnotes\" data-footnotes>\n",
+            "<ol>\n",
+            "<li id=\"fn-%F0%9F%98%84ref\">\n",
+            "<p>Here is the footnote. <a href=\"#fnref-%F0%9F%98%84ref\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n",
+            "</li>\n",
+            "</ol>\n",
+            "</section>\n"
+        ),
+    );
+}
+
+#[test]
 fn sourcepos() {
     assert_ast_match!(
         [extension.footnotes],

--- a/src/tests/footnotes.rs
+++ b/src/tests/footnotes.rs
@@ -170,6 +170,28 @@ fn footnote_escapes_name() {
 }
 
 #[test]
+fn footnote_case_insensitive_and_case_preserving() {
+    html_opts!(
+        [extension.footnotes],
+        concat!(
+            "Here is a footnote reference.[^AB] and [^ab]\n",
+            "\n",
+            "[^aB]: Here is the footnote.\n",
+        ),
+        concat!(
+            "<p>Here is a footnote reference.<sup class=\"footnote-ref\"><a href=\"#fn-aB\" id=\"fnref-aB\" data-footnote-ref>1</a></sup> and <sup class=\"footnote-ref\"><a href=\"#fn-aB\" id=\"fnref-aB-2\" data-footnote-ref>1</a></sup></p>\n",
+            "<section class=\"footnotes\" data-footnotes>\n",
+            "<ol>\n",
+            "<li id=\"fn-aB\">\n",
+            "<p>Here is the footnote. <a href=\"#fnref-aB\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a> <a href=\"#fnref-aB-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1-2\" aria-label=\"Back to reference 1-2\">↩<sup class=\"footnote-ref\">2</sup></a></p>\n",
+            "</li>\n",
+            "</ol>\n",
+            "</section>\n"
+        ),
+    );
+}
+
+#[test]
 fn sourcepos() {
     assert_ast_match!(
         [extension.footnotes],


### PR DESCRIPTION
This escapes footnote names.  So `[^😄ref]` would yield the name `%F0%9F%98%84ref`

It also makes footnote names case-insensitive but case-preserving.  So if the footnote definition is `[^aB]: footnote`, you can reference it as `[^AB]` or `[^ab]`, etc.  The final name will be the definition name, `aB`.

Related to https://github.com/kivikakk/comrak/issues/307