### PR TITLE
Fix release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,12 @@ jobs:
                   git add -f changelog.txt README.md
                   git commit -m "[auto-docs][skip test]: update changelog" || true
 
+            - name: Push to protected branch
+              uses: CasperWA/push-protected@v2
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  branch: main
+
             - name: Create tag
               run: |
                   git tag -a v${{ steps.version-label.outputs.version }} -m "Release v${{ steps.version-label.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,16 @@ name: Release and publish
 
 on:
     workflow_dispatch:
+    pull_request_target:
+        types:
+            - closed
 
 permissions:
     contents: write
     pull-requests: write
 
 jobs:
-    release:
+    prepare:
         runs-on: ubuntu-latest
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,7 +58,7 @@ jobs:
 
             - name: Update changelog.txt
               run: |
-                  echo "## [v${{ steps.version-label.outputs.version }}] - `date +%d-%m-%Y`" >> changelog.txt.tmp
+                  echo "# [v${{ steps.version-label.outputs.version }}] - `date +%d-%m-%Y`" >> changelog.txt.tmp
                   echo "${{steps.generate-release-notes.outputs.changelog}}" >> changelog.txt.tmp
                   echo '-n' >> changelog.txt
                   cat changelog.txt >> changelog.txt.tmp
@@ -66,29 +69,33 @@ jobs:
                   cargo run --example update-readme
 
             - name: Commit Changelog and README
-              run: |
-                  git config --local user.email "actions@github.com"
-                  git config --local user.name "Actions Auto Build"
-                  git add -f changelog.txt README.md
-                  git commit -m "[auto-docs][skip test]: update changelog" || true
+              run: git add -f changelog.txt README.md
 
-            - name: Push to protected branch
-              uses: CasperWA/push-protected@v2
+            - name: Create Pull Request
+              id: cpr
+              uses: peter-evans/create-pull-request@v6
+              with:
+                  commit-message: "[skip test] update changelog"
+                  title: "[skip test] Release v${{ steps.version-label.outputs.version }}"
+                  body: >
+                      This is an automated PR to build the latest changelog. Upon merging,
+                      a new release will be created and published to crates.io.<br/>
+                      Due to security considerations, PRs created by GitHub Actions cannot
+                      be merged automatically. Please review the changes and merge the PR.<br/>
+                      If you require the test suites to run, you can close the PR and reopen it to trigger
+                      those workflows.
+                  delete-branch: true
+                  labels: release
+                  branch: "release/v${{ steps.version-label.outputs.version }}"
+
+            - name: Enable Pull Request Automerge
+              uses: peter-evans/enable-pull-request-automerge@v3
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
-                  branch: main
+                  pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
 
-            - name: Create tag
-              run: |
-                  git tag -a v${{ steps.version-label.outputs.version }} -m "Release v${{ steps.version-label.outputs.version }}"
-                  git push origin --tags
-
-            - name: Publish GitHub release
-              run: |
-                  gh release create v${{ steps.version-label.outputs.version }} --generate-notes
-
-    publish:
-        needs: release
+    release:
+        if: ${{ (github.event.pull_request.merged == true) && (contains(github.event.pull_request.labels.*.name, 'release')) }}
         runs-on: ubuntu-latest
         env:
             CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
@@ -98,8 +105,23 @@ jobs:
               with:
                   submodules: recursive
 
+            - name: Get current version
+              id: version-label
+              run: |
+                  VERSION=$(grep version Cargo.toml | head -n 1 | cut -d'"' -f2)
+                  echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+            - name: Create tag
+              run: |
+                  git tag -a v${{ steps.version-label.outputs.version }} -m "Release v${{ steps.version-label.outputs.version }}"
+                  git push origin --tags
+
             - name: Login to Crates.io
               run: cargo login ${CRATES_IO_TOKEN}
+
+            - name: Publish GitHub release
+              run: |
+                  gh release create v${{ steps.version-label.outputs.version }} --generate-notes
 
             - name: Publish crate
               run: cargo publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,6 @@ jobs:
               with:
                   submodules: true
 
