### PR TITLE
Rename `ComrakFoo` types to just `Foo` for easier usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ the file does not exist.
 And there's a Rust interface. You can use `comrak::markdown_to_html` directly:
 
 ``` rust
-use comrak::{markdown_to_html, ComrakOptions};
-assert_eq!(markdown_to_html("Hello, **世界**!", &ComrakOptions::default()),
+use comrak::{markdown_to_html, Options};
+assert_eq!(markdown_to_html("Hello, **世界**!", &Options::default()),
            "<p>Hello, <strong>世界</strong>!</p>\n");
 ```
 
@@ -153,7 +153,7 @@ Or you can parse the input into an AST yourself, manipulate it, and then use you
 
 ``` rust
 extern crate comrak;
-use comrak::{parse_document, format_html, Arena, ComrakOptions};
+use comrak::{parse_document, format_html, Arena, Options};
 use comrak::nodes::{AstNode, NodeValue};
 
 // The returned nodes are created in the supplied Arena, and are bound by its lifetime.
@@ -162,7 +162,7 @@ let arena = Arena::new();
 let root = parse_document(
     &arena,
     "This is my input.\n\n1. Also my input.\n2. Certainly my input.\n",
-    &ComrakOptions::default());
+    &Options::default());
 
 fn iter_nodes<'a, F>(node: &'a AstNode<'a>, f: &F)
     where F : Fn(&'a AstNode<'a>) {
@@ -183,7 +183,7 @@ iter_nodes(root, &|node| {
 });
 
 let mut html = vec![];
-format_html(root, &ComrakOptions::default(), &mut html).unwrap();
+format_html(root, &Options::default(), &mut html).unwrap();
 
 assert_eq!(
     String::from_utf8(html).unwrap(),
@@ -224,7 +224,7 @@ Comrak additionally supports its own extensions, which are yet to be specced out
 - Shortcodes
 
 By default none are enabled; they are individually enabled with each parse by setting the appropriate values in the
-[`ComrakOptions` struct](https://docs.rs/comrak/newest/comrak/struct.ComrakOptions.html).
+[`Options` struct](https://docs.rs/comrak/newest/comrak/struct.Options.html).
 
 ## Plugins
 
@@ -233,7 +233,7 @@ By default none are enabled; they are individually enabled with each parse by se
 At the moment syntax highlighting of codefence blocks is the only feature that can be enhanced with plugins.
 
 Create an implementation of the `SyntaxHighlighterAdapter` trait, and then provide an instance of such adapter to
-`ComrakPlugins.render.codefence_syntax_highlighter`. For formatting a markdown document with plugins, use the
+`Plugins.render.codefence_syntax_highlighter`. For formatting a markdown document with plugins, use the
 `markdown_to_html_with_plugins` function, which accepts your plugin as a parameter.
 
 See the `syntax_highlighter.rs` and `syntect.rs` examples for more details.
@@ -242,7 +242,7 @@ See the `syntax_highlighter.rs` and `syntect.rs` examples for more details.
 
 [`syntect`](https://github.com/trishume/syntect) is a syntax highlighting library for Rust. By default, `comrak` offers
 a plugin for it. In order to utilize it, create an instance of `plugins::syntect::SyntectAdapter` and use it as your
-`ComrakPlugins` option.
+`Plugins` option.
 
 ## Related projects
 

--- a/benches/progit.rs
+++ b/benches/progit.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use comrak::{format_html, parse_document, Arena, ComrakOptions};
+use comrak::{format_html, parse_document, Arena, Options};
 use test::Bencher;
 
 #[bench]
@@ -15,8 +15,8 @@ fn bench_progit(b: &mut Bencher) {
     file.read_to_string(&mut s).unwrap();
     b.iter(|| {
         let arena = Arena::new();
-        let root = parse_document(&arena, &s, &ComrakOptions::default());
+        let root = parse_document(&arena, &s, &Options::default());
         let mut output = vec![];
-        format_html(root, &ComrakOptions::default(), &mut output).unwrap()
+        format_html(root, &Options::default(), &mut output).unwrap()
     });
 }

--- a/examples/custom_headings.rs
+++ b/examples/custom_headings.rs
@@ -2,14 +2,14 @@ use comrak::{
     adapters::{HeadingAdapter, HeadingMeta},
     markdown_to_html_with_plugins,
     nodes::Sourcepos,
-    ComrakOptions, ComrakPlugins,
+    Options, Plugins,
 };
 use std::io::{self, Write};
 
 fn main() {
     let adapter = CustomHeadingAdapter;
-    let mut options = ComrakOptions::default();
-    let mut plugins = ComrakPlugins::default();
+    let mut options = Options::default();
+    let mut plugins = Plugins::default();
     plugins.render.heading_adapter = Some(&adapter);
 
     print_html(
@@ -62,7 +62,7 @@ impl HeadingAdapter for CustomHeadingAdapter {
     }
 }
 
-fn print_html(document: &str, options: &ComrakOptions, plugins: &ComrakPlugins) {
+fn print_html(document: &str, options: &Options, plugins: &Plugins) {
     let html = markdown_to_html_with_plugins(document, options, plugins);
     println!("{}", html);
 }

--- a/examples/headers.rs
+++ b/examples/headers.rs
@@ -2,7 +2,7 @@
 
 use comrak::{
     nodes::{AstNode, NodeCode, NodeValue},
-    parse_document, Arena, ComrakOptions,
+    parse_document, Arena, Options,
 };
 
 fn main() {
@@ -13,7 +13,7 @@ fn main() {
 
 fn get_document_title(document: &str) -> String {
     let arena = Arena::new();
-    let root = parse_document(&arena, document, &ComrakOptions::default());
+    let root = parse_document(&arena, document, &Options::default());
 
     for node in root.children() {
         let header = match node.data.clone().into_inner().value {

--- a/examples/s-expr.rs
+++ b/examples/s-expr.rs
@@ -14,7 +14,7 @@ const INDENT: usize = 4;
 const CLOSE_NEWLINE: bool = false;
 
 use comrak::nodes::{AstNode, NodeValue};
-use comrak::{parse_document, Arena, ComrakExtensionOptions, ComrakOptions};
+use comrak::{parse_document, Arena, ExtensionOptions, Options};
 use std::env;
 use std::error::Error;
 use std::fs::File;
@@ -74,8 +74,8 @@ fn iter_nodes<'a, W: Write>(
 fn dump(source: &str) -> io::Result<()> {
     let arena = Arena::new();
 
-    let opts = ComrakOptions {
-        extension: ComrakExtensionOptions {
+    let opts = Options {
+        extension: ExtensionOptions {
             strikethrough: true,
             tagfilter: true,
             table: true,
@@ -84,9 +84,9 @@ fn dump(source: &str) -> io::Result<()> {
             superscript: true,
             footnotes: true,
             description_lists: true,
-            ..ComrakExtensionOptions::default()
+            ..ExtensionOptions::default()
         },
-        ..ComrakOptions::default()
+        ..Options::default()
     };
 
     let doc = parse_document(&arena, source, &opts);

--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -1,17 +1,17 @@
 // Samples used in the README.  Wanna make sure they work as advertised.
 
 fn small() {
-    use comrak::{markdown_to_html, ComrakOptions};
+    use comrak::{markdown_to_html, Options};
 
     assert_eq!(
-        markdown_to_html("Hello, **世界**!", &ComrakOptions::default()),
+        markdown_to_html("Hello, **世界**!", &Options::default()),
         "<p>Hello, <strong>世界</strong>!</p>\n"
     );
 }
 
 fn large() {
     use comrak::nodes::{AstNode, NodeValue};
-    use comrak::{format_html, parse_document, Arena, ComrakOptions};
+    use comrak::{format_html, parse_document, Arena, Options};
 
     // The returned nodes are created in the supplied Arena, and are bound by its lifetime.
     let arena = Arena::new();
@@ -19,7 +19,7 @@ fn large() {
     let root = parse_document(
         &arena,
         "This is my input.\n\n1. Also my input.\n2. Certainly my input.\n",
-        &ComrakOptions::default(),
+        &Options::default(),
     );
 
     fn iter_nodes<'a, F>(node: &'a AstNode<'a>, f: &F)
@@ -40,7 +40,7 @@ fn large() {
     });
 
     let mut html = vec![];
-    format_html(root, &ComrakOptions::default(), &mut html).unwrap();
+    format_html(root, &Options::default(), &mut html).unwrap();
 
     assert_eq!(
         String::from_utf8(html).unwrap(),

--- a/examples/syntax_highlighter.rs
+++ b/examples/syntax_highlighter.rs
@@ -1,7 +1,7 @@
 //! This example shows how to implement a syntax highlighter plugin.
 
 use comrak::adapters::SyntaxHighlighterAdapter;
-use comrak::{markdown_to_html_with_plugins, ComrakOptions, ComrakPlugins};
+use comrak::{markdown_to_html_with_plugins, Options, Plugins};
 use std::collections::HashMap;
 use std::io::{self, Write};
 
@@ -59,8 +59,8 @@ impl SyntaxHighlighterAdapter for PotatoSyntaxAdapter {
 
 fn main() {
     let adapter = PotatoSyntaxAdapter::new(42);
-    let options = ComrakOptions::default();
-    let mut plugins = ComrakPlugins::default();
+    let options = Options::default();
+    let mut plugins = Plugins::default();
 
     plugins.render.codefence_syntax_highlighter = Some(&adapter);
 

--- a/examples/syntect.rs
+++ b/examples/syntect.rs
@@ -1,12 +1,12 @@
 //! This example shows how to use the bundled syntect plugin.
 
 use comrak::plugins::syntect::SyntectAdapter;
-use comrak::{markdown_to_html_with_plugins, ComrakOptions, ComrakPlugins};
+use comrak::{markdown_to_html_with_plugins, Options, Plugins};
 
 fn main() {
     let adapter = SyntectAdapter::new("base16-ocean.dark");
-    let options = ComrakOptions::default();
-    let mut plugins = ComrakPlugins::default();
+    let options = Options::default();
+    let mut plugins = Plugins::default();
 
     plugins.render.codefence_syntax_highlighter = Some(&adapter);
 

--- a/examples/update-readme.rs
+++ b/examples/update-readme.rs
@@ -1,10 +1,10 @@
-// Update the "comrak --help" text in Comrak's own README.
+// Update the "comrak --help" text in 's own README.
 
 use std::fmt::Write;
 use std::str;
 
 use comrak::nodes::{AstNode, NodeValue};
-use comrak::{format_commonmark, parse_document, Arena, ComrakOptions};
+use comrak::{format_commonmark, parse_document, Arena, Options};
 
 const DEPENDENCIES: &str = "[dependencies]\ncomrak = ";
 const HELP: &str = "$ comrak --help\n";
@@ -13,7 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     let arena = Arena::new();
 
     let readme = std::fs::read_to_string("README.md")?;
-    let doc = parse_document(&arena, &readme, &ComrakOptions::default());
+    let doc = parse_document(&arena, &readme, &Options::default());
 
     fn iter_nodes<'a, F>(node: &'a AstNode<'a>, f: &F)
     where
@@ -56,7 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     });
 
     let mut out = vec![];
-    format_commonmark(doc, &ComrakOptions::default(), &mut out).unwrap();
+    format_commonmark(doc, &Options::default(), &mut out).unwrap();
 
     std::fs::write("README.md", &out)?;
 

--- a/examples/update-readme.rs
+++ b/examples/update-readme.rs
@@ -1,4 +1,4 @@
-// Update the "comrak --help" text in 's own README.
+// Update the "comrak --help" text in Comrak's own README.
 
 use std::fmt::Write;
 use std::str;

--- a/fuzz/fuzz_targets/all_options.rs
+++ b/fuzz/fuzz_targets/all_options.rs
@@ -3,15 +3,15 @@
 use libfuzzer_sys::fuzz_target;
 
 use comrak::{
-    markdown_to_html, ComrakExtensionOptions, ComrakOptions, ComrakParseOptions,
-    ComrakRenderOptions, ListStyleType,
+    markdown_to_html, ExtensionOptions, Options, ParseOptions,
+    RenderOptions, ListStyleType,
 };
 
 fuzz_target!(|s: &str| {
     markdown_to_html(
         s,
-        &ComrakOptions {
-            extension: ComrakExtensionOptions {
+        &Options {
+            extension: ExtensionOptions {
                 strikethrough: true,
                 tagfilter: true,
                 table: true,
@@ -24,12 +24,12 @@ fuzz_target!(|s: &str| {
                 front_matter_delimiter: Some("---".to_string()),
                 shortcodes: true,
             },
-            parse: ComrakParseOptions {
+            parse: ParseOptions {
                 smart: true,
                 default_info_string: Some("rust".to_string()),
                 relaxed_tasklist_matching: true,
             },
-            render: ComrakRenderOptions {
+            render: RenderOptions {
                 hardbreaks: true,
                 github_pre_lang: true,
                 full_info_string: true,

--- a/fuzz/fuzz_targets/cli_default.rs
+++ b/fuzz/fuzz_targets/cli_default.rs
@@ -3,16 +3,16 @@
 use libfuzzer_sys::fuzz_target;
 
 use comrak::{
-    markdown_to_html_with_plugins, plugins::syntect::SyntectAdapter, ComrakPlugins,
-    ComrakRenderPlugins,
+    markdown_to_html_with_plugins, plugins::syntect::SyntectAdapter, Plugins,
+    RenderPlugins,
 };
 
 // Note that we end up fuzzing Syntect here.
 
 fuzz_target!(|s: &str| {
     let adapter = SyntectAdapter::new("base16-ocean.dark");
-    let plugins = ComrakPlugins {
-        render: ComrakRenderPlugins {
+    let plugins = Plugins {
+        render: RenderPlugins {
             codefence_syntax_highlighter: Some(&adapter),
             ..Default::default()
         },

--- a/fuzz/fuzz_targets/fuzz_options.rs
+++ b/fuzz/fuzz_targets/fuzz_options.rs
@@ -2,12 +2,12 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use comrak::{markdown_to_html, ComrakOptions};
+use comrak::{markdown_to_html, Options};
 
 #[derive(Debug, arbitrary::Arbitrary)]
 struct FuzzInput<'s> {
     s: &'s str,
-    opts: ComrakOptions,
+    opts: Options,
 }
 
 fuzz_target!(|i: FuzzInput| {

--- a/fuzz/fuzz_targets/gfm.rs
+++ b/fuzz/fuzz_targets/gfm.rs
@@ -2,7 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use comrak::{markdown_to_html, ComrakExtensionOptions, ComrakOptions, ComrakRenderOptions};
+use comrak::{markdown_to_html, ExtensionOptions, Options, RenderOptions};
 
 // Note that what I'm targetting here isn't exactly the same
 // as --gfm, but rather an approximation of what cmark-gfm
@@ -11,8 +11,8 @@ use comrak::{markdown_to_html, ComrakExtensionOptions, ComrakOptions, ComrakRend
 fuzz_target!(|s: &str| {
     markdown_to_html(
         s,
-        &ComrakOptions {
-            extension: ComrakExtensionOptions {
+        &Options {
+            extension: ExtensionOptions {
                 strikethrough: true,
                 tagfilter: true,
                 table: true,
@@ -20,7 +20,7 @@ fuzz_target!(|s: &str| {
                 ..Default::default()
             },
             parse: Default::default(),
-            render: ComrakRenderOptions {
+            render: RenderOptions {
                 hardbreaks: true,
                 github_pre_lang: true,
                 unsafe_: true,

--- a/fuzz/fuzz_targets/gfm_footnotes.rs
+++ b/fuzz/fuzz_targets/gfm_footnotes.rs
@@ -2,7 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use comrak::{markdown_to_html, ComrakExtensionOptions, ComrakOptions, ComrakRenderOptions};
+use comrak::{markdown_to_html, ExtensionOptions, Options, RenderOptions};
 
 // Note that what I'm targetting here isn't exactly the same
 // as --gfm, but rather an approximation of what cmark-gfm
@@ -11,8 +11,8 @@ use comrak::{markdown_to_html, ComrakExtensionOptions, ComrakOptions, ComrakRend
 fuzz_target!(|s: &str| {
     markdown_to_html(
         s,
-        &ComrakOptions {
-            extension: ComrakExtensionOptions {
+        &Options {
+            extension: ExtensionOptions {
                 strikethrough: true,
                 tagfilter: true,
                 table: true,
@@ -21,7 +21,7 @@ fuzz_target!(|s: &str| {
                 ..Default::default()
             },
             parse: Default::default(),
-            render: ComrakRenderOptions {
+            render: RenderOptions {
                 hardbreaks: true,
                 github_pre_lang: true,
                 unsafe_: true,

--- a/fuzz/fuzz_targets/gfm_sourcepos.rs
+++ b/fuzz/fuzz_targets/gfm_sourcepos.rs
@@ -2,7 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use comrak::{markdown_to_html, ComrakExtensionOptions, ComrakOptions, ComrakRenderOptions};
+use comrak::{markdown_to_html, ExtensionOptions, Options, RenderOptions};
 
 // Note that what I'm targetting here isn't exactly the same
 // as --gfm, but rather an approximation of what cmark-gfm
@@ -11,8 +11,8 @@ use comrak::{markdown_to_html, ComrakExtensionOptions, ComrakOptions, ComrakRend
 fuzz_target!(|s: &str| {
     markdown_to_html(
         s,
-        &ComrakOptions {
-            extension: ComrakExtensionOptions {
+        &Options {
+            extension: ExtensionOptions {
                 strikethrough: true,
                 tagfilter: true,
                 table: true,
@@ -20,7 +20,7 @@ fuzz_target!(|s: &str| {
                 ..Default::default()
             },
             parse: Default::default(),
-            render: ComrakRenderOptions {
+            render: RenderOptions {
                 hardbreaks: true,
                 github_pre_lang: true,
                 unsafe_: true,

--- a/fuzz/fuzz_targets/quadratic.rs
+++ b/fuzz/fuzz_targets/quadratic.rs
@@ -2,8 +2,8 @@
 #![feature(int_roundings)]
 #![no_main]
 use comrak::{
-    markdown_to_html, ComrakExtensionOptions, ComrakOptions, ComrakParseOptions,
-    ComrakRenderOptions, ListStyleType,
+    markdown_to_html, ExtensionOptions, Options, ParseOptions,
+    RenderOptions, ListStyleType,
 };
 use libfuzzer_sys::arbitrary::{self, Arbitrary};
 use libfuzzer_sys::fuzz_target;
@@ -165,15 +165,15 @@ impl Markdown {
 }
 
 #[derive(Arbitrary, Debug)]
-struct FuzzComrakOptions {
-    extension: FuzzComrakExtensionOptions,
-    parse: FuzzComrakParseOptions,
-    render: FuzzComrakRenderOptions,
+struct FuzzOptions {
+    extension: FuzzExtensionOptions,
+    parse: FuzzParseOptions,
+    render: FuzzRenderOptions,
 }
 
-impl FuzzComrakOptions {
-    fn to_options(&self) -> ComrakOptions {
-        ComrakOptions {
+impl FuzzOptions {
+    fn to_options(&self) -> Options {
+        Options {
             extension: self.extension.to_options(),
             parse: self.parse.to_options(),
             render: self.render.to_options(),
@@ -182,7 +182,7 @@ impl FuzzComrakOptions {
 }
 
 #[derive(Arbitrary, Debug)]
-struct FuzzComrakExtensionOptions {
+struct FuzzExtensionOptions {
     strikethrough: bool,
     tagfilter: bool,
     table: bool,
@@ -194,9 +194,9 @@ struct FuzzComrakExtensionOptions {
     shortcodes: bool,
 }
 
-impl FuzzComrakExtensionOptions {
-    fn to_options(&self) -> ComrakExtensionOptions {
-        ComrakExtensionOptions {
+impl FuzzExtensionOptions {
+    fn to_options(&self) -> ExtensionOptions {
+        ExtensionOptions {
             strikethrough: self.strikethrough,
             tagfilter: self.tagfilter,
             table: self.table,
@@ -213,14 +213,14 @@ impl FuzzComrakExtensionOptions {
 }
 
 #[derive(Arbitrary, Debug)]
-struct FuzzComrakParseOptions {
+struct FuzzParseOptions {
     smart: bool,
     relaxed_tasklist_matching: bool,
 }
 
-impl FuzzComrakParseOptions {
-    fn to_options(&self) -> ComrakParseOptions {
-        ComrakParseOptions {
+impl FuzzParseOptions {
+    fn to_options(&self) -> ParseOptions {
+        ParseOptions {
             smart: self.smart,
             default_info_string: None,
             relaxed_tasklist_matching: self.relaxed_tasklist_matching,
@@ -229,7 +229,7 @@ impl FuzzComrakParseOptions {
 }
 
 #[derive(Arbitrary, Debug)]
-struct FuzzComrakRenderOptions {
+struct FuzzRenderOptions {
     hardbreaks: bool,
     github_pre_lang: bool,
     full_info_string: bool,
@@ -240,9 +240,9 @@ struct FuzzComrakRenderOptions {
     sourcepos: bool,
 }
 
-impl FuzzComrakRenderOptions {
-    fn to_options(&self) -> ComrakRenderOptions {
-        ComrakRenderOptions {
+impl FuzzRenderOptions {
+    fn to_options(&self) -> RenderOptions {
+        RenderOptions {
             hardbreaks: self.hardbreaks,
             github_pre_lang: self.github_pre_lang,
             full_info_string: self.full_info_string,
@@ -260,7 +260,7 @@ impl FuzzComrakRenderOptions {
 /// parsing options.
 #[derive(Arbitrary, Debug)]
 struct Input {
-    options: FuzzComrakOptions,
+    options: FuzzOptions,
     markdown: Markdown,
 }
 

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -6,10 +6,10 @@ use crate::nodes::{
 };
 #[cfg(feature = "shortcodes")]
 use crate::parser::shortcodes::NodeShortCode;
-use crate::parser::ComrakOptions;
+use crate::parser::Options;
 use crate::scanners;
 use crate::strings::trim_start_match;
-use crate::{nodes, ComrakPlugins};
+use crate::{nodes, Plugins};
 
 use std::cmp::max;
 use std::io::{self, Write};
@@ -17,18 +17,18 @@ use std::io::{self, Write};
 /// Formats an AST as CommonMark, modified by the given options.
 pub fn format_document<'a>(
     root: &'a AstNode<'a>,
-    options: &ComrakOptions,
+    options: &Options,
     output: &mut dyn Write,
 ) -> io::Result<()> {
-    format_document_with_plugins(root, options, output, &ComrakPlugins::default())
+    format_document_with_plugins(root, options, output, &Plugins::default())
 }
 
 /// Formats an AST as CommonMark, modified by the given options. Accepts custom plugins.
 pub fn format_document_with_plugins<'a>(
     root: &'a AstNode<'a>,
-    options: &ComrakOptions,
+    options: &Options,
     output: &mut dyn Write,
-    _plugins: &ComrakPlugins,
+    _plugins: &Plugins,
 ) -> io::Result<()> {
     let mut f = CommonMarkFormatter::new(root, options);
     f.format(root);
@@ -41,7 +41,7 @@ pub fn format_document_with_plugins<'a>(
 
 struct CommonMarkFormatter<'a, 'o> {
     node: &'a AstNode<'a>,
-    options: &'o ComrakOptions,
+    options: &'o Options,
     v: Vec<u8>,
     prefix: Vec<u8>,
     column: usize,
@@ -75,7 +75,7 @@ impl<'a, 'o> Write for CommonMarkFormatter<'a, 'o> {
 }
 
 impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
-    fn new(node: &'a AstNode<'a>, options: &'o ComrakOptions) -> Self {
+    fn new(node: &'a AstNode<'a>, options: &'o Options) -> Self {
         CommonMarkFormatter {
             node,
             options,

--- a/src/html.rs
+++ b/src/html.rs
@@ -3,7 +3,7 @@ use crate::ctype::isspace;
 use crate::nodes::{
     AstNode, ListType, NodeCode, NodeFootnoteDefinition, NodeValue, TableAlignment,
 };
-use crate::parser::{ComrakOptions, ComrakPlugins};
+use crate::parser::{Options, Plugins};
 use crate::scanners;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -18,18 +18,18 @@ use crate::adapters::HeadingMeta;
 /// Formats an AST as HTML, modified by the given options.
 pub fn format_document<'a>(
     root: &'a AstNode<'a>,
-    options: &ComrakOptions,
+    options: &Options,
     output: &mut dyn Write,
 ) -> io::Result<()> {
-    format_document_with_plugins(root, options, output, &ComrakPlugins::default())
+    format_document_with_plugins(root, options, output, &Plugins::default())
 }
 
 /// Formats an AST as HTML, modified by the given options. Accepts custom plugins.
 pub fn format_document_with_plugins<'a>(
     root: &'a AstNode<'a>,
-    options: &ComrakOptions,
+    options: &Options,
     output: &mut dyn Write,
-    plugins: &ComrakPlugins,
+    plugins: &Plugins,
 ) -> io::Result<()> {
     let mut writer = WriteWithLast {
         output,
@@ -131,11 +131,11 @@ impl Anchorizer {
 
 struct HtmlFormatter<'o> {
     output: &'o mut WriteWithLast<'o>,
-    options: &'o ComrakOptions,
+    options: &'o Options,
     anchorizer: Anchorizer,
     footnote_ix: u32,
     written_footnote_ix: u32,
-    plugins: &'o ComrakPlugins<'o>,
+    plugins: &'o Plugins<'o>,
 }
 
 #[rustfmt::skip]
@@ -365,11 +365,7 @@ where
 }
 
 impl<'o> HtmlFormatter<'o> {
-    fn new(
-        options: &'o ComrakOptions,
-        output: &'o mut WriteWithLast<'o>,
-        plugins: &'o ComrakPlugins,
-    ) -> Self {
+    fn new(options: &'o Options, output: &'o mut WriteWithLast<'o>, plugins: &'o Plugins) -> Self {
         HtmlFormatter {
             options,
             output,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@
 //! You can use `comrak::markdown_to_html` directly:
 //!
 //! ```
