### PR TITLE
Add a multiline blockquote extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Options:
           Multiple extensions can be delimited with ",", e.g. --extension strikethrough,table
           
           [possible values: strikethrough, tagfilter, table, autolink, tasklist, superscript,
-          footnotes, description-lists]
+          footnotes, description-lists, multiline-block-quotes]
 
   -t, --to <FORMAT>
           Specify output format

--- a/examples/s-expr.rs
+++ b/examples/s-expr.rs
@@ -83,6 +83,7 @@ fn dump(source: &str) -> io::Result<()> {
         .superscript(true)
         .footnotes(true)
         .description_lists(true)
+        .multiline_block_quotes(true)
         .build()
         .unwrap();
 

--- a/fuzz/fuzz_targets/all_options.rs
+++ b/fuzz/fuzz_targets/all_options.rs
@@ -18,6 +18,7 @@ fuzz_target!(|s: &str| {
     extension.header_ids = Some("user-content-".to_string());
     extension.footnotes = true;
     extension.description_lists = true;
+    extension.multiline_block_quotes = true;
     extension.front_matter_delimiter = Some("---".to_string());
     extension.shortcodes = true;
 

--- a/fuzz/fuzz_targets/quadratic.rs
+++ b/fuzz/fuzz_targets/quadratic.rs
@@ -192,6 +192,7 @@ struct FuzzExtensionOptions {
     superscript: bool,
     footnotes: bool,
     description_lists: bool,
+    multiline_block_quotes: bool,
     shortcodes: bool,
 }
 
@@ -206,6 +207,7 @@ impl FuzzExtensionOptions {
         extension.superscript = self.superscript;
         extension.footnotes = self.footnotes;
         extension.description_lists = self.description_lists;
+        extension.multiline_block_quotes = self.multiline_block_quotes;
         extension.shortcodes = self.shortcodes;
         extension.front_matter_delimiter = None;
         extension.header_ids = None;

--- a/script/cibuild
+++ b/script/cibuild
@@ -34,6 +34,8 @@ if [ x"$SPEC" = "xtrue" ]; then
 	# python3 roundtrip_tests.py --spec extensions-table-prefer-style-attributes.txt "$PROGRAM_ARG --table-prefer-style-attributes" --extensions "table strikethrough autolink tagfilter footnotes tasklist" || failed=1
 	python3 roundtrip_tests.py --spec extensions-full-info-string.txt "$PROGRAM_ARG --full-info-string" \
 		|| failed=1
+	python3 spec_tests.py --no-normalize --spec ../../../src/tests/fixtures/multiline_blockquote.txt "$PROGRAM_ARG" \
+		|| failed=1
 
 	python3 spec_tests.py --no-normalize --spec regression.txt "$PROGRAM_ARG" \
 		|| failed=1

--- a/script/cibuild
+++ b/script/cibuild
@@ -34,7 +34,7 @@ if [ x"$SPEC" = "xtrue" ]; then
 	# python3 roundtrip_tests.py --spec extensions-table-prefer-style-attributes.txt "$PROGRAM_ARG --table-prefer-style-attributes" --extensions "table strikethrough autolink tagfilter footnotes tasklist" || failed=1
 	python3 roundtrip_tests.py --spec extensions-full-info-string.txt "$PROGRAM_ARG --full-info-string" \
 		|| failed=1
-	python3 spec_tests.py --no-normalize --spec ../../../src/tests/fixtures/multiline_blockquote.txt "$PROGRAM_ARG" \
+	python3 spec_tests.py --no-normalize --spec ../../../src/tests/fixtures/multiline_blockquote.txt "$PROGRAM_ARG -e multiline-block-quotes" \
 		|| failed=1
 
 	python3 spec_tests.py --no-normalize --spec regression.txt "$PROGRAM_ARG" \

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -377,6 +377,7 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
             NodeValue::FootnoteReference(ref nfr) => {
                 self.format_footnote_reference(nfr.name.as_bytes(), entering)
             }
+            NodeValue::MultilineBlockQuote(..) => self.format_block_quote(entering),
         };
         true
     }

--- a/src/html.rs
+++ b/src/html.rs
@@ -993,6 +993,17 @@ impl<'o> HtmlFormatter<'o> {
                     self.output.write_all(b"</li>\n")?;
                 }
             }
+            NodeValue::MultilineBlockQuote(_) => {
+                if entering {
+                    self.cr()?;
+                    self.output.write_all(b"<blockquote")?;
+                    self.render_sourcepos(node)?;
+                    self.output.write_all(b">\n")?;
+                } else {
+                    self.cr()?;
+                    self.output.write_all(b"</blockquote>\n")?;
+                }
+            }
         }
         Ok(false)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,7 @@ enum Extension {
     Superscript,
     Footnotes,
     DescriptionLists,
+    MultilineBlockQuotes,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -210,6 +211,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .header_ids(cli.header_ids)
         .footnotes(exts.contains(&Extension::Footnotes))
         .description_lists(exts.contains(&Extension::DescriptionLists))
+        .multiline_block_quotes(exts.contains(&Extension::MultilineBlockQuotes))
         .front_matter_delimiter(cli.front_matter_delimiter);
 
     #[cfg(feature = "shortcodes")]

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -480,7 +480,7 @@ impl NodeValue {
             NodeValue::FootnoteReference(..) => "footnote_reference",
             #[cfg(feature = "shortcodes")]
             NodeValue::ShortCode(_) => "shortcode",
-            NodeValue::MultilineBlockQuote(_) => "block_quote",
+            NodeValue::MultilineBlockQuote(_) => "multiline_block_quote",
         }
     }
 }

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -7,6 +7,8 @@ use std::convert::TryFrom;
 #[cfg(feature = "shortcodes")]
 use crate::parser::shortcodes::NodeShortCode;
 