-            - name: Setup Rust
-              uses: actions-rs/toolchain@v1
-              with:
-                  profile: minimal
-                  toolchain: stable
-                  override: true
-
             - name: Configure Git
               run: |
                   git config --local user.email "actions@github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,8 @@ jobs:
                   git push origin --tags
 
             - name: Publish GitHub release
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   gh release create v${{ steps.version-label.outputs.version }} --generate-notes
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ permissions:
 jobs:
     release:
         runs-on: ubuntu-latest
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
         outputs:
             version: ${{ steps.version-label.outputs.version }}
@@ -51,13 +53,13 @@ jobs:
                   }
                   echo "changelog<<EOF"$'\n'"$(generate)"$'\n'EOF >> $GITHUB_OUTPUT
 
-            - name: Update CHANGELOG.md
+            - name: Update changelog.txt
               run: |
-                  echo "## [v${{ steps.version-label.outputs.version }}] - `date +%d-%m-%Y`" >> CHANGELOG.md.tmp
-                  echo "${{steps.generate-release-notes.outputs.changelog}}" >> CHANGELOG.md.tmp
-                  echo '-n' >> CHANGELOG.md
-                  cat CHANGELOG.md >> CHANGELOG.md.tmp
-                  mv CHANGELOG.md.tmp CHANGELOG.md
+                  echo "## [v${{ steps.version-label.outputs.version }}] - `date +%d-%m-%Y`" >> changelog.txt.tmp
+                  echo "${{steps.generate-release-notes.outputs.changelog}}" >> changelog.txt.tmp
+                  echo '-n' >> changelog.txt
+                  cat changelog.txt >> changelog.txt.tmp
+                  mv changelog.txt.tmp changelog.txt
 
             - name: Update README
               run: |
@@ -67,7 +69,7 @@ jobs:
               run: |
                   git config --local user.email "actions@github.com"
                   git config --local user.name "Actions Auto Build"
-                  git add -f CHANGELOG.md README.md
+                  git add -f changelog.txt README.md
                   git commit -m "[auto-docs][skip test]: update changelog" || true
 
             - name: Create tag