-//! use comrak::{markdown_to_html, ComrakOptions};
-//! assert_eq!(markdown_to_html("Hello, **世界**!", &ComrakOptions::default()),
+//! use comrak::{markdown_to_html, Options};
+//! assert_eq!(markdown_to_html("Hello, **世界**!", &Options::default()),
 //!            "<p>Hello, <strong>世界</strong>!</p>\n");
 //! ```
 //!
@@ -16,7 +16,7 @@
 //! formatter:
 //!
 //! ```
-//! use comrak::{Arena, parse_document, format_html, ComrakOptions};
+//! use comrak::{Arena, parse_document, format_html, Options};
 //! use comrak::nodes::{AstNode, NodeValue};
 //!
 //! # fn main() {
@@ -26,7 +26,7 @@
 //! let root = parse_document(
 //!     &arena,
 //!     "This is my input.\n\n1. Also my input.\n2. Certainly my input.\n",
-//!     &ComrakOptions::default());
+//!     &Options::default());
 //!
 //! fn iter_nodes<'a, F>(node: &'a AstNode<'a>, f: &F)
 //!     where F : Fn(&'a AstNode<'a>) {
@@ -47,7 +47,7 @@
 //! });
 //!
 //! let mut html = vec![];
-//! format_html(root, &ComrakOptions::default(), &mut html).unwrap();
+//! format_html(root, &Options::default(), &mut html).unwrap();
 //!
 //! assert_eq!(
 //!     String::from_utf8(html).unwrap(),
