### PR TITLE
Handle footnote names that have been parsed into multiple nodes

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "4f0807fb6f644c83f3e4ec014fec9858c1c8b26a7db8eb5f0bde5817df9c1df7"
 
 [[package]]
 name = "comrak"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "arbitrary",
  "clap",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -54,3 +54,9 @@ name = "gfm_sourcepos"
 path = "fuzz_targets/gfm_sourcepos.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "gfm_footnotes"
+path = "fuzz_targets/gfm_footnotes.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/gfm_footnotes.rs
+++ b/fuzz/fuzz_targets/gfm_footnotes.rs
@@ -1,0 +1,32 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use comrak::{markdown_to_html, ComrakExtensionOptions, ComrakOptions, ComrakRenderOptions};
+
+// Note that what I'm targetting here isn't exactly the same
+// as --gfm, but rather an approximation of what cmark-gfm
+// options are routinely used by Commonmarker users.
+
+fuzz_target!(|s: &str| {
+    markdown_to_html(
+        s,
+        &ComrakOptions {
+            extension: ComrakExtensionOptions {
+                strikethrough: true,
+                tagfilter: true,
+                table: true,
+                autolink: true,
+                footnotes: true,
+                ..Default::default()
+            },
+            parse: Default::default(),
+            render: ComrakRenderOptions {
+                hardbreaks: true,
+                github_pre_lang: true,
+                unsafe_: true,
+                ..Default::default()
+            },
+        },
+    );
+});

--- a/src/arena_tree.rs
+++ b/src/arena_tree.rs
@@ -7,7 +7,7 @@ A DOM-like tree data structure based on `&Node` references.
 Any non-trivial tree involves reference cycles
 (e.g. if a node has a first child, the parent of the child is that node).
 To enable this, nodes need to live in an arena allocator
-such as `arena::TypedArena` distrubuted with rustc (which is `#[unstable]` as of this writing)
+such as `arena::TypedArena` distributed with rustc (which is `#[unstable]` as of this writing)
 or [`typed_arena::Arena`](https://crates.io/crates/typed-arena).
 
 If you need mutability in the node’s `data`,
@@ -33,7 +33,7 @@ pub struct Node<'a, T: 'a> {
 }
 
 /// A simple Debug implementation that prints the children as a tree, without
-/// ilooping through the various interior pointer cycles.
+/// looping through the various interior pointer cycles.
 impl<'a, T: 'a> fmt::Debug for Node<'a, T>
 where
     T: fmt::Debug,
@@ -95,7 +95,7 @@ impl<'a, T> Node<'a, T> {
         self.previous_sibling.get()
     }
 
-    /// Return a reference to the previous sibling of this node, unless it is a last child.
+    /// Return a reference to the next sibling of this node, unless it is a last child.
     pub fn next_sibling(&self) -> Option<&'a Node<'a, T>> {
         self.next_sibling.get()
     }

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -9,6 +9,7 @@ use crate::parser::{
 };
 use crate::scanners;
 use crate::strings;
+use crate::strings::Case;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -1197,7 +1198,7 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
         }
 
         // Need to normalize both to lookup in refmap and to call callback
