### PR TITLE
Avoid backslashes before a new block.

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "4f0807fb6f644c83f3e4ec014fec9858c1c8b26a7db8eb5f0bde5817df9c1df7"
 
 [[package]]
 name = "comrak"
-version = "0.20.0"
+version = "0.22.0"
 dependencies = [
  "arbitrary",
  "clap",


### PR DESCRIPTION
This changes the behaviour of the commonmark renderer to avoid rendering newlines as backslashes (1) at the end of a block and (2) when the next node in the current block is a block.

Fixes #372.

This isn't quite the solution that I described in the [comment](https://github.com/kivikakk/comrak/issues/372#issuecomment-2036177787), because I discovered another situation where backslash-newlines are treated differently from the double-space variant:
```text
a
\
b
```
is parsed as a single paragraph with a line break, but the double-space version is parsed as two paragraphs with no line break. I think the backslash variant is the one most likely to round-trip correctly, so I went with that as often as possible.