### PR TITLE
Allow for Syntect to simply generate CSS classes

### DIFF
--- a/examples/syntect.rs
+++ b/examples/syntect.rs
@@ -4,7 +4,7 @@ use comrak::plugins::syntect::SyntectAdapter;
 use comrak::{markdown_to_html_with_plugins, Options, Plugins};
 
 fn main() {
-    let adapter = SyntectAdapter::new("base16-ocean.dark");
+    let adapter = SyntectAdapter::new(Some("base16-ocean.dark"));
     let options = Options::default();
     let mut plugins = Plugins::default();
 

--- a/examples/syntect.rs
+++ b/examples/syntect.rs
@@ -1,10 +1,15 @@
 //! This example shows how to use the bundled syntect plugin.
 
-use comrak::plugins::syntect::SyntectAdapter;
+use comrak::plugins::syntect::SyntectAdapterBuilder;
 use comrak::{markdown_to_html_with_plugins, Options, Plugins};
 
 fn main() {
-    let adapter = SyntectAdapter::new(Some("base16-ocean.dark"));
+    run_with(SyntectAdapterBuilder::new().theme("base16-ocean.dark"));
+    run_with(SyntectAdapterBuilder::new().css());
+}
+
+fn run_with(builder: SyntectAdapterBuilder) {
+    let adapter = builder.build();
     let options = Options::default();
     let mut plugins = Plugins::default();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,7 +251,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     if theme.is_empty() || theme == "none" {
         syntax_highlighter = None;
     } else {
-        adapter = SyntectAdapter::new(&theme);
+        adapter = SyntectAdapter::new(Some(&theme));
         syntax_highlighter = Some(&adapter);
     }
 

--- a/src/tests/plugins.rs
+++ b/src/tests/plugins.rs
@@ -88,8 +88,8 @@ fn heading_adapter_plugin() {
 
 #[test]
 #[cfg(feature = "syntect")]
-fn syntect_plugin() {
-    let adapter = crate::plugins::syntect::SyntectAdapter::new("base16-ocean.dark");
+fn syntect_plugin_with_base16_ocean_dark_theme() {
+    let adapter = crate::plugins::syntect::SyntectAdapter::new(Some("base16-ocean.dark"));
 
     let input = concat!("```rust\n", "fn main<'a>();\n", "```\n");
     let expected = concat!(
@@ -97,6 +97,26 @@ fn syntect_plugin() {
         "<span style=\"color:#b48ead;\">fn </span><span style=\"color:#8fa1b3;\">main</span><span style=\"color:#c0c5ce;\">",
         "&lt;</span><span style=\"color:#b48ead;\">&#39;a</span><span style=\"color:#c0c5ce;\">&gt;();\n</span>",
         "</code></pre>\n"
+    );
+
+    let mut plugins = Plugins::default();
+    plugins.render.codefence_syntax_highlighter = Some(&adapter);
+
+    html_plugins(input, expected, &plugins);
+}
+
+#[test]
+#[cfg(feature = "syntect")]
+fn syntect_plugin_with_css_classes() {
+    let adapter = crate::plugins::syntect::SyntectAdapter::new(None);
+
+    let input = concat!("```rust\n", "fn main<'a>();\n", "```\n");
+    let expected = concat!(
+        "<pre class=\"syntax-highlighting\"><code class=\"language-rust\">",
+        "<span class=\"source rust\"><span class=\"meta function rust\"><span class=\"meta function rust\"><span class=\"storage type function rust\">fn</span> </span><span class=\"entity name function rust\">main</span></span><span class=\"meta generic rust\"><span class=\"punctuation definition generic begin rust\">&lt;</span>",
+        "<span class=\"storage modifier lifetime rust\">&#39;a</span><span class=\"punctuation definition generic end rust\">&gt;</span></span><span class=\"meta function rust\"><span class=\"meta function parameters rust\"><span class=\"punctuation section parameters begin rust\">(</span></span><span class=\"meta function rust\">",
+        "<span class=\"meta function parameters rust\"><span class=\"punctuation section parameters end rust\">)</span></span></span></span><span class=\"punctuation terminator rust\">;</span>\n</span>",
+        "</code></pre>\n",
     );
 
     let mut plugins = Plugins::default();

--- a/src/tests/regressions.rs
+++ b/src/tests/regressions.rs
@@ -1,5 +1,4 @@
 use super::*;
-use ntest::timeout;
 
 #[test]
 fn pointy_brace() {


### PR DESCRIPTION
Syntect has the ability to [generate its syntax highlighting with CSS classes](https://github.com/trishume/syntect/blob/95df8850c9859c5403408cf8e7b5a2d7cc6cda2b/examples/synhtml-css-classes.rs#L96), rather than inline styles. 

I wanted to use this in Commonmarker, but I couldn't find an easy, non-breaking API to support this feature. I'm happy to rework or rearchitect it into anything that looks better. Technically this is still a non-1.0 library so breaking changes are permitted per sem ver, but, well, you know.... _people_.