@@ -76,8 +78,6 @@ jobs:
                   git push origin --tags
 
             - name: Publish GitHub release
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   gh release create v${{ steps.version-label.outputs.version }} --generate-notes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "comrak"
-version = "0.23.1-pre.3"
+version = "0.23.0"
 dependencies = [
  "arbitrary",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.23.1-pre.2"
+version = "0.23.1-pre.3"
 dependencies = [
  "arbitrary",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.23.1-pre.1"
+version = "0.23.1-pre.2"
 dependencies = [
  "arbitrary",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comrak"
-version = "0.23.1-pre.2"
+version = "0.23.1-pre.3"
 authors = ["Amelia Cuss <amelia@kivikakk.ee>"]
 rust-version = "1.62.1"
 description = "A 100% CommonMark-compatible GitHub Flavored Markdown parser and formatter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comrak"
-version = "0.23.1-pre.3"
+version = "0.23.0"
 authors = ["Amelia Cuss <amelia@kivikakk.ee>"]
 rust-version = "1.62.1"
 description = "A 100% CommonMark-compatible GitHub Flavored Markdown parser and formatter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comrak"
-version = "0.23.1-pre.1"
+version = "0.23.1-pre.2"
 authors = ["Amelia Cuss <amelia@kivikakk.ee>"]
 rust-version = "1.62.1"
 description = "A 100% CommonMark-compatible GitHub Flavored Markdown parser and formatter"

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-### 0.23.0
+# [0.23.0]
 
 * add traverse() demo example by @kaesluder in https://github.com/kivikakk/comrak/pull/370
 * Avoid backslashes before a new block. by @jneem in https://github.com/kivikakk/comrak/pull/373
@@ -11,7 +11,7 @@
 * Return brackets in autolinks behavior back to cmark-gfm by @digitalmoksha in https://github.com/kivikakk/comrak/pull/386
 
 
-### 0.22.0
+# [0.22.0]
 
 * Fix broken docs link in README by @ohakutsu in https://github.com/kivikakk/comrak/pull/364
 * Make non public nodes public by @mfontanini in https://github.com/kivikakk/comrak/pull/363
@@ -20,19 +20,19 @@
 * Add math support by @digitalmoksha in https://github.com/kivikakk/comrak/pull/366
 
 
-### 0.21.0
+# [0.21.0]
 
 * Add a multiline blockquote extension by @digitalmoksha in https://github.com/kivikakk/comrak/pull/359
 
 
-### 0.20.0
+# [0.20.0]
 
 * build(deps): bump rustix from 0.36.11 to 0.36.16 in /fuzz by @dependabot in https://github.com/kivikakk/comrak/pull/346
 * Use Nix for CI. by @charlottia in https://github.com/kivikakk/comrak/pull/338
 * Allow for Syntect to simply generate CSS classes by @gjtorikian in https://github.com/kivikakk/comrak/pull/347
 
 
-### 0.19.0
+# [0.19.0]
 
 * Simplify anchorize() by @kornelski in https://github.com/kivikakk/comrak/pull/297
 * Use footnote name for reference id by @digitalmoksha in https://github.com/kivikakk/comrak/pull/300
@@ -59,14 +59,14 @@
 * Sync with cmark-gfm-0.29.0.gfm.13 by @digitalmoksha in https://github.com/kivikakk/comrak/pull/345
 
 
-### 0.18.0
+# [0.18.0]
 
 * Improve performance of bundled plugins, and streaming I/O by @kivikakk in https://github.com/kivikakk/comrak/pull/288
 * Implement Default for enums without using #[default] attribute by @silverpill in https://github.com/kivikakk/comrak/pull/293
 * XML and sourcepos support by @kivikakk in https://github.com/kivikakk/comrak/pull/232
 * Add a quadratic fuzzer by @philipturnbull in https://github.com/kivikakk/comrak/pull/295
 
-### 0.17.1
+# [0.17.1]
 
 * Fix some panics found by trivial fuzzing.
 
@@ -76,7 +76,7 @@ Missed from the 0.17.0 changelog:
 * Add support for full_info_string render option by @digitalmoksha in https://github.com/kivikakk/comrak/pull/276
 * chore: improve debug performance by @conradludgate in https://github.com/kivikakk/comrak/pull/283
 
-### 0.17.0
+# [0.17.0]
 
 This contains some breaking changes from an API point of view, but output is
 largely unchanged.  Spec compliance is improved, and benchmark runtime is over
@@ -100,7 +100,7 @@ Many thanks to @philipturnbull and @darakian of the GitHub Security Lab for
 bringing these issues to my attention and detailing the reproduction steps for
 each case.
 
-### 0.16.0
+# [0.16.0]
 
 * Track which symbol was used to mark task item as checked by @felipesere in https://github.com/kivikakk/comrak/pull/252
 * improve tagfilter performance by @fiji-flo in https://github.com/kivikakk/comrak/pull/256
@@ -111,7 +111,7 @@ each case.
 * Add custom heading adapter by @lucperkins in https://github.com/kivikakk/comrak/pull/266
 * Keep track of "^" symbol when within footnotes by @gjtorikian in https://github.com/kivikakk/comrak/pull/274
 
-### 0.15.0
+# [0.15.0]
 
 * table: fix start_line of Table itself by @kivikakk in https://github.com/kivikakk/comrak/pull/231
 * Rename header file to match c libname by @gjtorikian in https://github.com/kivikakk/comrak/pull/233
@@ -127,7 +127,7 @@ each case.
 * Bump clap version to 4.0 and switch to the Derive API by @tranzystorek-io in https://github.com/kivikakk/comrak/pull/248
 * c-api: remove by @kivikakk in https://github.com/kivikakk/comrak/pull/249
 
-### 0.14.0
+# [0.14.0]
 
 * Add C FFI, allowing Comrak to be used from other languages. (#171, Garen
   Torikian)
@@ -135,16 +135,16 @@ each case.
 * Add option to specify character used for unordered list bullets in
   CommonMark output. (#229, Edward Loveall)
 
-### 0.13.2
+# [0.13.2]
 
 * Fix Windows build.
 
-### 0.13.1
+# [0.13.1]
 
 * Support compiling for WASM. (#222, Ben Wishoshavich)
 * Replace deprecated twoway dependency. (#224)
 
-### 0.13.0
+# [0.13.0]
 
 * SECURITY: Bump regex to 1.5.5. (#221, Dependabot)
 * Drop unneeded YAML dependency from Syntect. (#199, Chris Wong)
@@ -154,127 +154,127 @@ each case.
 * Line break handling adjustments. (#214, Michael Anderson)
 * Disable control characters in link definitions. (#219, Michael Anderson)
 
-### 0.12.1
+# [0.12.1]
 
 * Only load syntax and theme sets once, on Syntect plugin instantiation. (#197)
 * Match syntax highlighting language names more loosely. (#198)
 
-### 0.12.0
+# [0.12.0]
 
 * Add pluggable syntax highlighting, and default implementation with syntect.
   (Daniel Simon, #194)
 
-### 0.11.0
+# [0.11.0]
 
 * Allow short URLs even with non-empty path. (#191, Bernard Teo)
 * Expose NodeCode struct in AST. (#192, Vojtech Kral)
 
-### 0.10.1
+# [0.10.1]
 
 * SECURITY: it was possible to smuggle unsafe URLs --- like `javascript:` ones
   --- even without using the "unsafe" mode of operation.  Thanks to Sam Sanoop
   (snoopysecurity) for reporting.
 * Recognise tables without a preceding newline. (#183)
 
-### 0.10.0
+# [0.10.0]
 
 * 0.9.1 was a semver-breaking change.
 * Add -o/--output CLI option. (#177)
 
-### 0.9.1
+# [0.9.1]
 
 * SECURITY: we were matching unsafe URL prefixes, such as `data:` or
   `javascript:`, in a case-sensitive manner.  This meant prefixes like `Data:`
   were untouched.  Please upgrade as soon as possible.  (Kouhei Morita)
 * Add support for ignoring front matter. (#170, Eitan Mosenkis.)
 
-### 0.9.0
+# [0.9.0]
 
 * 0.8.2 was a semver-breaking change, so we're now bumping to 0.9.0.  Some
   tests have been added to catch this in future.
 * Allow image/ prefix on data URIs. (#169, Daniel Sorichetti)
 
-### 0.8.2
+# [0.8.2]
 
 * Fix some lint issues. (#152, Caleb Maclennan)
 * Build benchmarks separately to tests. (#154)
 * Add support for a config file for CLI use. (#157, with thanks to AJ ONeal.)
 
-### 0.8.1
+# [0.8.1]
 
 * Add escape option to escape raw HTML instead of clobbering it. (#150, Ryan
   Westlund)
 
-### 0.8.0
+# [0.8.0]
 
 * 0.7.1 was a semver-breaking change.  This is now 0.8.0.
 
-### 0.7.1
+# [0.7.1]
 
 * Reduce list item indentation in line with spec. (#135, Casey Rodarmor)
 * Split uber-struct ComrakOptions into substructures.
 * Refactor HTML formatter escaping. (#140, Donough Liu)
 * Don't render <p> inside <dt> tags. (#145)
 
-### 0.7.0
+# [0.7.0]
 
 * Supporting stable and newer again, since dependencies keep breaking for
   1.27.0. (#134)
 
-### 0.6.2
+# [0.6.2]
 
 * Exclude unneeded files from crate. (#120, Igor Gnatenko)
 * Bump the twoway dependency. (#121, Igor Gnatenko)
 
-### 0.6.1
+# [0.6.1]
 
 * Add --gfm flag to CLI to enable all GitHub Flavored Markdown extensions and
   options. (#118, James R Miller)
 
-### 0.6.0
+# [0.6.0]
 
 * Add TaskItem variant to NodeValue. (#115, Élisabeth Henry)
 
-### 0.5.1
+# [0.5.1]
 
 * Support building on Rust versions back to 1.27.0. (#114)
 
-### 0.5.0
+# [0.5.0]
 
 * Update API so that footnote reference and definition identifiers match.
   (#110, Élisabeth Henry)
 * Update to CommonMark spec 0.29. (#112)
 
-### 0.4.4
+# [0.4.4]
 
 * Add From<NodeValue> impl to AstNode. (#105, Sunjay Varma)
 
-### 0.4.3
+# [0.4.3]
 
 * Add a Default derive and Ast::new to make ASTs programmatically
   constructible. (#101, Sunjay Varma and #102)
 
-### 0.4.2
+# [0.4.2]
 
 * Add a callback to fill in broken reference links, per pulldown_cmark's
   Parser::new_with_broken_link_callback. (#100, Sunjay Varma)
 * Update to latest spec.  (#99)
 
-### 0.4.1
+# [0.4.1]
 
 * Fix a bug in anchor generation; it should now be on par with GitHub's. (#97, Clifford T. Matthews)
 * Expose anchor generation for use in library consumers. (#94, Clifford T. Matthews)
 
-### 0.4.0
+# [0.4.0]
 
 * Invert default-false `safe` flag to default-false `unsafe_` flag.  If you
   were not enabling safe mode before, you'll need to enable unsafe mode now.
 
-### 0.3.1
+# [0.3.1]
 
 * Keep up-to-date with the spec.
 
-### 0.3.0
+# [0.3.0]
 
 * Significant test coverage and code clean up. (#82, #83, Brian Anderson)
 * Description list support. (#86, Ayose Cazorla)
@@ -282,83 +282,83 @@ each case.
 * Footnotes are now enabled via an extension option, not a flag of its own. (#87)
 * Extend `cmark-gfm` compatibility to include all extension and regression tests. (#87)
 
-### 0.2.14
+# [0.2.14]
 
 * Speed enhancements. (#76, Brian Anderson)
 * Target latest spec; bring comrak closer into line with cmark. (#81, Brian Anderson and Ashe Connor)
 
-### 0.2.13
+# [0.2.13]
 
 * Speed enhancements. (#75, Shaquille Johnson)
 
-### 0.2.12
+# [0.2.12]
 
 * Add safety options per the reference C implementation. (#67)
 
-### 0.2.11
+# [0.2.11]
 
 * Expose Arena type so users don't need to bring it in themselves (#66, Vincent
   Prouillet).
 
-### 0.2.10
+# [0.2.10]
 
 * Bring up to date with latest spec.
 * Fix parsing of tables nested in other block elements (#61, Brian Anderson).
 * Protect against stack smashing in inline processors and CommonMark and HTML
   formatters (#63, Brian Anderson).
 
-### 0.2.9
+# [0.2.9]
 
 * Fix a corner case in the ATX header parser (#53, Brian Anderson).
 * Fix grammar for scanning table marker rows (#55, Brian Anderson).
 * Add smart punctuation (#57).
 
-### 0.2.8
+# [0.2.8]
 
 * Add `default-info-string` argument/option to specify a default language in fenced
   code blocks. (Thanks to @steveklabnik for the suggestion.)
 
-### 0.2.7
+# [0.2.7]
 
 * Use [`pest`](https://github.com/pest-parser/pest) instead of regexes for lexing.
 
-### 0.2.6
+# [0.2.6]
 
 * Fixed a bug where back-to-back emphases would not be processed correctly.
   (#45; thanks to @SSJohns for the report.)
 
-### 0.2.5
+# [0.2.5]
 
 * Fixed a bug where an exclamation mark "!" followed by a footnote would be
   eaten by the parser.
 
-### 0.2.4
+# [0.2.4]
 
 * Added footnotes support.
 
-### 0.2.3
+# [0.2.3]
 
 * Added header IDs extension.
 
-### 0.2.2
+# [0.2.2]
 
 * Fix for pathological reference link parsing.
 
-### 0.2.1
+# [0.2.1]
 
 * Speed optimisations.
 
-### 0.2.0
+# [0.2.0]
 
 * The formatters no longer produce Strings themeselves; you must specify an
   output stream.
 * Speed up whitespace normalisation.
 
-### 0.1.9
+# [0.1.9]
 
 * Multibyte character fix for autolink (#35, Shaquille Johnson).
 * Resolve panics with tables in awkward situations (#36).
 
-### 0.1.8
+# [0.1.8]
 
 * Fix possible DoS in link parsing (#33, Demi Obenour).


### PR DESCRIPTION
The bad news is I made a slight error in https://github.com/kivikakk/comrak/pull/374: I needed to provide a GitHub token to create a release.

The good news is that now that the workflow is in `main`, I can make any adjustments necessary here in the PR. 

I also noticed a bunch of warnings stemming from the (deprecated!) https://github.com/actions-rs/toolchain action:

<img width="1315" alt="Screenshot 2024-05-01 at 12 53 54" src="https://github.com/kivikakk/comrak/assets/64050/2a24344a-a679-4cf9-9d98-fc6e1336a09d">

I'm actually not sure why I included this step, because it's not at all necessary to have Rust installed for this process.