### PR TITLE
Expand traverse and descendants documentation: Issue #369

### DIFF
--- a/src/arena_tree.rs
+++ b/src/arena_tree.rs
@@ -142,15 +142,15 @@ impl<'a, T> Node<'a, T> {
     /// Call `.next().unwrap()` once on the iterator to skip the node itself.
     ///
     /// *Similar Functions:* Use `traverse()` or `reverse_traverse` if you need
-    /// references to the `NodeEdge` structs associated with each `AstNode`
+    /// references to the `NodeEdge` structs associated with each `Node`
     pub fn descendants(&'a self) -> Descendants<'a, T> {
         Descendants(self.traverse())
     }
 
-    /// Return an iterator of references to `NodeEdge` structs for each `Node` and its descendants,
+    /// Return an iterator of references to `NodeEdge` enums for each `Node` and its descendants,
     /// in tree order.
     ///
-    /// `NodeEdge` structs represent the `Start` and `End` of each node.
+    /// `NodeEdge` enums represent the `Start` or `End` of each node.
     ///
     /// *Similar Functions:* Use `descendants()` if you don't need `Start` and `End`.
     pub fn traverse(&'a self) -> Traverse<'a, T> {
@@ -160,10 +160,10 @@ impl<'a, T> Node<'a, T> {
         }
     }
 
-    /// Return an iterator of references to `NodeEdge` structs for each `Node` and its descendants,
+    /// Return an iterator of references to `NodeEdge` enums for each `Node` and its descendants,
     /// in *reverse* order.
     ///
-    /// `NodeEdge` structs represent the `Start` and `End` of each node.
+    /// `NodeEdge` enums represent the `Start` or `End` of each node.
     ///
     /// *Similar Functions:* Use `descendants()` if you don't need `Start` and `End`.
     pub fn reverse_traverse(&'a self) -> ReverseTraverse<'a, T> {

--- a/src/arena_tree.rs
+++ b/src/arena_tree.rs
@@ -136,15 +136,23 @@ impl<'a, T> Node<'a, T> {
         ReverseChildren(self.last_child.get())
     }
 
-    /// Return an iterator of references to this node and its descendants, in tree order.
+    /// Return an iterator of references to this `Node` and its descendants, in tree order.
     ///
     /// Parent nodes appear before the descendants.
     /// Call `.next().unwrap()` once on the iterator to skip the node itself.
+    ///
+    /// *Similar Functions:* Use `traverse()` or `reverse_traverse` if you need
+    /// references to the `NodeEdge` structs associated with each `AstNode`
     pub fn descendants(&'a self) -> Descendants<'a, T> {
         Descendants(self.traverse())
     }
 
-    /// Return an iterator of references to this node and its descendants, in tree order.
+    /// Return an iterator of references to `NodeEdge` structs for each `Node` and its descendants,
+    /// in tree order.
+    ///
+    /// `NodeEdge` structs represent the `Start` and `End` of each node.
+    ///
+    /// *Similar Functions:* Use `descendants()` if you don't need `Start` and `End`.
     pub fn traverse(&'a self) -> Traverse<'a, T> {
         Traverse {
             root: self,
@@ -152,7 +160,12 @@ impl<'a, T> Node<'a, T> {
         }
     }
 
-    /// Return an iterator of references to this node and its descendants, in tree order.
+    /// Return an iterator of references to `NodeEdge` structs for each `Node` and its descendants,
+    /// in *reverse* order.
+    ///
+    /// `NodeEdge` structs represent the `Start` and `End` of each node.
+    ///
+    /// *Similar Functions:* Use `descendants()` if you don't need `Start` and `End`.
     pub fn reverse_traverse(&'a self) -> ReverseTraverse<'a, T> {
         ReverseTraverse {
             root: self,


### PR DESCRIPTION
original traverse documentation is a shortened version of descendants
documentation. Edited documentation comments to clarify the following:

1. traverse and reverse_traverse return an iterator of `NodeEdge`
objects. `NodeEdge` objects mark start (similar to `<div>`) and end
(similar to `</div>`) of each node.

2. descendants returns an iterator of `Node` objects. This is probably
more useful if you want to play with the Node contents.

3. added a short "Similar Functions" section to the inline documentation
to point users in the right direction.

Improves on issue #369