@@ -100,29 +100,37 @@ pub use html::format_document as format_html;
 pub use html::format_document_with_plugins as format_html_with_plugins;
 pub use html::Anchorizer;
 pub use parser::{
-    parse_document, parse_document_with_broken_link_callback, ComrakExtensionOptions,
-    ComrakOptions, ComrakParseOptions, ComrakPlugins, ComrakRenderOptions, ComrakRenderPlugins,
-    ListStyleType,
+    parse_document, parse_document_with_broken_link_callback, ExtensionOptions, ListStyleType,
+    Options, ParseOptions, Plugins, RenderOptions, RenderPlugins,
 };
 pub use typed_arena::Arena;
 pub use xml::format_document as format_xml;
 pub use xml::format_document_with_plugins as format_xml_with_plugins;
 
+/// Legacy naming of [`ExtensionOptions`]
+pub type ComrakExtensionOptions = ExtensionOptions;
+/// Legacy naming of [`Options`]
+pub type ComrakOptions = Options;
+/// Legacy naming of [`ParseOptions`]
+pub type ComrakParseOptions = ParseOptions;
+/// Legacy naming of [`Plugins`]
+pub type ComrakPlugins<'a> = Plugins<'a>;
+/// Legacy naming of [`RenderOptions`]
+pub type ComrakRenderOptions = RenderOptions;
+/// Legacy naming of [`RenderPlugins`]
+pub type ComrakRenderPlugins<'a> = RenderPlugins<'a>;
+
 /// Render Markdown to HTML.
 ///
 /// See the documentation of the crate root for an example.