+use crate::parser::multiline_block_quote::NodeMultilineBlockQuote;
+
 /// The core AST node enum.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NodeValue {
@@ -151,6 +153,19 @@ pub enum NodeValue {
     #[cfg(feature = "shortcodes")]
     /// **Inline**. An Emoji character generated from a shortcode. Enable with feature "shortcodes".
     ShortCode(NodeShortCode),
+
+    /// **Block**. A [multiline block quote](https://github.github.com/gfm/#block-quotes).  Spans multiple
+    /// lines and contains other **blocks**.
+    ///
+    /// ``` md
+    /// >>>
+    /// A paragraph.
+    ///
+    /// - item one
+    /// - item two
+    /// >>>
+    /// ```
+    MultilineBlockQuote(NodeMultilineBlockQuote),
 }
 
 /// Alignment of a single table cell.
@@ -391,6 +406,7 @@ impl NodeValue {
                 | NodeValue::TableRow(..)
                 | NodeValue::TableCell
                 | NodeValue::TaskItem(..)
+                | NodeValue::MultilineBlockQuote(_)
         )
     }
 
@@ -464,6 +480,7 @@ impl NodeValue {
             NodeValue::FootnoteReference(..) => "footnote_reference",
             #[cfg(feature = "shortcodes")]
             NodeValue::ShortCode(_) => "shortcode",
+            NodeValue::MultilineBlockQuote(_) => "block_quote",
         }
     }
 }
@@ -646,6 +663,10 @@ pub fn can_contain_type<'a>(node: &'a AstNode<'a>, child: &NodeValue) -> bool {
                 | NodeValue::Strikethrough
                 | NodeValue::HtmlInline(..)
         ),