-        let lab = strings::normalize_label(&lab, false);
+        let lab = strings::normalize_label(&lab, Case::DontPreserve);
         let mut reff = if found_label {
             self.refmap.lookup(&lab)
         } else {

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1223,7 +1223,13 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
             && match bracket_inl_text.next_sibling() {
                 Some(n) => {
                     if n.data.borrow().value.text().is_some() {
-                        n.data.borrow().value.text().unwrap().as_bytes()[0] == b'^'
+                        n.data
+                            .borrow()
+                            .value
+                            .text()
+                            .unwrap()
+                            .as_bytes()
+                            .starts_with(&[b'^'])
                     } else {
                         false
                     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -14,7 +14,7 @@ use crate::nodes::{
     NodeHtmlBlock, NodeList, NodeValue,
 };
 use crate::scanners;
-use crate::strings::{self, split_off_front_matter};
+use crate::strings::{self, split_off_front_matter, Case};
 use std::cell::RefCell;
 use std::cmp::min;
 use std::collections::HashMap;
@@ -1785,11 +1785,11 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
             NodeValue::FootnoteDefinition(ref nfd) => {
                 node.detach();
                 map.insert(
-                    strings::normalize_label(&nfd.name, false),
+                    strings::normalize_label(&nfd.name, Case::DontPreserve),
                     FootnoteDefinition {
                         ix: None,
                         node,
-                        name: strings::normalize_label(&nfd.name, true),
+                        name: strings::normalize_label(&nfd.name, Case::Preserve),
                         total_references: 0,
                     },
                 );
@@ -1811,7 +1811,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
         let mut replace = None;
         match ast.value {
             NodeValue::FootnoteReference(ref mut nfr) => {
-                let normalized = strings::normalize_label(&nfr.name, false);
+                let normalized = strings::normalize_label(&nfr.name, Case::DontPreserve);
                 if let Some(ref mut footnote) = map.get_mut(&normalized) {
                     let ix = match footnote.ix {
                         Some(ix) => ix,
@@ -1824,7 +1824,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
                     footnote.total_references += 1;
                     nfr.ref_num = footnote.total_references;
                     nfr.ix = ix;
-                    nfr.name = strings::normalize_label(&footnote.name, true);
+                    nfr.name = strings::normalize_label(&footnote.name, Case::Preserve);
                 } else {
                     replace = Some(nfr.name.clone());
                 }
@@ -2025,7 +2025,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
             }
         }
 
-        lab = strings::normalize_label(&lab, false);
+        lab = strings::normalize_label(&lab, Case::DontPreserve);
         if !lab.is_empty() {
             subj.refmap.map.entry(lab).or_insert(Reference {
                 url: String::from_utf8(strings::clean_url(url)).unwrap(),

--- a/src/tests/footnotes.rs
+++ b/src/tests/footnotes.rs
@@ -192,6 +192,46 @@ fn footnote_case_insensitive_and_case_preserving() {
 }
 
 #[test]
+fn footnote_name_parsed_into_multiple_nodes() {
+    html_opts!(
+        [extension.footnotes],
+        concat!(
+            "Foo.[^_ab]\n",
+            "\n",
+            "[^_ab]: Here is the footnote.\n",
+        ),
+        concat!(
+            "<p>Foo.<sup class=\"footnote-ref\"><a href=\"#fn-_ab\" id=\"fnref-_ab\" data-footnote-ref>1</a></sup></p>\n",
+            "<section class=\"footnotes\" data-footnotes>\n",
+            "<ol>\n",
+            "<li id=\"fn-_ab\">\n",
+            "<p>Here is the footnote. <a href=\"#fnref-_ab\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n",
+            "</li>\n",
+            "</ol>\n",
+            "</section>\n"
+        ),
+    );
+}
+
+#[test]
+fn footnote_invalid_with_missing_name() {
+    html_opts!(
+        [extension.footnotes],
+        "Foo.[^]\n\n[^]: Here is the footnote.\n",
+        "<p>Foo.[^]</p>\n<p>[^]: Here is the footnote.</p>\n"
+    );
+}
+
+#[test]
+fn footnote_does_not_allow_spaces_in_name() {
+    html_opts!(
+        [extension.footnotes],
+        "Foo.[^one two]\n\n[^one two]: Here is the footnote.\n",
+        "<p>Foo.[^one two]</p>\n<p>[^one two]: Here is the footnote.</p>\n"
+    );
+}
+
+#[test]
 fn sourcepos() {
     assert_ast_match!(
         [extension.footnotes],

--- a/src/tests/footnotes.rs
+++ b/src/tests/footnotes.rs
@@ -232,6 +232,24 @@ fn footnote_does_not_allow_spaces_in_name() {
 }
 
 #[test]
+fn footnote_does_not_expand_emphasis_in_name() {
+    html_opts!(
+        [extension.footnotes],
+        "Foo[^**one**]\n[^**one**]: bar\n",
+        concat!(
+            "<p>Foo<sup class=\"footnote-ref\"><a href=\"#fn-**one**\" id=\"fnref-**one**\" data-footnote-ref>1</a></sup></p>\n",
+            "<section class=\"footnotes\" data-footnotes>\n",
+            "<ol>\n",
+            "<li id=\"fn-**one**\">\n",
+            "<p>bar <a href=\"#fnref-**one**\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n",
+            "</li>\n",
+            "</ol>\n",
+            "</section>\n"
+        ),
+    );
+}
+
+#[test]
 fn sourcepos() {
     assert_ast_match!(
         [extension.footnotes],


### PR DESCRIPTION
For example `[^_foo]` gives `^`, `_`, and `foo`.

Related `cmark-gfm` PR: https://github.com/github/cmark-gfm/pull/229

Related issue: https://github.com/kivikakk/comrak/issues/306