### PR TITLE
Make non public nodes public

### DIFF
--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -5,7 +5,7 @@ use std::cell::RefCell;
 use std::convert::TryFrom;
 
 #[cfg(feature = "shortcodes")]
-use crate::parser::shortcodes::NodeShortCode;
+pub use crate::parser::shortcodes::NodeShortCode;
 
 pub use crate::parser::multiline_block_quote::NodeMultilineBlockQuote;
 

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -7,7 +7,7 @@ use std::convert::TryFrom;
 #[cfg(feature = "shortcodes")]
 use crate::parser::shortcodes::NodeShortCode;
 
-use crate::parser::multiline_block_quote::NodeMultilineBlockQuote;
+pub use crate::parser::multiline_block_quote::NodeMultilineBlockQuote;
 
 /// The core AST node enum.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/parser/shortcodes.rs
+++ b/src/parser/shortcodes.rs
@@ -8,14 +8,17 @@ pub struct NodeShortCode(
 );
 
 impl NodeShortCode {
+    /// Checks whether the input is a valid short code.
     pub fn is_valid(value: &str) -> bool {
         emojis::get_by_shortcode(value).is_some()
     }
 
+    /// Get the underlying shortcode.
     pub fn shortcode(&self) -> &str {
         &self.0
     }
 
+    /// Get the emoji for this short code.
     pub fn emoji(&self) -> &'static str {
         emojis::get_by_shortcode(&self.0).unwrap().as_str()
     }


### PR DESCRIPTION
`NodeMultilineBlockQuote` and `NodeShortCode` are not exported anywhere in this crate.