+
+        NodeValue::MultilineBlockQuote(_) => {
+            child.block() && !matches!(*child, NodeValue::Item(..) | NodeValue::TaskItem(..))
+        }
 
         _ => false,
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -340,6 +340,29 @@ pub struct ExtensionOptions {
     /// ```
     pub front_matter_delimiter: Option<String>,
 
+    /// Enables the multiline block quote extension.
+    ///
+    /// Place `>>>` before and after text to make it into
+    /// a block quote.
+    ///
+    /// ``` md
+    /// Paragraph one
+    ///
+    /// >>>
+    /// Paragraph two
+    ///
+    /// - one
+    /// - two
+    /// >>>
+    /// ```
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
+    /// options.extension.multiline_block_quotes = true;
+    /// assert_eq!(markdown_to_html(">>>\nparagraph\n>>>", &options),
+    ///            "<blockquote>\n<p>paragraph</p>\n</blockquote>\n");
+    /// ```
+    pub multiline_block_quotes: bool,
+
     #[cfg(feature = "shortcodes")]
     #[cfg_attr(docsrs, doc(cfg(feature = "shortcodes")))]
     /// Phrases wrapped inside of ':' blocks will be replaced with emojis.
@@ -999,6 +1022,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
             let indented = self.indent >= CODE_INDENT;
 
             if !indented
+                && self.options.extension.multiline_block_quotes
                 && unwrap_into(
                     scanners::open_multiline_block_quote_fence(&line[self.first_nonspace..]),
                     &mut matched,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -355,6 +355,8 @@ pub struct ExtensionOptions {
     /// - two
     /// >>>
     /// ```
+    ///
+    /// ```
     /// # use comrak::{markdown_to_html, Options};
     /// let mut options = Options::default();
     /// options.extension.multiline_block_quotes = true;

--- a/src/parser/multiline_block_quote.rs
+++ b/src/parser/multiline_block_quote.rs
@@ -1,0 +1,9 @@
+/// The metadata of a multiline blockquote.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NodeMultilineBlockQuote {
+    /// The length of the fence.
+    pub fence_length: usize,
+
+    /// ??? The indentation level of the code within the block.
+    pub fence_offset: usize,
+}

--- a/src/parser/multiline_block_quote.rs
+++ b/src/parser/multiline_block_quote.rs
@@ -4,6 +4,6 @@ pub struct NodeMultilineBlockQuote {
     /// The length of the fence.
     pub fence_length: usize,
 
-    /// ??? The indentation level of the code within the block.
+    /// The indentation level of the fence marker.
     pub fence_offset: usize,
 }

--- a/src/scanners.re
+++ b/src/scanners.re
@@ -376,6 +376,28 @@ pub fn shortcode(s: &[u8]) -> Option<usize> {
 */
 }
 
+pub fn open_multiline_block_quote_fence(s: &[u8]) -> Option<usize> {
+    let mut cursor = 0;
+    let mut marker = 0;
+    let mut ctxmarker = 0;
+    let len = s.len();
+/*!re2c
+    [>]{3,} / [ \t]*[\r\n] { return Some(cursor); }
+    * { return None; }
+*/
+}
+
+pub fn close_multiline_block_quote_fence(s: &[u8]) -> Option<usize> {
+    let mut cursor = 0;
+    let mut marker = 0;
+    let mut ctxmarker = 0;
+    let len = s.len();
+/*!re2c
+    [>]{3,} / [ \t]*[\r\n] { return Some(cursor); }
+    * { return None; }
+*/
+}
+
 // Returns both the length of the match, and the tasklist character.
 pub fn tasklist(s: &[u8]) -> Option<(usize, u8)> {
     let mut cursor = 0;

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -22548,6 +22548,318 @@ pub fn shortcode(s: &[u8]) -> Option<usize> {
     }
 }
 
+pub fn open_multiline_block_quote_fence(s: &[u8]) -> Option<usize> {
+    let mut cursor = 0;
+    let mut marker = 0;
+    let mut ctxmarker = 0;
+    let len = s.len();
+
+    {
+        #[allow(unused_assignments)]
+        let mut yych: u8 = 0;
+        let mut yystate: usize = 0;
+        'yyl: loop {
+            match yystate {
+                0 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    cursor += 1;
+                    match yych {
+                        0x3E => {
+                            yystate = 3;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 1;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                1 => {
+                    yystate = 2;
+                    continue 'yyl;
+                }
+                2 => {
+                    return None;
+                }
+                3 => {
+                    marker = cursor;
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x3E => {
+                            cursor += 1;
+                            yystate = 4;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 2;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                4 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x3E => {
+                            cursor += 1;
+                            yystate = 6;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                5 => {
+                    cursor = marker;
+                    yystate = 2;
+                    continue 'yyl;
+                }
+                6 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x09 | 0x20 => {
+                            ctxmarker = cursor;
+                            cursor += 1;
+                            yystate = 7;
+                            continue 'yyl;
+                        }
+                        0x0A | 0x0D => {
+                            ctxmarker = cursor;
+                            cursor += 1;
+                            yystate = 8;
+                            continue 'yyl;
+                        }
+                        0x3E => {
+                            cursor += 1;
+                            yystate = 6;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                7 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x09 | 0x20 => {
+                            cursor += 1;
+                            yystate = 7;
+                            continue 'yyl;
+                        }
+                        0x0A | 0x0D => {
+                            cursor += 1;
+                            yystate = 8;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                8 => {
+                    cursor = ctxmarker;
+                    {
+                        return Some(cursor);
+                    }
+                }
+                _ => {
+                    panic!("internal lexer error")
+                }
+            }
+        }
+    }
+}
+
+pub fn close_multiline_block_quote_fence(s: &[u8]) -> Option<usize> {
+    let mut cursor = 0;
+    let mut marker = 0;
+    let mut ctxmarker = 0;
+    let len = s.len();
+
+    {
+        #[allow(unused_assignments)]
+        let mut yych: u8 = 0;
+        let mut yystate: usize = 0;
+        'yyl: loop {
+            match yystate {
+                0 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    cursor += 1;
+                    match yych {
+                        0x3E => {
+                            yystate = 3;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 1;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                1 => {
+                    yystate = 2;
+                    continue 'yyl;
+                }
+                2 => {
+                    return None;
+                }
+                3 => {
+                    marker = cursor;
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x3E => {
+                            cursor += 1;
+                            yystate = 4;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 2;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                4 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x3E => {
+                            cursor += 1;
+                            yystate = 6;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                5 => {
+                    cursor = marker;
+                    yystate = 2;
+                    continue 'yyl;
+                }
+                6 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x09 | 0x20 => {
+                            ctxmarker = cursor;
+                            cursor += 1;
+                            yystate = 7;
+                            continue 'yyl;
+                        }
+                        0x0A | 0x0D => {
+                            ctxmarker = cursor;
+                            cursor += 1;
+                            yystate = 8;
+                            continue 'yyl;
+                        }
+                        0x3E => {
+                            cursor += 1;
+                            yystate = 6;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                7 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x09 | 0x20 => {
+                            cursor += 1;
+                            yystate = 7;
+                            continue 'yyl;
+                        }
+                        0x0A | 0x0D => {
+                            cursor += 1;
+                            yystate = 8;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                8 => {
+                    cursor = ctxmarker;
+                    {
+                        return Some(cursor);
+                    }
+                }
+                _ => {
+                    panic!("internal lexer error")
+                }
+            }
+        }
+    }
+}
+
 // Returns both the length of the match, and the tasklist character.
 pub fn tasklist(s: &[u8]) -> Option<(usize, u8)> {
     let mut cursor = 0;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,6 +12,7 @@ mod description_lists;
 mod footnotes;
 mod fuzz;
 mod header_ids;
+mod multiline_block_quotes;
 mod options;
 mod pathological;
 mod plugins;
@@ -117,6 +118,7 @@ macro_rules! html_opts {
                 header_ids: Some("user-content-".to_string()),
                 footnotes: true,
                 description_lists: true,
+                multiline_block_quotes: true,
                 front_matter_delimiter: Some("---".to_string()),
                 shortcodes: true,
             },

--- a/src/tests/api.rs
+++ b/src/tests/api.rs
@@ -212,5 +212,6 @@ fn exercise_full_api() {
             let _: String = nfr.name;
             let _: u32 = nfr.ix;
         }
+        nodes::NodeValue::MultilineBlockQuote(_) => {}
     }
 }

--- a/src/tests/api.rs
+++ b/src/tests/api.rs
@@ -44,6 +44,7 @@ fn exercise_full_api() {
     extension.header_ids(Some("abc".to_string()));
     extension.footnotes(false);
     extension.description_lists(false);
+    extension.multiline_block_quotes(false);
     extension.front_matter_delimiter(None);
     #[cfg(feature = "shortcodes")]
     extension.shortcodes(true);
@@ -212,6 +213,9 @@ fn exercise_full_api() {
             let _: String = nfr.name;
             let _: u32 = nfr.ix;
         }
-        nodes::NodeValue::MultilineBlockQuote(_) => {}
+        nodes::NodeValue::MultilineBlockQuote(mbc) => {
+            let _: usize = mbc.fence_length;
+            let _: usize = mbc.fence_offset;
+        }
     }
 }

--- a/src/tests/fixtures/multiline_blockquote.txt
+++ b/src/tests/fixtures/multiline_blockquote.txt
@@ -1,0 +1,311 @@
+---
+title: GitLab Flavored Markdown Spec
+version: 0.1
+date: '2023-12-18'
+license: '[CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/)'
+...
+
+## Multi-line Blockquotes
+
+Simple container
+
+```````````````````````````````` example
+>>>
+*content*
+>>>
+.
+<blockquote>
+<p><em>content</em></p>
+</blockquote>
+````````````````````````````````
+
+
+Can contain block elements
+
+```````````````````````````````` example
+>>>
+### heading
+
+-----------
+>>>
+.
+<blockquote>
+<h3>heading</h3>
+<hr />
+</blockquote>
+````````````````````````````````
+
+
+Ending marker can be longer
+
+```````````````````````````````` example
+>>>>>>
+  hello world
+>>>>>>>>>>>
+normal
+.
+<blockquote>
+<p>hello world</p>
+</blockquote>
+<p>normal</p>
+````````````````````````````````
+
+
+Nested blockquotes
+
+```````````````````````````````` example
+>>>>>
+>>>>
+foo
+>>>>
+>>>>>
+.
+<blockquote>
+<blockquote>
+<p>foo</p>
+</blockquote>
+</blockquote>
+````````````````````````````````
+
+Incorrectly nested blockquotes
+
+```````````````````````````````` example
+>>>>
+this block is closed with 5 markers below
+
+>>>>>
+
+auto-closed blocks
+>>>>>
+>>>>
+.
+<blockquote>
+<p>this block is closed with 5 markers below</p>
+</blockquote>
+<p>auto-closed blocks</p>
+<blockquote>
+<blockquote>
+</blockquote>
+</blockquote>
+````````````````````````````````
+
+
+Marker can be indented up to 3 spaces
+
+```````````````````````````````` example
+   >>>>
+   first-level blockquote
+    >>>
+    second-level blockquote
+    >>>
+   >>>>
+   regular paragraph
+.
+<blockquote>
+<p>first-level blockquote</p>
+<blockquote>
+<p>second-level blockquote</p>
+</blockquote>
+</blockquote>
+<p>regular paragraph</p>
+````````````````````````````````
+
+
+Fours spaces makes it a code block
+
+```````````````````````````````` example
+    >>>
+    content
+    >>>
+.
+<pre><code>&gt;&gt;&gt;
+content
+&gt;&gt;&gt;
+</code></pre>
+````````````````````````````````
+
+
+Detection of embedded 4 spaces code block starts in the
+column the blockquote starts, not from the beginning of
+the line.
+
+```````````````````````````````` example
+  >>>
+      code block
+  >>>
+.
+<blockquote>
+<pre><code>code block
+</code></pre>
+</blockquote>
+````````````````````````````````
+
+```````````````````````````````` example
+   >>>>
+   content
+    >>>
+        code block
+    >>>
+   >>>>
+.
+<blockquote>
+<p>content</p>
+<blockquote>
+<pre><code>code block
+</code></pre>
+</blockquote>
+</blockquote>
+````````````````````````````````
+
+Closing marker can't have text on the same line
+
+```````````````````````````````` example
+>>>
+foo
+>>> arg=123
+.
+<blockquote>
+<p>foo</p>
+<blockquote>
+<blockquote>
+<blockquote>
+<p>arg=123</p>
+</blockquote>
+</blockquote>
+</blockquote>
+</blockquote>
+````````````````````````````````
+
+
+Blockquotes self-close at the end of the document
+
+```````````````````````````````` example
+>>>
+foo
+.
+<blockquote>
+<p>foo</p>
+</blockquote>
+````````````````````````````````
+
+
+They should terminate paragraphs
+
+```````````````````````````````` example
+blah blah
+>>>
+content
+>>>
+.
+<p>blah blah</p>
+<blockquote>
+<p>content</p>
+</blockquote>
+````````````````````````````````
+
+
+They can be nested in lists
+
+```````````````````````````````` example
+ -  >>>
+    - foo
+    >>>
+.
+<ul>
+<li>
+<blockquote>
+<ul>
+<li>foo</li>
+</ul>
+</blockquote>
+</li>
+</ul>
+````````````````````````````````
+
+
+Or in blockquotes
+
+```````````````````````````````` example
+> >>>
+> foo
+>> bar
+> baz
+> >>>
+.
+<blockquote>
+<blockquote>
+<p>foo</p>
+<blockquote>
+<p>bar
+baz</p>
+</blockquote>
+</blockquote>
+</blockquote>
+````````````````````````````````
+
+
+List indentation
+
+```````````````````````````````` example
+ -  >>>
+    foo
+    bar
+    >>>
+
+ -  >>>
+    foo
+    bar
+    >>>
+.
+<ul>
+<li>
+<blockquote>
+<p>foo
+bar</p>
+</blockquote>
+</li>
+<li>
+<blockquote>
+<p>foo
+bar</p>
+</blockquote>
+</li>
+</ul>
+````````````````````````````````
+
+
+Ignored inside code blocks:
+
+```````````````````````````````` example
+```txt
+# Code
+>>>
+# Code
+>>>
+# Code
+```
+.
+<pre><code class="language-txt"># Code
+&gt;&gt;&gt;
+# Code
+&gt;&gt;&gt;
+# Code
+</code></pre>
+````````````````````````````````
+
+
+Does not require a leading or trailing blank line
+
+```````````````````````````````` example
+Some text
+>>>
+A quote
+>>>
+Some other text
+.
+<p>Some text</p>
+<blockquote>
+<p>A quote</p>
+</blockquote>
+<p>Some other text</p>
+````````````````````````````````

--- a/src/tests/multiline_block_quotes.rs
+++ b/src/tests/multiline_block_quotes.rs
@@ -1,0 +1,75 @@
+use super::*;
+
+#[test]
+fn multiline_block_quotes() {
+    html_opts!(
+        [extension.multiline_block_quotes],
+        concat!(">>>\n", "Paragraph 1\n", "\n", "Paragraph 2\n", ">>>\n",),
+        concat!(
+            "<blockquote>\n",
+            "<p>Paragraph 1</p>\n",
+            "<p>Paragraph 2</p>\n",
+            "</blockquote>\n",
+        ),
+    );
+
+    html_opts!(
+        [extension.multiline_block_quotes],
+        concat!(
+            "- item one\n",
+            "\n",
+            "  >>>\n",
+            "  Paragraph 1\n",
+            "\n",
+            "  Paragraph 2\n",
+            "  >>>\n",
+            "- item two\n"
+        ),
+        concat!(
+            "<ul>\n",
+            "<li>\n",
+            "<p>item one</p>\n",
+            "<blockquote>\n",
+            "<p>Paragraph 1</p>\n",
+            "<p>Paragraph 2</p>\n",
+            "</blockquote>\n",
+            "</li>\n",
+            "<li>\n",
+            "<p>item two</p>\n",
+            "</li>\n",
+            "</ul>\n",
+        ),
+    );
+}
+
+#[test]
+fn sourcepos() {
+    assert_ast_match!(
+        [extension.multiline_block_quotes],
+        "- item one\n"
+        "\n"
+        "  >>>\n"
+        "  Paragraph 1\n"
+        "  >>>\n"
+        "- item two\n",
+        (document (1:1-6:10) [
+            (list (1:1-6:10) [
+                (item (1:1-5:5) [      // (description_item (1:1-3:4) [
+                    (paragraph (1:3-1:10) [
+                        (text (1:3-1:10) "item one")
+                    ])
+                    (multiline_block_quote (3:3-5:5) [
+                        (paragraph (4:3-4:13) [
+                            (text (4:3-4:13) "Paragraph 1")
+                        ])
+                    ])
+                ])
+                (item (6:1-6:10) [      // (description_item (5:1-7:6) [
+                    (paragraph (6:3-6:10) [
+                        (text (6:3-6:10) "item two")
+                    ])
+                ])
+            ])
+        ])
+    );
+}

--- a/src/tests/propfuzz.rs
+++ b/src/tests/propfuzz.rs
@@ -17,6 +17,7 @@ fn propfuzz_doesnt_crash(md: String) {
             header_ids: Some("user-content-".to_string()),
             footnotes: true,
             description_lists: true,
+            multiline_block_quotes: true,
             front_matter_delimiter: None,
             #[cfg(feature = "shortcodes")]
             shortcodes: true,

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -172,6 +172,7 @@ impl<'o> XmlFormatter<'o> {
                 }
                 NodeValue::FrontMatter(_) => (),
                 NodeValue::BlockQuote => {}
+                NodeValue::MultilineBlockQuote(..) => {}
                 NodeValue::Item(..) => {}
                 NodeValue::DescriptionList => {}
                 NodeValue::DescriptionItem(..) => (),


### PR DESCRIPTION
Adds the ability to enclose multiple lines in a blockquote. Such as:

```
>>>
Paragraph one

Paragraph two
>>>
```

This is part of the GitLab Flavored Markdown (GLFM) specification, https://docs.gitlab.com/ee/user/markdown.html#multiline-blockquote
