### PR TITLE
Use text-align over deprecated align attribute for td and th

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -916,13 +916,13 @@ impl<'o> HtmlFormatter<'o> {
 
                     match alignments[i] {
                         TableAlignment::Left => {
-                            self.output.write_all(b" align=\"left\"")?;
+                            self.output.write_all(b" style=\"text-align: left\"")?;
                         }
                         TableAlignment::Right => {
-                            self.output.write_all(b" align=\"right\"")?;
+                            self.output.write_all(b" style=\"text-align: right\"")?;
                         }
                         TableAlignment::Center => {
-                            self.output.write_all(b" align=\"center\"")?;
+                            self.output.write_all(b" style=\"text-align: center\"")?;
                         }
                         TableAlignment::None => (),
                     }


### PR DESCRIPTION
align attribute is deprecated, and the text aligning of <td> and <th> elements should be done by text-align