### PR TITLE
Sync with cmark-gfm-0.29.0.gfm.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Collective](https://opencollective.com/comrak/all/badge.svg?label=financial+cont
 [![crates.io version](https://img.shields.io/crates/v/comrak.svg)](https://crates.io/crates/comrak)
 [![docs.rs](https://docs.rs/comrak/badge.svg)](https://docs.rs/comrak)
 
-Rust port of [github's `cmark-gfm`](https://github.com/github/cmark). *Currently synced with release `0.29.0.gfm.12`*.
+Rust port of [github's `cmark-gfm`](https://github.com/github/cmark). *Currently synced with release `0.29.0.gfm.13`*.
 
 - [Installation](#installation)
 - [Usage](#usage)

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -42,8 +42,8 @@ fn try_opening_header<'a>(
         return Some((container, false, false));
     }
 
-    let marker_row = match row(&line[parser.first_nonspace..]) {
-        Some(marker_row) => marker_row,
+    let delimiter_row = match row(&line[parser.first_nonspace..]) {
+        Some(delimiter_row) => delimiter_row,
         None => return Some((container, false, true)),
     };
 
@@ -52,7 +52,7 @@ fn try_opening_header<'a>(
         None => return Some((container, false, true)),
     };
 
-    if header_row.cells.len() != marker_row.cells.len() {
+    if header_row.cells.len() != delimiter_row.cells.len() {
         return Some((container, false, true));
     }
 
@@ -61,7 +61,7 @@ fn try_opening_header<'a>(
     }
 
     let mut alignments = vec![];
-    for cell in marker_row.cells {
+    for cell in delimiter_row.cells {
         let cell_content = cell.content.as_bytes();
         let left = !cell_content.is_empty() && cell_content[0] == b':';
         let right = !cell_content.is_empty() && cell_content[cell_content.len() - 1] == b':';

--- a/src/scanners.re
+++ b/src/scanners.re
@@ -316,7 +316,7 @@ pub fn dangerous_url(s: &[u8]) -> Option<usize> {
     table_spacechar = [ \t\v\f];
     table_newline = [\r]?[\n];
 
-    table_marker = (table_spacechar*[:]?[-]+[:]?table_spacechar*);
+    table_delimiter = (table_spacechar*[:]?[-]+[:]?table_spacechar*);
     table_cell = (escaped_char|[^\x00|\r\n])+;
 
 */
@@ -326,7 +326,7 @@ pub fn table_start(s: &[u8]) -> Option<usize> {
     let mut marker = 0;
     let len = s.len();
 /*!re2c
-    [|]? table_marker ([|] table_marker)* [|]? table_spacechar* table_newline {
+    [|]? table_delimiter ([|] table_delimiter)* [|]? table_spacechar* table_newline {
         return Some(cursor);
     }
     * { return None; }


### PR DESCRIPTION
Syncs with `cmark-gfm` version `0.29.0.gfm.13`.

There were no functional changes, just a tweak to some nomenclature related to https://github.com/github/cmark-gfm/pull/273.  While the `src/scanners.re` was updated, this was just the internal variable name.  I verified by running `make src/scanners.rs`, there were no changes generated for `src/scanners.rs`