### PR TITLE
Fix autolink detection inside wiki style link brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Options:
       --relaxed-tasklist-character
           Enable relaxing which character is allowed in a tasklists
 
+      --relaxed-autolinks
+          Enable relaxing of autolink parsing, allowing links to be recognized when in brackets
+
       --default-info-string <INFO>
           Default value for fenced code block's info strings if none is given
 

--- a/fuzz/fuzz_targets/all_options.rs
+++ b/fuzz/fuzz_targets/all_options.rs
@@ -25,6 +25,7 @@ fuzz_target!(|s: &str| {
     parse.smart = true;
     parse.default_info_string = Some("rust".to_string());
     parse.relaxed_tasklist_matching = true;
+    parse.relaxed_autolinks = true;
 
     let mut render = RenderOptions::default();
     render.hardbreaks = true;

--- a/fuzz/fuzz_targets/quadratic.rs
+++ b/fuzz/fuzz_targets/quadratic.rs
@@ -217,6 +217,7 @@ impl FuzzExtensionOptions {
 struct FuzzParseOptions {
     smart: bool,
     relaxed_tasklist_matching: bool,
+    relaxed_autolinks: bool,
 }
 
 impl FuzzParseOptions {
@@ -225,6 +226,7 @@ impl FuzzParseOptions {
         parse.smart = self.smart;
         parse.default_info_string = None;
         parse.relaxed_tasklist_matching = self.relaxed_tasklist_matching;
+        parse.relaxed_autolinks = self.relaxed_autolinks;
         parse
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,10 @@ struct Cli {
     #[arg(long)]
     relaxed_tasklist_character: bool,
 
+    /// Enable relaxing of autolink parsing, allowing links to be recognized when in brackets
+    #[arg(long)]
+    relaxed_autolinks: bool,
+
     /// Default value for fenced code block's info strings if none is given
     #[arg(long, value_name = "INFO")]
     default_info_string: Option<String>,
@@ -219,6 +223,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .smart(cli.smart)
         .default_info_string(cli.default_info_string)
         .relaxed_tasklist_matching(cli.relaxed_tasklist_character)
+        .relaxed_autolinks(cli.relaxed_autolinks)
         .build()?;
 
     let render = RenderOptionsBuilder::default()

--- a/src/parser/autolink.rs
+++ b/src/parser/autolink.rs
@@ -17,8 +17,25 @@ pub(crate) fn process_autolinks<'a>(
 
     while i < len {
         let mut post_org = None;
+        let mut bracket_opening = 0;
 
+        // cmark-gfm ignores links inside brackets, such as `[[http://example.com]`
         while i < len {
+            match contents[i] {
+                b'[' => {
+                    bracket_opening += 1;
+                }
+                b']' => {
+                    bracket_opening -= 1;
+                }
+                _ => (),
+            }
+
+            if bracket_opening > 0 {
+                i += 1;
+                continue;
+            }
+
             match contents[i] {
                 b':' => {
                     post_org = url_match(arena, contents, i);

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -390,6 +390,21 @@ pub struct ParseOptions {
 
     /// Whether or not a simple `x` or `X` is used for tasklist or any other symbol is allowed.
     pub relaxed_tasklist_matching: bool,
+
+    /// Relax parsing of autolinks, allowing links to be detected inside brackets.
+    ///
+    /// ```
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
+    /// options.extension.autolink = true;
+    /// assert_eq!(markdown_to_html("[https://foo.com]", &options),
+    ///            "<p>[https://foo.com]</p>\n");
+    ///
+    /// options.parse.relaxed_autolinks = true;
+    /// assert_eq!(markdown_to_html("[https://foo.com]", &options),
+    ///            "<p>[<a href=\"https://foo.com\">https://foo.com</a>]</p>\n");
+    /// ```
+    pub relaxed_autolinks: bool,
 }
 
 #[non_exhaustive]
@@ -1954,7 +1969,12 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
         }
 
         if self.options.extension.autolink {
-            autolink::process_autolinks(self.arena, node, text);
+            autolink::process_autolinks(
+                self.arena,
+                node,
+                text,
+                self.options.parse.relaxed_autolinks,
+            );
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -123,6 +123,7 @@ macro_rules! html_opts {
                 smart: true,
                 default_info_string: Some("rust".to_string()),
                 relaxed_tasklist_matching: true,
+                relaxed_autolinks: true,
             },
             render: $crate::RenderOptions {
                 hardbreaks: true,

--- a/src/tests/api.rs
+++ b/src/tests/api.rs
@@ -52,7 +52,8 @@ fn exercise_full_api() {
         parse: ParseOptions {
             smart: false,
             default_info_string: Some("abc".to_string()),
-            relaxed_tasklist_matching: true,
+            relaxed_tasklist_matching: false,
+            relaxed_autolinks: false,
         },
         render: RenderOptions {
             hardbreaks: false,

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -57,15 +57,48 @@ fn autolink_ignore_links_in_brackets() {
     let examples = [
         ["[https://foo.com]", "<p>[https://foo.com]</p>\n"],
         ["[[https://foo.com]]", "<p>[[https://foo.com]]</p>\n"],
-        ["[[Foo|https://foo.com]]", "<p>[[Foo|https://foo.com]]</p>\n"],
+        [
+            "[[Foo|https://foo.com]]",
+            "<p>[[Foo|https://foo.com]]</p>\n",
+        ],
         [
             "[<https://foo.com>]",
-            "<p>[<a href=\"https://foo.com\">https://foo.com</a>]</p>\n"
+            "<p>[<a href=\"https://foo.com\">https://foo.com</a>]</p>\n",
         ],
     ];
 
     for example in examples {
         html_opts!([extension.autolink], example[0], example[1]);
+    }
+}
+
+#[test]
+fn autolink_relaxed_links_in_brackets() {
+    let examples = [
+        [
+            "[https://foo.com]",
+            "<p>[<a href=\"https://foo.com\">https://foo.com</a>]</p>\n",
+        ],
+        [
+            "[[https://foo.com]]",
+            "<p>[[<a href=\"https://foo.com\">https://foo.com</a>]]</p>\n",
+        ],
+        [
+            "[[Foo|https://foo.com]]",
+            "<p>[[Foo|<a href=\"https://foo.com\">https://foo.com</a>]]</p>\n",
+        ],
+        [
+            "[<https://foo.com>]",
+            "<p>[<a href=\"https://foo.com\">https://foo.com</a>]</p>\n",
+        ],
+    ];
+
+    for example in examples {
+        html_opts!(
+            [extension.autolink, parse.relaxed_autolinks],
+            example[0],
+            example[1]
+        );
     }
 }
 

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -53,6 +53,23 @@ fn autolink_no_link_bad() {
 }
 
 #[test]
+fn autolink_ignore_links_in_brackets() {
+    let examples = [
+        ["[https://foo.com]", "<p>[https://foo.com]</p>\n"],
+        ["[[https://foo.com]]", "<p>[[https://foo.com]]</p>\n"],
+        ["[[Foo|https://foo.com]]", "<p>[[Foo|https://foo.com]]</p>\n"],
+        [
+            "[<https://foo.com>]",
+            "<p>[<a href=\"https://foo.com\">https://foo.com</a>]</p>\n"
+        ],
+    ];
+
+    for example in examples {
+        html_opts!([extension.autolink], example[0], example[1]);
+    }
+}
+
+#[test]
 fn sourcepos_correctly_restores_context() {
     // There's unsoundness in trying to maintain and adjust sourcepos
     // when doing autolinks in the light of:

--- a/src/tests/propfuzz.rs
+++ b/src/tests/propfuzz.rs
@@ -25,6 +25,7 @@ fn propfuzz_doesnt_crash(md: String) {
             smart: true,
             default_info_string: Some("Rust".to_string()),
             relaxed_tasklist_matching: true,
+            relaxed_autolinks: true,
         },
         render: RenderOptions {
             hardbreaks: true,


### PR DESCRIPTION
Related to https://github.com/kivikakk/comrak/issues/296

`cmark-gfm` does _not_ detect an autolink in `[[http://example.com]]`.  However by default `comrak` was.

This PR implements the `cmark-gfm` behavior.  It also introduces the option `relaxed-autolinks` to allow detection inside brackets, as many other markdown packages do.