### PR TITLE
Change `relaxed-autolinks` to allow any url scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Options:
           Enable relaxing which character is allowed in a tasklists
 
       --relaxed-autolinks
-          Enable relaxing of autolink parsing, allowing links to be recognized when in brackets
+          Enable relaxing of autolink parsing, allow links to be recognized when in brackets
+          and allow all url schemes
 
       --default-info-string <INFO>
           Default value for fenced code block's info strings if none is given

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -135,6 +135,7 @@ dependencies = [
  "derive_builder",
  "emojis",
  "entities",
+ "in-place",
  "memchr",
  "once_cell",
  "regex",
@@ -303,6 +304,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +364,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "in-place"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdb69f3adfd5f493210cece799f4620417bf9965bc1536c22ae0e29ba27a8c0"
+dependencies = [
+ "tempfile",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +380,15 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -382,7 +410,7 @@ checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
- "rustix",
+ "rustix 0.36.16",
  "windows-sys 0.45.0",
 ]
 
@@ -444,6 +472,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "memchr"
@@ -563,13 +597,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -600,7 +643,21 @@ dependencies = [
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
  "windows-sys 0.45.0",
 ]
 
@@ -727,6 +784,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix 0.37.7",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,7 +811,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c9afddd2cec1c0909f06b00ef33f94ab2cc0578c4a610aa208ddfec8aa2b43a"
 dependencies = [
- "rustix",
+ "rustix 0.36.16",
  "windows-sys 0.45.0",
 ]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,8 @@ struct Cli {
     #[arg(long)]
     relaxed_tasklist_character: bool,
 
-    /// Enable relaxing of autolink parsing, allowing links to be recognized when in brackets
+    /// Enable relaxing of autolink parsing, allow links to be recognized when in brackets
+    /// and allow all url schemes
     #[arg(long)]
     relaxed_autolinks: bool,
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -462,7 +462,8 @@ pub struct ParseOptions {
     /// Whether or not a simple `x` or `X` is used for tasklist or any other symbol is allowed.
     pub relaxed_tasklist_matching: bool,
 
-    /// Relax parsing of autolinks, allowing links to be detected inside brackets.
+    /// Relax parsing of autolinks, allow links to be detected inside brackets
+    /// and allow all url schemes
     ///
     /// ```
     /// # use comrak::{markdown_to_html, Options};

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -22,10 +22,10 @@ fn autolink_email() {
 fn autolink_scheme() {
     html_opts!(
         [extension.autolink],
-        concat!("https://google.com/search\n"),
+        concat!("https://google.com/search\n", "rdar://localhost.com/blah"),
         concat!(
-            "<p><a href=\"https://google.com/search\">https://google.\
-             com/search</a></p>\n"
+            "<p><a href=\"https://google.com/search\">https://google.com/search</a>\n",
+            "rdar://localhost.com/blah</p>\n"
         ),
     );
 }
@@ -90,6 +90,36 @@ fn autolink_relaxed_links_in_brackets() {
         [
             "[<https://foo.com>]",
             "<p>[<a href=\"https://foo.com\">https://foo.com</a>]</p>\n",
+        ],
+    ];
+
+    for example in examples {
+        html_opts!(
+            [extension.autolink, parse.relaxed_autolinks],
+            example[0],
+            example[1]
+        );
+    }
+}
+
+#[test]
+fn autolink_relaxed_links_schemes() {
+    let examples = [
+        [
+            "https://foo.com",
+            "<p><a href=\"https://foo.com\">https://foo.com</a></p>\n",
+        ],
+        [
+            "smb:///Volumes/shared/foo.pdf",
+            "<p><a href=\"smb:///Volumes/shared/foo.pdf\">smb:///Volumes/shared/foo.pdf</a></p>\n",
+        ],
+        [
+            "irc://irc.freenode.net/git",
+            "<p><a href=\"irc://irc.freenode.net/git\">irc://irc.freenode.net/git</a></p>\n",
+        ],
+        [
+            "rdar://localhost.com/blah",
+            "<p><a href=\"rdar://localhost.com/blah\">rdar://localhost.com/blah</a></p>\n",
         ],
     ];
 


### PR DESCRIPTION
This change makes the `relaxed-autolinks` option allow any url scheme to be detected.

For example, `smb://example.com` would be detected as an autolink.

Closes https://github.com/kivikakk/comrak/issues/379