### PR TITLE
Comma delimited info string language

### DIFF
--- a/src/plugins/syntect.rs
+++ b/src/plugins/syntect.rs
@@ -58,7 +58,7 @@ impl SyntaxHighlighterAdapter for SyntectAdapter {
         let fallback_syntax = "Plain Text";
 
         let lang: &str = match lang {
-            Some(l) if !l.is_empty() => l,
+            Some(l) if !l.is_empty() => l.split_once(',').map(|(left, _)| left).unwrap_or(l),
             _ => fallback_syntax,
         };
 

--- a/src/tests/plugins.rs
+++ b/src/tests/plugins.rs
@@ -91,16 +91,22 @@ fn heading_adapter_plugin() {
 fn syntect_plugin() {
     let adapter = crate::plugins::syntect::SyntectAdapter::new("base16-ocean.dark");
 
-    let input = concat!("```rust\n", "fn main<'a>();\n", "```\n");
-    let expected = concat!(
-        "<pre style=\"background-color:#2b303b;\"><code class=\"language-rust\">",
-        "<span style=\"color:#b48ead;\">fn </span><span style=\"color:#8fa1b3;\">main</span><span style=\"color:#c0c5ce;\">",
-        "&lt;</span><span style=\"color:#b48ead;\">&#39;a</span><span style=\"color:#c0c5ce;\">&gt;();\n</span>",
-        "</code></pre>\n"
-    );
+    let cases = vec![
+        (
+            concat!("```rust\n", "fn main<'a>();\n", "```\n"),
+            concat!(
+                "<pre style=\"background-color:#2b303b;\"><code class=\"language-rust\">",
+                "<span style=\"color:#b48ead;\">fn </span><span style=\"color:#8fa1b3;\">main</span><span style=\"color:#c0c5ce;\">",
+                "&lt;</span><span style=\"color:#b48ead;\">&#39;a</span><span style=\"color:#c0c5ce;\">&gt;();\n</span>",
+                "</code></pre>\n"
+            ),
+        ),
+    ];
 
     let mut plugins = Plugins::default();
     plugins.render.codefence_syntax_highlighter = Some(&adapter);
 
-    html_plugins(input, expected, &plugins);
+    for (input, expected) in cases {
+        html_plugins(input, expected, &plugins);
+    }
 }

--- a/src/tests/plugins.rs
+++ b/src/tests/plugins.rs
@@ -101,6 +101,21 @@ fn syntect_plugin() {
                 "</code></pre>\n"
             ),
         ),
+        (
+            // Language should still be highlighted when delimited by a comma
+            "\
+            ```rust,ignore\n\
+            fn main() {}\n\
+            ```\n\
+            ",
+            "\
+            <pre style=\"background-color:#2b303b;\"><code class=\"language-rust,ignore\">\
+                <span style=\"color:#b48ead;\">fn </span>\
+                <span style=\"color:#8fa1b3;\">main</span>\
+                <span style=\"color:#c0c5ce;\">() {}\n</span>\
+            </code></pre>\n\
+            ",
+        ),
     ];
 
     let mut plugins = Plugins::default();


### PR DESCRIPTION
Fixes #246 

Changes the syntect plugin to split off any text following a comma from the language tag to match what is supported by rustdoc and GitHub. This now accepts ```` ```rust,no_run```` as Rust code