-pub fn markdown_to_html(md: &str, options: &ComrakOptions) -> String {
-    markdown_to_html_with_plugins(md, options, &ComrakPlugins::default())
+pub fn markdown_to_html(md: &str, options: &Options) -> String {
+    markdown_to_html_with_plugins(md, options, &Plugins::default())
 }
 
 /// Render Markdown to HTML using plugins.
 ///
 /// See the documentation of the crate root for an example.
-pub fn markdown_to_html_with_plugins(
-    md: &str,
-    options: &ComrakOptions,
-    plugins: &ComrakPlugins,
-) -> String {
+pub fn markdown_to_html_with_plugins(md: &str, options: &Options, plugins: &Plugins) -> String {
     let arena = Arena::new();
     let root = parse_document(&arena, md, options);
     let mut bw = BufWriter::new(Vec::new());
@@ -136,7 +144,7 @@ pub fn version() -> &'static str {
 }
 
 /// Render Markdown back to CommonMark.
-pub fn markdown_to_commonmark(md: &str, options: &ComrakOptions) -> String {
+pub fn markdown_to_commonmark(md: &str, options: &Options) -> String {
     let arena = Arena::new();
     let root = parse_document(&arena, md, options);
     let mut bw = BufWriter::new(Vec::new());
@@ -146,16 +154,16 @@ pub fn markdown_to_commonmark(md: &str, options: &ComrakOptions) -> String {
 
 /// Render Markdown to CommonMark XML.
 /// See https://github.com/commonmark/commonmark-spec/blob/master/CommonMark.dtd.
-pub fn markdown_to_commonmark_xml(md: &str, options: &ComrakOptions) -> String {
-    markdown_to_commonmark_xml_with_plugins(md, options, &ComrakPlugins::default())
+pub fn markdown_to_commonmark_xml(md: &str, options: &Options) -> String {
+    markdown_to_commonmark_xml_with_plugins(md, options, &Plugins::default())
 }
 
 /// Render Markdown to CommonMark XML using plugins.
 /// See https://github.com/commonmark/commonmark-spec/blob/master/CommonMark.dtd.
 pub fn markdown_to_commonmark_xml_with_plugins(
     md: &str,
-    options: &ComrakOptions,
-    plugins: &ComrakPlugins,
+    options: &Options,
+    plugins: &Plugins,
 ) -> String {
     let arena = Arena::new();
     let root = parse_document(&arena, md, options);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
 //! The `comrak` binary.
 
 use comrak::{
-    adapters::SyntaxHighlighterAdapter, plugins::syntect::SyntectAdapter, Arena,
-    ComrakExtensionOptions, ComrakOptions, ComrakParseOptions, ComrakPlugins, ComrakRenderOptions,
-    ListStyleType,
+    adapters::SyntaxHighlighterAdapter, plugins::syntect::SyntectAdapter, Arena, ExtensionOptions,
+    ListStyleType, Options, ParseOptions, Plugins, RenderOptions,
 };
 use std::boxed::Box;
 use std::env;
@@ -195,8 +194,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let exts = &cli.extensions;
 
-    let options = ComrakOptions {
-        extension: ComrakExtensionOptions {
+    let options = Options {
+        extension: ExtensionOptions {
             strikethrough: exts.contains(&Extension::Strikethrough) || cli.gfm,
             tagfilter: exts.contains(&Extension::Tagfilter) || cli.gfm,
             table: exts.contains(&Extension::Table) || cli.gfm,
@@ -210,12 +209,12 @@ fn main() -> Result<(), Box<dyn Error>> {
             #[cfg(feature = "shortcodes")]
             shortcodes: cli.gemojis,
         },
-        parse: ComrakParseOptions {
+        parse: ParseOptions {
             smart: cli.smart,
             default_info_string: cli.default_info_string,
             relaxed_tasklist_matching: cli.relaxed_tasklist_character,
         },
-        render: ComrakRenderOptions {
+        render: RenderOptions {
             hardbreaks: cli.hardbreaks,
             github_pre_lang: cli.github_pre_lang || cli.gfm,
             full_info_string: cli.full_info_string,
@@ -228,7 +227,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
 
     let syntax_highlighter: Option<&dyn SyntaxHighlighterAdapter>;
-    let mut plugins: ComrakPlugins = ComrakPlugins::default();
+    let mut plugins: Plugins = Plugins::default();
     let adapter: SyntectAdapter;
 
     let theme = cli.syntax_highlighting;

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -111,7 +111,7 @@ pub enum NodeValue {
     TaskItem(Option<char>),
 
     /// **Inline**.  A [soft line break](https://github.github.com/gfm/#soft-line-breaks).  If
-    /// the `hardbreaks` option is set in `ComrakOptions` during formatting, it will be formatted
+    /// the `hardbreaks` option is set in `Options` during formatting, it will be formatted
     /// as a `LineBreak`.
     SoftBreak,
 

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -4,9 +4,7 @@ use crate::entity;
 use crate::nodes::{Ast, AstNode, NodeCode, NodeFootnoteReference, NodeLink, NodeValue, Sourcepos};
 #[cfg(feature = "shortcodes")]
 use crate::parser::shortcodes::NodeShortCode;
-use crate::parser::{
-    unwrap_into_2, unwrap_into_copy, AutolinkType, Callback, ComrakOptions, Reference,
-};
+use crate::parser::{unwrap_into_2, unwrap_into_copy, AutolinkType, Callback, Options, Reference};
 use crate::scanners;
 use crate::strings;
 use crate::strings::Case;
@@ -23,7 +21,7 @@ const MAX_LINK_LABEL_LENGTH: usize = 1000;
 
 pub struct Subject<'a: 'd, 'r, 'o, 'd, 'i, 'c: 'subj, 'subj> {
     pub arena: &'a Arena<AstNode<'a>>,
-    options: &'o ComrakOptions,
+    options: &'o Options,
     pub input: &'i [u8],
     line: usize,
     pub pos: usize,
@@ -107,7 +105,7 @@ struct Bracket<'a> {
 impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
     pub fn new(
         arena: &'a Arena<AstNode<'a>>,
-        options: &'o ComrakOptions,
+        options: &'o Options,
         input: &'i [u8],
         line: usize,
         block_offset: usize,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -45,7 +45,7 @@ macro_rules! node_matches {
 pub fn parse_document<'a>(
     arena: &'a Arena<AstNode<'a>>,
     buffer: &str,
-    options: &ComrakOptions,
+    options: &Options,
 ) -> &'a AstNode<'a> {
     parse_document_with_broken_link_callback(arena, buffer, options, None)
 }
@@ -61,7 +61,7 @@ pub fn parse_document<'a>(
 /// described in the [GFM spec](https://github.github.com/gfm/#matches).
 ///
 /// ```
-/// use comrak::{Arena, parse_document_with_broken_link_callback, format_html, ComrakOptions};
+/// use comrak::{Arena, parse_document_with_broken_link_callback, format_html, Options};
 /// use comrak::nodes::{AstNode, NodeValue};
 ///
 /// # fn main() -> std::io::Result<()> {
@@ -71,7 +71,7 @@ pub fn parse_document<'a>(
 /// let root = parse_document_with_broken_link_callback(
 ///     &arena,
 ///     "# Cool input!\nWow look at this cool [link][foo]. A [broken link] renders as text.",
-///     &ComrakOptions::default(),
+///     &Options::default(),
 ///     Some(&mut |link_ref: &str| match link_ref {
 ///         "foo" => Some((
 ///             "https://www.rust-lang.org/".to_string(),
@@ -82,7 +82,7 @@ pub fn parse_document<'a>(
 /// );
 ///
 /// let mut output = Vec::new();
-/// format_html(root, &ComrakOptions::default(), &mut output)?;
+/// format_html(root, &Options::default(), &mut output)?;
 /// let output_str = std::str::from_utf8(&output).expect("invalid UTF-8");
 /// assert_eq!(output_str, "<h1>Cool input!</h1>\n<p>Wow look at this cool \
 ///                 <a href=\"https://www.rust-lang.org/\" title=\"The Rust Language\">link</a>. \
@@ -93,7 +93,7 @@ pub fn parse_document<'a>(
 pub fn parse_document_with_broken_link_callback<'a, 'c>(
     arena: &'a Arena<AstNode<'a>>,
     buffer: &str,
-    options: &ComrakOptions,
+    options: &Options,
     callback: Option<Callback<'c>>,
 ) -> &'a AstNode<'a> {
     let root: &'a AstNode<'a> = arena.alloc(Node::new(RefCell::new(Ast {
@@ -132,35 +132,35 @@ pub struct Parser<'a, 'o, 'c> {
     last_line_length: usize,
     last_buffer_ended_with_cr: bool,
     total_size: usize,
-    options: &'o ComrakOptions,
+    options: &'o Options,
     callback: Option<Callback<'c>>,
 }
 
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// Umbrella options struct.
-pub struct ComrakOptions {
+pub struct Options {
     /// Enable CommonMark extensions.
-    pub extension: ComrakExtensionOptions,
+    pub extension: ExtensionOptions,
 
     /// Configure parse-time options.
-    pub parse: ComrakParseOptions,
+    pub parse: ParseOptions,
 
     /// Configure render-time options.
-    pub render: ComrakRenderOptions,
+    pub render: RenderOptions,
 }
 
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// Options to select extensions.
-pub struct ComrakExtensionOptions {
+pub struct ExtensionOptions {
     /// Enables the
     /// [strikethrough extension](https://github.github.com/gfm/#strikethrough-extension-)
     /// from the GFM spec.
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// options.extension.strikethrough = true;
     /// assert_eq!(markdown_to_html("Hello ~world~ there.\n", &options),
     ///            "<p>Hello <del>world</del> there.</p>\n");
@@ -172,8 +172,8 @@ pub struct ComrakExtensionOptions {
     /// from the GFM spec.
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// options.extension.tagfilter = true;
     /// options.render.unsafe_ = true;
     /// assert_eq!(markdown_to_html("Hello <xmp>.\n\n<xmp>", &options),
@@ -185,8 +185,8 @@ pub struct ComrakExtensionOptions {
     /// from the GFM spec.
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// options.extension.table = true;
     /// assert_eq!(markdown_to_html("| a | b |\n|---|---|\n| c | d |\n", &options),
     ///            "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n\
@@ -198,8 +198,8 @@ pub struct ComrakExtensionOptions {
     /// from the GFM spec.
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// options.extension.autolink = true;
     /// assert_eq!(markdown_to_html("Hello www.github.com.\n", &options),
     ///            "<p>Hello <a href=\"http://www.github.com\">www.github.com</a>.</p>\n");
@@ -214,8 +214,8 @@ pub struct ComrakExtensionOptions {
     /// rendered.
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// options.extension.tasklist = true;
     /// options.render.unsafe_ = true;
     /// assert_eq!(markdown_to_html("* [x] Done\n* [ ] Not done\n", &options),
@@ -227,8 +227,8 @@ pub struct ComrakExtensionOptions {
     /// Enables the superscript Comrak extension.
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// options.extension.superscript = true;
     /// assert_eq!(markdown_to_html("e = mc^2^.\n", &options),
     ///            "<p>e = mc<sup>2</sup>.</p>\n");
@@ -238,8 +238,8 @@ pub struct ComrakExtensionOptions {
     /// Enables the header IDs Comrak extension.
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// options.extension.header_ids = Some("user-content-".to_string());
     /// assert_eq!(markdown_to_html("# README\n", &options),
     ///            "<h1><a href=\"#readme\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-readme\"></a>README</h1>\n");
@@ -252,8 +252,8 @@ pub struct ComrakExtensionOptions {
     /// [Kramdown](https://kramdown.gettalong.org/syntax.html#footnotes).
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// options.extension.footnotes = true;
     /// assert_eq!(markdown_to_html("Hi[^x].\n\n[^x]: A greeting.\n", &options),
     ///            "<p>Hi<sup class=\"footnote-ref\"><a href=\"#fn-x\" id=\"fnref-x\" data-footnote-ref>1</a></sup>.</p>\n<section class=\"footnotes\" data-footnotes>\n<ol>\n<li id=\"fn-x\">\n<p>A greeting. <a href=\"#fnref-x\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n</li>\n</ol>\n</section>\n");
@@ -280,8 +280,8 @@ pub struct ComrakExtensionOptions {
     /// ```
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// options.extension.description_lists = true;
     /// assert_eq!(markdown_to_html("Term\n\n: Definition", &options),
     ///            "<dl><dt>Term</dt>\n<dd>\n<p>Definition</p>\n</dd>\n</dl>\n");
@@ -306,18 +306,18 @@ pub struct ComrakExtensionOptions {
     /// ```
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// options.extension.front_matter_delimiter = Some("---".to_owned());
     /// assert_eq!(
     ///     markdown_to_html("---\nlayout: post\n---\nText\n", &options),
-    ///     markdown_to_html("Text\n", &ComrakOptions::default()));
+    ///     markdown_to_html("Text\n", &Options::default()));
     /// ```
     ///
     /// ```
-    /// # use comrak::{format_commonmark, Arena, ComrakOptions};
+    /// # use comrak::{format_commonmark, Arena, Options};
     /// use comrak::parse_document;
-    /// let mut options = ComrakOptions::default();
+    /// let mut options = Options::default();
     /// options.extension.front_matter_delimiter = Some("---".to_owned());
     /// let arena = Arena::new();
     /// let input ="---\nlayout: post\n---\nText\n";
@@ -333,8 +333,8 @@ pub struct ComrakExtensionOptions {
     /// Phrases wrapped inside of ':' blocks will be replaced with emojis.
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// assert_eq!(markdown_to_html("Happy Friday! :smile:", &options),
     ///            "<p>Happy Friday! :smile:</p>\n");
     ///
@@ -348,12 +348,12 @@ pub struct ComrakExtensionOptions {
 #[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// Options for parser functions.
-pub struct ComrakParseOptions {
+pub struct ParseOptions {
     /// Punctuation (quotes, full-stops and hyphens) are converted into 'smart' punctuation.
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// assert_eq!(markdown_to_html("'Hello,' \"world\" ...", &options),
     ///            "<p>'Hello,' &quot;world&quot; ...</p>\n");
     ///
@@ -366,8 +366,8 @@ pub struct ComrakParseOptions {
     /// The default info string for fenced code blocks.
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// assert_eq!(markdown_to_html("```\nfn hello();\n```\n", &options),
     ///            "<pre><code>fn hello();\n</code></pre>\n");
     ///
@@ -384,13 +384,13 @@ pub struct ComrakParseOptions {
 #[derive(Default, Debug, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// Options for formatter functions.
-pub struct ComrakRenderOptions {
+pub struct RenderOptions {
     /// [Soft line breaks](http://spec.commonmark.org/0.27/#soft-line-breaks) in the input
     /// translate into hard line breaks in the output.
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// assert_eq!(markdown_to_html("Hello.\nWorld.\n", &options),
     ///            "<p>Hello.\nWorld.</p>\n");
     ///
@@ -403,8 +403,8 @@ pub struct ComrakRenderOptions {
     /// GitHub-style `<pre lang="xyz">` is used for fenced code blocks with info tags.
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// assert_eq!(markdown_to_html("``` rust\nfn hello();\n```\n", &options),
     ///            "<pre><code class=\"language-rust\">fn hello();\n</code></pre>\n");
     ///
@@ -417,8 +417,8 @@ pub struct ComrakRenderOptions {
     /// Enable full info strings for code blocks
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// assert_eq!(markdown_to_html("``` rust extra info\nfn hello();\n```\n", &options),
     ///            "<pre><code class=\"language-rust\">fn hello();\n</code></pre>\n");
     ///
@@ -432,10 +432,10 @@ pub struct ComrakRenderOptions {
     /// The wrap column when outputting CommonMark.
     ///
     /// ```
-    /// # use comrak::{parse_document, ComrakOptions, format_commonmark};
+    /// # use comrak::{parse_document, Options, format_commonmark};
     /// # fn main() {
     /// # let arena = typed_arena::Arena::new();
-    /// let mut options = ComrakOptions::default();
+    /// let mut options = Options::default();
     /// let node = parse_document(&arena, "hello hello hello hello hello hello", &options);
     /// let mut output = vec![];
     /// format_commonmark(node, &options, &mut output).unwrap();
@@ -454,8 +454,8 @@ pub struct ComrakRenderOptions {
     /// Allow rendering of raw HTML and potentially dangerous links.
     ///
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// let input = "<script>\nalert('xyz');\n</script>\n\n\
     ///              Possibly <marquee>annoying</marquee>.\n\n\
     ///              [Dangerous](javascript:alert(document.cookie)).\n\n\
@@ -478,8 +478,8 @@ pub struct ComrakRenderOptions {
 
     /// Escape raw HTML instead of clobbering it.
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
     /// let input = "<i>italic text</i>";
     ///
     /// assert_eq!(markdown_to_html(input, &options),
@@ -498,8 +498,8 @@ pub struct ComrakRenderOptions {
     /// * `ListStyleType::Star` to use `*`
     ///
     /// ```rust
-    /// # use comrak::{markdown_to_commonmark, ComrakOptions, ListStyleType};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_commonmark, Options, ListStyleType};
+    /// let mut options = Options::default();
     /// let input = "- one\n- two\n- three";
     /// assert_eq!(markdown_to_commonmark(input, &options),
     ///            "- one\n- two\n- three\n"); // default is Dash
@@ -519,8 +519,8 @@ pub struct ComrakRenderOptions {
     /// Not yet compatible with extension.description_lists.
     ///
     /// ```rust
-    /// # use comrak::{markdown_to_commonmark_xml, ComrakOptions};
-    /// let mut options = ComrakOptions::default();
+    /// # use comrak::{markdown_to_commonmark_xml, Options};
+    /// let mut options = Options::default();
     /// options.render.sourcepos = true;
     /// let input = "Hello *world*!";
     /// let xml = markdown_to_commonmark_xml(input, &options);
@@ -531,23 +531,23 @@ pub struct ComrakRenderOptions {
 
 #[derive(Default, Debug)]
 /// Umbrella plugins struct.
-pub struct ComrakPlugins<'p> {
+pub struct Plugins<'p> {
     /// Configure render-time plugins.
-    pub render: ComrakRenderPlugins<'p>,
+    pub render: RenderPlugins<'p>,
 }
 
 #[derive(Default)]
 /// Plugins for alternative rendering.
-pub struct ComrakRenderPlugins<'p> {
+pub struct RenderPlugins<'p> {
     /// Provide a syntax highlighter adapter implementation for syntax
     /// highlighting of codefence blocks.
     /// ```
-    /// # use comrak::{markdown_to_html, ComrakOptions, ComrakPlugins, markdown_to_html_with_plugins};
+    /// # use comrak::{markdown_to_html, Options, Plugins, markdown_to_html_with_plugins};
     /// # use comrak::adapters::SyntaxHighlighterAdapter;
     /// use std::collections::HashMap;
     /// use std::io::{self, Write};
-    /// let options = ComrakOptions::default();
-    /// let mut plugins = ComrakPlugins::default();
+    /// let options = Options::default();
+    /// let mut plugins = Plugins::default();
     /// let input = "```rust\nfn main<'a>();\n```";
     ///
     /// assert_eq!(markdown_to_html_with_plugins(input, &options, &plugins),
@@ -580,9 +580,9 @@ pub struct ComrakRenderPlugins<'p> {
     pub heading_adapter: Option<&'p dyn HeadingAdapter>,
 }
 
-impl Debug for ComrakRenderPlugins<'_> {
+impl Debug for RenderPlugins<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ComrakRenderPlugins")
+        f.debug_struct("RenderPlugins")
             .field(
                 "codefence_syntax_highlighter",
                 &"impl SyntaxHighlighterAdapter",
@@ -608,7 +608,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
     fn new(
         arena: &'a Arena<AstNode<'a>>,
         root: &'a AstNode<'a>,
-        options: &'o ComrakOptions,
+        options: &'o Options,
         callback: Option<Callback<'c>>,
     ) -> Self {
         Parser {
@@ -2212,7 +2212,7 @@ pub enum AutolinkType {
 
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-/// Options for bulleted list redering in markdown. See `link_style` in [ComrakRenderOptions] for more details.
+/// Options for bulleted list redering in markdown. See `link_style` in [RenderOptions] for more details.
 pub enum ListStyleType {
     /// The `-` character
     Dash = 45,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -42,9 +42,9 @@ fn compare_strs(output: &str, expected: &str, kind: &str) {
 }
 
 #[track_caller]
-fn commonmark(input: &str, expected: &str, opts: Option<&ComrakOptions>) {
+fn commonmark(input: &str, expected: &str, opts: Option<&Options>) {
     let arena = Arena::new();
-    let defaults = ComrakOptions::default();
+    let defaults = Options::default();
     let options = opts.unwrap_or(&defaults);
 
     let root = parse_document(&arena, input, options);
@@ -61,16 +61,16 @@ pub fn html(input: &str, expected: &str) {
 #[track_caller]
 fn html_opts_i<F>(input: &str, expected: &str, opts: F)
 where
-    F: Fn(&mut ComrakOptions),
+    F: Fn(&mut Options),
 {
-    let mut options = ComrakOptions::default();
+    let mut options = Options::default();
     opts(&mut options);
 
     html_opts_w(input, expected, &options);
 }
 
 #[track_caller]
-fn html_opts_w(input: &str, expected: &str, options: &ComrakOptions) {
+fn html_opts_w(input: &str, expected: &str, options: &Options) {
     let arena = Arena::new();
 
     let root = parse_document(&arena, input, &options);
@@ -104,8 +104,8 @@ macro_rules! html_opts {
         });
     };
     ([all], $lhs:expr, $rhs:expr) => {
-        $crate::tests::html_opts_w($lhs, $rhs, &$crate::ComrakOptions {
-            extension: $crate::ComrakExtensionOptions {
+        $crate::tests::html_opts_w($lhs, $rhs, &$crate::Options {
+            extension: $crate::ExtensionOptions {
                 strikethrough: true,
                 tagfilter: true,
                 table: true,
@@ -118,12 +118,12 @@ macro_rules! html_opts {
                 front_matter_delimiter: Some("---".to_string()),
                 shortcodes: true,
             },
-            parse: $crate::ComrakParseOptions {
+            parse: $crate::ParseOptions {
                 smart: true,
                 default_info_string: Some("rust".to_string()),
                 relaxed_tasklist_matching: true,
             },
-            render: $crate::ComrakRenderOptions {
+            render: $crate::RenderOptions {
                 hardbreaks: true,
                 github_pre_lang: true,
                 full_info_string: true,
@@ -140,9 +140,9 @@ macro_rules! html_opts {
 pub(crate) use html_opts;
 
 #[track_caller]
-fn html_plugins(input: &str, expected: &str, plugins: &ComrakPlugins) {
+fn html_plugins(input: &str, expected: &str, plugins: &Plugins) {
     let arena = Arena::new();
-    let options = ComrakOptions::default();
+    let options = Options::default();
 
     let root = parse_document(&arena, input, &options);
     let mut output = vec![];
@@ -173,10 +173,10 @@ fn xml(input: &str, expected: &str) {
 #[track_caller]
 fn xml_opts<F>(input: &str, expected: &str, opts: F)
 where
-    F: Fn(&mut ComrakOptions),
+    F: Fn(&mut Options),
 {
     let arena = Arena::new();
-    let mut options = ComrakOptions::default();
+    let mut options = Options::default();
     opts(&mut options);
 
     let root = parse_document(&arena, input, &options);
@@ -246,9 +246,9 @@ pub(crate) use ast;
 #[track_caller]
 fn assert_ast_match_i<F>(md: &str, amt: AstMatchTree, opts: F)
 where
-    F: Fn(&mut ComrakOptions),
+    F: Fn(&mut Options),
 {
-    let mut options = ComrakOptions::default();
+    let mut options = Options::default();
     options.render.sourcepos = true;
     opts(&mut options);
 

--- a/src/tests/api.rs
+++ b/src/tests/api.rs
@@ -8,8 +8,8 @@ use super::*;
 #[test]
 fn exercise_full_api() {
     let arena = Arena::new();
-    let default_options = ComrakOptions::default();
-    let default_plugins = ComrakPlugins::default();
+    let default_options = Options::default();
+    let default_plugins = Plugins::default();
     let node = parse_document(&arena, "# My document\n", &default_options);
     let mut buffer = vec![];
 
@@ -34,8 +34,8 @@ fn exercise_full_api() {
         Some(&mut |_: &str| Some(("abc".to_string(), "xyz".to_string()))),
     );
 
-    let _ = ComrakOptions {
-        extension: ComrakExtensionOptions {
+    let _ = Options {
+        extension: ExtensionOptions {
             strikethrough: false,
             tagfilter: false,
             table: false,
@@ -49,12 +49,12 @@ fn exercise_full_api() {
             #[cfg(feature = "shortcodes")]
             shortcodes: true,
         },
-        parse: ComrakParseOptions {
+        parse: ParseOptions {
             smart: false,
             default_info_string: Some("abc".to_string()),
             relaxed_tasklist_matching: true,
         },
-        render: ComrakRenderOptions {
+        render: RenderOptions {
             hardbreaks: false,
             github_pre_lang: false,
             full_info_string: false,
@@ -111,8 +111,8 @@ fn exercise_full_api() {
 
     let mock_adapter = MockAdapter {};
 
-    let _ = ComrakPlugins {
-        render: ComrakRenderPlugins {
+    let _ = Plugins {
+        render: RenderPlugins {
             codefence_syntax_highlighter: Some(&mock_adapter),
             heading_adapter: Some(&mock_adapter),
         },

--- a/src/tests/core.rs
+++ b/src/tests/core.rs
@@ -239,7 +239,7 @@ fn backticks_num() {
     let input = "Some `code1`. More ``` code2 ```.\n";
 
     let arena = Arena::new();
-    let options = ComrakOptions::default();
+    let options = Options::default();
     let root = parse_document(&arena, input, &options);
 
     let code1 = NodeValue::Code(NodeCode {

--- a/src/tests/options.rs
+++ b/src/tests/options.rs
@@ -5,11 +5,11 @@ fn markdown_list_bullets() {
     let dash = concat!("- a\n");
     let plus = concat!("+ a\n");
     let star = concat!("* a\n");
-    let mut dash_opts = ComrakOptions::default();
+    let mut dash_opts = Options::default();
     dash_opts.render.list_style = ListStyleType::Dash;
-    let mut plus_opts = ComrakOptions::default();
+    let mut plus_opts = Options::default();
     plus_opts.render.list_style = ListStyleType::Plus;
-    let mut star_opts = ComrakOptions::default();
+    let mut star_opts = Options::default();
     star_opts.render.list_style = ListStyleType::Star;
 
     commonmark(dash, dash, Some(&dash_opts));
@@ -27,7 +27,7 @@ fn markdown_list_bullets() {
 
 #[test]
 fn width_breaks() {
-    let mut options = ComrakOptions::default();
+    let mut options = Options::default();
     options.render.width = 72;
     let input = concat!(
         "this should break because it has breakable characters. break right here newline\n",

--- a/src/tests/plugins.rs
+++ b/src/tests/plugins.rs
@@ -42,7 +42,7 @@ fn syntax_highlighter_plugin() {
         "</code></pre>\n"
     );
 
-    let mut plugins = ComrakPlugins::default();
+    let mut plugins = Plugins::default();
     let adapter = MockAdapter {};
     plugins.render.codefence_syntax_highlighter = Some(&adapter);
 
@@ -68,7 +68,7 @@ fn heading_adapter_plugin() {
         }
     }
 
-    let mut plugins = ComrakPlugins::default();
+    let mut plugins = Plugins::default();
     let adapter = MockAdapter {};
     plugins.render.heading_adapter = Some(&adapter);
 
@@ -99,7 +99,7 @@ fn syntect_plugin() {
         "</code></pre>\n"
     );
 
-    let mut plugins = ComrakPlugins::default();
+    let mut plugins = Plugins::default();
     plugins.render.codefence_syntax_highlighter = Some(&adapter);
 
     html_plugins(input, expected, &plugins);

--- a/src/tests/propfuzz.rs
+++ b/src/tests/propfuzz.rs
@@ -6,8 +6,8 @@ use propfuzz::prelude::*;
 #[cfg(not(target_arch = "wasm32"))]
 #[propfuzz]
 fn propfuzz_doesnt_crash(md: String) {
-    let options = ComrakOptions {
-        extension: ComrakExtensionOptions {
+    let options = Options {
+        extension: ExtensionOptions {
             strikethrough: true,
             tagfilter: true,
             table: true,
@@ -21,12 +21,12 @@ fn propfuzz_doesnt_crash(md: String) {
             #[cfg(feature = "shortcodes")]
             shortcodes: true,
         },
-        parse: ComrakParseOptions {
+        parse: ParseOptions {
             smart: true,
             default_info_string: Some("Rust".to_string()),
             relaxed_tasklist_matching: true,
         },
-        render: ComrakRenderOptions {
+        render: RenderOptions {
             hardbreaks: true,
             github_pre_lang: true,
             full_info_string: true,

--- a/src/tests/regressions.rs
+++ b/src/tests/regressions.rs
@@ -81,18 +81,18 @@ fn no_panic_on_empty_bookended_atx_headers() {
 fn no_stack_smash_html() {
     let s: String = ">".repeat(150_000);
     let arena = Arena::new();
-    let root = parse_document(&arena, &s, &ComrakOptions::default());
+    let root = parse_document(&arena, &s, &Options::default());
     let mut output = vec![];
-    html::format_document(root, &ComrakOptions::default(), &mut output).unwrap()
+    html::format_document(root, &Options::default(), &mut output).unwrap()
 }
 
 #[test]
 fn no_stack_smash_cm() {
     let s: String = ">".repeat(150_000);
     let arena = Arena::new();
-    let root = parse_document(&arena, &s, &ComrakOptions::default());
+    let root = parse_document(&arena, &s, &Options::default());
     let mut output = vec![];
-    cm::format_document(root, &ComrakOptions::default(), &mut output).unwrap()
+    cm::format_document(root, &Options::default(), &mut output).unwrap()
 }
 
 #[test]

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -1,5 +1,5 @@
 use crate::nodes::{AstNode, ListType, NodeCode, NodeValue};
-use crate::parser::{ComrakOptions, ComrakPlugins};
+use crate::parser::{Options, Plugins};
 use once_cell::sync::Lazy;
 use std::io::{self, Write};
 
@@ -8,18 +8,18 @@ use crate::nodes::NodeHtmlBlock;
 /// Formats an AST as HTML, modified by the given options.
 pub fn format_document<'a>(
     root: &'a AstNode<'a>,
-    options: &ComrakOptions,
+    options: &Options,
     output: &mut dyn Write,
 ) -> io::Result<()> {
-    format_document_with_plugins(root, options, output, &ComrakPlugins::default())
+    format_document_with_plugins(root, options, output, &Plugins::default())
 }
 
 /// Formats an AST as HTML, modified by the given options. Accepts custom plugins.
 pub fn format_document_with_plugins<'a>(
     root: &'a AstNode<'a>,
-    options: &ComrakOptions,
+    options: &Options,
     output: &mut dyn Write,
-    plugins: &ComrakPlugins,
+    plugins: &Plugins,
 ) -> io::Result<()> {
     output.write_all(b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")?;
     output.write_all(b"<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n")?;
@@ -29,17 +29,13 @@ pub fn format_document_with_plugins<'a>(
 
 struct XmlFormatter<'o> {
     output: &'o mut dyn Write,
-    options: &'o ComrakOptions,
-    _plugins: &'o ComrakPlugins<'o>,
+    options: &'o Options,
+    _plugins: &'o Plugins<'o>,
     indent: u32,
 }
 
 impl<'o> XmlFormatter<'o> {
-    fn new(
-        options: &'o ComrakOptions,
-        output: &'o mut dyn Write,
-        plugins: &'o ComrakPlugins,
-    ) -> Self {
+    fn new(options: &'o Options, output: &'o mut dyn Write, plugins: &'o Plugins) -> Self {
         XmlFormatter {
             options,
             output,


### PR DESCRIPTION
There are a few types whose names start with `Comrak`:

```
ComrakExtensionOptions
ComrakOptions
ComrakParseOptions
ComrakPlugins
ComrakRenderOptions
ComrakRenderPlugins
```

This sort of naming is somewhat redundant - they are longer & clunky to work with, even though they are unlikely to conflict with anything. This PR removes the `Comrak` prefix so they are more ergonomic. Any users who do have conflicts can use e.g. `comrak::Plugins`.

This PR also adds aliases for the old type names, so no workflows are affected.