### PR TITLE
Add support for wikilinks format

### DIFF
--- a/examples/s-expr.rs
+++ b/examples/s-expr.rs
@@ -86,6 +86,8 @@ fn dump(source: &str) -> io::Result<()> {
         .multiline_block_quotes(true)
         .math_dollars(true)
         .math_code(true)
+        .wikilinks_title_after_pipe(true)
+        .wikilinks_title_before_pipe(true)
         .build()
         .unwrap();
 

--- a/fuzz/fuzz_targets/all_options.rs
+++ b/fuzz/fuzz_targets/all_options.rs
@@ -23,7 +23,9 @@ fuzz_target!(|s: &str| {
     extension.math_code = true;
     extension.front_matter_delimiter = Some("---".to_string());
     extension.shortcodes = true;
-
+    extension.wikilinks_title_after_pipe = true;
+    extension.wikilinks_title_before_pipe = true;
+    
     let mut parse = ParseOptions::default();
     parse.smart = true;
     parse.default_info_string = Some("rust".to_string());

--- a/fuzz/fuzz_targets/quadratic.rs
+++ b/fuzz/fuzz_targets/quadratic.rs
@@ -196,6 +196,8 @@ struct FuzzExtensionOptions {
     math_dollars: bool,
     math_code: bool,
     shortcodes: bool,
+    wikilinks_title_after_pipe: bool,
+    wikilinks_title_before_pipe: bool,
 }
 
 impl FuzzExtensionOptions {
@@ -213,6 +215,8 @@ impl FuzzExtensionOptions {
         extension.math_dollars = self.math_dollars;
         extension.math_code = self.math_code;
         extension.shortcodes = self.shortcodes;
+        extension.wikilinks_title_after_pipe = self.wikilinks_title_after_pipe;
+        extension.wikilinks_title_before_pipe = self.wikilinks_title_before_pipe;
         extension.front_matter_delimiter = None;
         extension.header_ids = None;
         extension

--- a/script/cibuild
+++ b/script/cibuild
@@ -40,6 +40,10 @@ python3 spec_tests.py --no-normalize --spec ../../../src/tests/fixtures/math_dol
   || failed=1
 python3 spec_tests.py --no-normalize --spec ../../../src/tests/fixtures/math_code.md "$PROGRAM_ARG -e math-code" \
   || failed=1
+python3 spec_tests.py --no-normalize --spec ../../../src/tests/fixtures/wikilinks_title_after_pipe.md "$PROGRAM_ARG -e wikilinks-title-after-pipe" \
+  || failed=1
+python3 spec_tests.py --no-normalize --spec ../../../src/tests/fixtures/wikilinks_title_before_pipe.md "$PROGRAM_ARG -e wikilinks-title-before-pipe" \
+  || failed=1
 
 python3 spec_tests.py --no-normalize --spec regression.txt "$PROGRAM_ARG" \
 	|| failed=1

--- a/src/html.rs
+++ b/src/html.rs
@@ -826,6 +826,9 @@ impl<'o> HtmlFormatter<'o> {
                         self.output.write_all(b"\" title=\"")?;
                         self.escape(nl.title.as_bytes())?;
                     }
+                    if nl.wikilink {
+                        self.output.write_all(b"\" data-wikilink=\"true")?;
+                    }
                     self.output.write_all(b"\">")?;
                 } else {
                     self.output.write_all(b"</a>")?;

--- a/src/html.rs
+++ b/src/html.rs
@@ -826,9 +826,6 @@ impl<'o> HtmlFormatter<'o> {
                         self.output.write_all(b"\" title=\"")?;
                         self.escape(nl.title.as_bytes())?;
                     }
-                    if nl.wikilink {
-                        self.output.write_all(b"\" data-wikilink=\"true")?;
-                    }
                     self.output.write_all(b"\">")?;
                 } else {
                     self.output.write_all(b"</a>")?;
@@ -1039,6 +1036,21 @@ impl<'o> HtmlFormatter<'o> {
             }) => {
                 if entering {
                     self.render_math_inline(node, literal, display_math, dollar_math)?;
+                }
+            }
+            NodeValue::WikiLink(ref nl) => {
+                if entering {
+                    self.output.write_all(b"<a")?;
+                    self.render_sourcepos(node)?;
+                    self.output.write_all(b" href=\"")?;
+                    let url = nl.url.as_bytes();
+                    if self.options.render.unsafe_ || !dangerous_url(url) {
+                        self.escape_href(url)?;
+                    }
+                    self.output.write_all(b"\" data-wikilink=\"true")?;
+                    self.output.write_all(b"\">")?;
+                } else {
+                    self.output.write_all(b"</a>")?;
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,8 @@ enum Extension {
     MultilineBlockQuotes,
     MathDollars,
     MathCode,
+    WikilinksTitleAfterPipe,
+    WikilinksTitleBeforePipe,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -238,6 +240,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .multiline_block_quotes(exts.contains(&Extension::MultilineBlockQuotes))
         .math_dollars(exts.contains(&Extension::MathDollars))
         .math_code(exts.contains(&Extension::MathCode))
+        .wikilinks_title_after_pipe(exts.contains(&Extension::WikilinksTitleAfterPipe))
+        .wikilinks_title_before_pipe(exts.contains(&Extension::WikilinksTitleBeforePipe))
         .front_matter_delimiter(cli.front_matter_delimiter);
 
     #[cfg(feature = "shortcodes")]

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -182,6 +182,9 @@ pub enum NodeValue {
 
     /// **Inline**.  A character that has been [escaped](https://github.github.com/gfm/#backslash-escapes)
     Escaped,
+
+    /// **Inline**.  A wikilink to some URL.
+    WikiLink(NodeWikiLink),
 }
 
 /// Alignment of a single table cell.
@@ -251,9 +254,13 @@ pub struct NodeLink {
     /// Note this field is used for the `title` attribute by the HTML formatter even for images;
     /// `alt` text is supplied in the image inline text.
     pub title: String,
+}
 
-    /// Whether this is a wikilink or not.
-    pub wikilink: bool,
+/// The details of a wikilink's destination.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeWikiLink {
+    /// The URL for the link destination.
+    pub url: String,
 }
 
 /// The metadata of a list; the kind of list, the delimiter used and so on.
@@ -492,6 +499,7 @@ impl NodeValue {
             NodeValue::MultilineBlockQuote(_) => "multiline_block_quote",
             NodeValue::Escaped => "escaped",
             NodeValue::Math(..) => "math",
+            NodeValue::WikiLink(..) => "wikilink",
         }
     }
 }
@@ -642,7 +650,8 @@ pub fn can_contain_type<'a>(node: &'a AstNode<'a>, child: &NodeValue) -> bool {
         | NodeValue::Emph
         | NodeValue::Strong
         | NodeValue::Link(..)
-        | NodeValue::Image(..) => !child.block(),
+        | NodeValue::Image(..)
+        | NodeValue::WikiLink(..) => !child.block(),
 
         NodeValue::Table(..) => matches!(*child, NodeValue::TableRow(..)),
 
@@ -660,6 +669,7 @@ pub fn can_contain_type<'a>(node: &'a AstNode<'a>, child: &NodeValue) -> bool {
                 | NodeValue::Strikethrough
                 | NodeValue::HtmlInline(..)
                 | NodeValue::Math(..)
+                | NodeValue::WikiLink(..)
         ),
 
         #[cfg(feature = "shortcodes")]
@@ -675,6 +685,7 @@ pub fn can_contain_type<'a>(node: &'a AstNode<'a>, child: &NodeValue) -> bool {
                 | NodeValue::Strikethrough
                 | NodeValue::HtmlInline(..)
                 | NodeValue::Math(..)
+                | NodeValue::WikiLink(..)
         ),
 
         NodeValue::MultilineBlockQuote(_) => {

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -251,6 +251,9 @@ pub struct NodeLink {
     /// Note this field is used for the `title` attribute by the HTML formatter even for images;
     /// `alt` text is supplied in the image inline text.
     pub title: String,
+
+    /// Whether this is a wikilink or not
+    pub wikilink: bool,
 }
 
 /// The metadata of a list; the kind of list, the delimiter used and so on.

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -253,7 +253,7 @@ pub struct NodeLink {
     pub title: String,
 
     /// Whether this is a wikilink or not.
-    pub wikilink: bool = false,
+    pub wikilink: bool,
 }
 
 /// The metadata of a list; the kind of list, the delimiter used and so on.

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -252,8 +252,8 @@ pub struct NodeLink {
     /// `alt` text is supplied in the image inline text.
     pub title: String,
 
-    /// Whether this is a wikilink or not
-    pub wikilink: bool,
+    /// Whether this is a wikilink or not.
+    pub wikilink: bool = false,
 }
 
 /// The metadata of a list; the kind of list, the delimiter used and so on.

--- a/src/parser/autolink.rs
+++ b/src/parser/autolink.rs
@@ -122,6 +122,7 @@ fn www_match<'a>(
         NodeValue::Link(NodeLink {
             url,
             title: String::new(),
+            wikilink: false,
         }),
         (0, 1, 0, 1).into(),
     );
@@ -290,6 +291,7 @@ fn url_match<'a>(
         NodeValue::Link(NodeLink {
             url: url.clone(),
             title: String::new(),
+            wikilink: false,
         }),
         (0, 1, 0, 1).into(),
     );
@@ -398,6 +400,7 @@ fn email_match<'a>(
         NodeValue::Link(NodeLink {
             url,
             title: String::new(),
+            wikilink: false,
         }),
         (0, 1, 0, 1).into(),
     );

--- a/src/parser/autolink.rs
+++ b/src/parser/autolink.rs
@@ -122,7 +122,6 @@ fn www_match<'a>(
         NodeValue::Link(NodeLink {
             url,
             title: String::new(),
-            wikilink: false,
         }),
         (0, 1, 0, 1).into(),
     );
@@ -291,7 +290,6 @@ fn url_match<'a>(
         NodeValue::Link(NodeLink {
             url: url.clone(),
             title: String::new(),
-            wikilink: false,
         }),
         (0, 1, 0, 1).into(),
     );
@@ -400,7 +398,6 @@ fn email_match<'a>(
         NodeValue::Link(NodeLink {
             url,
             title: String::new(),
-            wikilink: false,
         }),
         (0, 1, 0, 1).into(),
     );

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1491,7 +1491,11 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
     pub fn close_bracket_match(&mut self, is_image: bool, url: String, title: String) {
         let brackets_len = self.brackets.len();
 
-        let nl = NodeLink { url, title };
+        let nl = NodeLink {
+            url,
+            title,
+            wikilink: false,
+        };
         let inl = self.make_inline(
             if is_image {
                 NodeValue::Image(nl)
@@ -1585,6 +1589,7 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
         let nl = NodeLink {
             url: String::from_utf8(url_clean).unwrap(),
             title: String::new(),
+            wikilink: true,
         };
         let inl = self.make_inline(NodeValue::Link(nl), startpos - 1, self.pos - 1);
         inl.append(self.make_inline(
@@ -1724,6 +1729,7 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
             NodeValue::Link(NodeLink {
                 url: String::from_utf8(strings::clean_autolink(url, kind)).unwrap(),
                 title: String::new(),
+                wikilink: false,
             }),
             start_column + 1,
             end_column + 1,

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -183,11 +183,30 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
             '.' => Some(self.handle_period()),
             '[' => {
                 self.pos += 1;
-                let inl =
-                    self.make_inline(NodeValue::Text("[".to_string()), self.pos - 1, self.pos - 1);
-                self.push_bracket(false, inl);
-                self.within_brackets = true;
-                Some(inl)
+
+                let mut wikilink_inl = None;
+
+                if (self.options.extension.wikilinks_title_after_pipe
+                    || self.options.extension.wikilinks_title_before_pipe)
+                    && !self.within_brackets
+                    && self.peek_char() == Some(&(b'['))
+                {
+                    wikilink_inl = self.handle_wikilink();
+                }
+
+                if wikilink_inl.is_none() {
+                    let inl = self.make_inline(
+                        NodeValue::Text("[".to_string()),
+                        self.pos - 1,
+                        self.pos - 1,
+                    );
+                    self.push_bracket(false, inl);
+                    self.within_brackets = true;
+
+                    Some(inl)
+                } else {
+                    wikilink_inl
+                }
             }
             ']' => {
                 self.within_brackets = false;
@@ -1546,6 +1565,117 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
             self.pos = startpos;
             None
         }
+    }
+
+    // Handles wikilink syntax
+    //   [[link text|url]]
+    //   [[url|link text]]
+    pub fn handle_wikilink(&mut self) -> Option<&'a AstNode<'a>> {
+        let startpos = self.pos;
+        let (url, title) = self.wikilink_url_title();
+
+        url?;
+
+        let url_clean = strings::clean_url(url.unwrap());
+        let title_clean = match title {
+            Some(title) => entity::unescape_html(title),
+            None => entity::unescape_html(url.unwrap()),
+        };
+
+        let nl = NodeLink {
+            url: String::from_utf8(url_clean).unwrap(),
+            title: String::new(),
+        };
+        let inl = self.make_inline(NodeValue::Link(nl), startpos - 1, self.pos - 1);
+        inl.append(self.make_inline(
+            NodeValue::Text(String::from_utf8(title_clean).unwrap()),
+            startpos - 1,
+            self.pos - 1,
+        ));
+
+        Some(inl)
+    }
+
+    pub fn wikilink_url_title(&mut self) -> (Option<&[u8]>, Option<&[u8]>) {
+        let left_startpos = self.pos;
+
+        if self.peek_char() != Some(&(b'[')) {
+            return (None, None);
+        }
+
+        let found_left = self.wikilink_component();
+
+        if !found_left {
+            self.pos = left_startpos;
+            return (None, None);
+        }
+
+        let left = strings::trim_slice(&self.input[left_startpos + 1..self.pos]);
+
+        if self.peek_char() == Some(&(b']')) && self.peek_char_n(1) == Some(&(b']')) {
+            self.pos += 2;
+            return (Some(left), None);
+        } else if self.peek_char() != Some(&(b'|')) {
+            self.pos = left_startpos;
+            return (None, None);
+        }
+
+        let right_startpos = self.pos;
+        let found_right = self.wikilink_component();
+
+        if !found_right {
+            self.pos = left_startpos;
+            return (None, None);
+        }
+
+        let right = strings::trim_slice(&self.input[right_startpos + 1..self.pos]);
+
+        if self.peek_char() == Some(&(b']')) && self.peek_char_n(1) == Some(&(b']')) {
+            self.pos += 2;
+
+            if self.options.extension.wikilinks_title_after_pipe {
+                (Some(left), Some(right))
+            } else {
+                (Some(right), Some(left))
+            }
+        } else {
+            self.pos = left_startpos;
+            (None, None)
+        }
+    }
+
+    // Locates the edge of a wikilink component (link text or url), and sets the
+    // self.pos to it's end if it's found.
+    pub fn wikilink_component(&mut self) -> bool {
+        let startpos = self.pos;
+
+        if self.peek_char() != Some(&(b'[')) && self.peek_char() != Some(&(b'|')) {
+            return false;
+        }
+
+        self.pos += 1;
+
+        let mut length = 0;
+        let mut c = 0;
+        while unwrap_into_copy(self.peek_char(), &mut c) && c != b'[' && c != b']' && c != b'|' {
+            if c == b'\\' {
+                self.pos += 1;
+                length += 1;
+                if self.peek_char().map_or(false, |&c| ispunct(c)) {
+                    self.pos += 1;
+                    length += 1;
+                }
+            } else {
+                self.pos += 1;
+                length += 1;
+            }
+            if length > MAX_LINK_LABEL_LENGTH {
+                self.pos = startpos;
+                return false;
+            }
+        }
+
+        true
     }
 
     pub fn spnl(&mut self) {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -423,6 +423,36 @@ pub struct ExtensionOptions {
     ///            "<p>Happy Friday! 😄</p>\n");
     /// ```
     pub shortcodes: bool,
+
+    /// Enables wikilinks using title after pipe syntax
+    ///
+    /// ```` md
+    /// [[url|link text]]
+    /// ````
+    ///
+    /// ```
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
+    /// options.extension.wikilinks_title_after_pipe = true;
+    /// assert_eq!(markdown_to_html("[[url|link text]]", &options),
+    ///            "<p><a href=\"url\">link text</a></p>\n");
+    /// ```
+    pub wikilinks_title_after_pipe: bool,
+
+    /// Enables wikilinks using title before pipe syntax
+    ///
+    /// ```` md
+    /// [[link text|url]]
+    /// ````
+    ///
+    /// ```
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
+    /// options.extension.wikilinks_title_before_pipe = true;
+    /// assert_eq!(markdown_to_html("[[link text|url]]", &options),
+    ///            "<p><a href=\"url\">link text</a></p>\n");
+    /// ```
+    pub wikilinks_title_before_pipe: bool,
 }
 
 #[non_exhaustive]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -427,30 +427,30 @@ pub struct ExtensionOptions {
     /// Enables wikilinks using title after pipe syntax
     ///
     /// ```` md
-    /// [[url|link text]]
+    /// [[url|link label]]
     /// ````
     ///
     /// ```
     /// # use comrak::{markdown_to_html, Options};
     /// let mut options = Options::default();
     /// options.extension.wikilinks_title_after_pipe = true;
-    /// assert_eq!(markdown_to_html("[[url|link text]]", &options),
-    ///            "<p><a href=\"url\" data-wikilink=\"true\">link text</a></p>\n");
+    /// assert_eq!(markdown_to_html("[[url|link label]]", &options),
+    ///            "<p><a href=\"url\" data-wikilink=\"true\">link label</a></p>\n");
     /// ```
     pub wikilinks_title_after_pipe: bool,
 
     /// Enables wikilinks using title before pipe syntax
     ///
     /// ```` md
-    /// [[link text|url]]
+    /// [[link label|url]]
     /// ````
     ///
     /// ```
     /// # use comrak::{markdown_to_html, Options};
     /// let mut options = Options::default();
     /// options.extension.wikilinks_title_before_pipe = true;
-    /// assert_eq!(markdown_to_html("[[link text|url]]", &options),
-    ///            "<p><a href=\"url\" data-wikilink=\"true\">link text</a></p>\n");
+    /// assert_eq!(markdown_to_html("[[link label|url]]", &options),
+    ///            "<p><a href=\"url\" data-wikilink=\"true\">link label</a></p>\n");
     /// ```
     pub wikilinks_title_before_pipe: bool,
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -435,7 +435,7 @@ pub struct ExtensionOptions {
     /// let mut options = Options::default();
     /// options.extension.wikilinks_title_after_pipe = true;
     /// assert_eq!(markdown_to_html("[[url|link text]]", &options),
-    ///            "<p><a href=\"url\">link text</a></p>\n");
+    ///            "<p><a href=\"url\" data-wikilink=\"true\">link text</a></p>\n");
     /// ```
     pub wikilinks_title_after_pipe: bool,
 
@@ -450,7 +450,7 @@ pub struct ExtensionOptions {
     /// let mut options = Options::default();
     /// options.extension.wikilinks_title_before_pipe = true;
     /// assert_eq!(markdown_to_html("[[link text|url]]", &options),
-    ///            "<p><a href=\"url\">link text</a></p>\n");
+    ///            "<p><a href=\"url\" data-wikilink=\"true\">link text</a></p>\n");
     /// ```
     pub wikilinks_title_before_pipe: bool,
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -25,6 +25,7 @@ mod superscript;
 mod table;
 mod tagfilter;
 mod tasklist;
+mod wikilinks;
 mod xml;
 
 #[track_caller]
@@ -141,6 +142,8 @@ macro_rules! html_opts {
                 math_code: true,
                 front_matter_delimiter: Some("---".to_string()),
                 shortcodes: true,
+                wikilinks_title_after_pipe: true,
+                wikilinks_title_before_pipe: true,
             },
             parse: $crate::ParseOptions {
                 smart: true,

--- a/src/tests/api.rs
+++ b/src/tests/api.rs
@@ -50,6 +50,8 @@ fn exercise_full_api() {
     extension.front_matter_delimiter(None);
     #[cfg(feature = "shortcodes")]
     extension.shortcodes(true);
+    extension.wikilinks_title_after_pipe(true);
+    extension.wikilinks_title_before_pipe(true);
 
     let mut parse = ParseOptionsBuilder::default();
     parse.smart(false);

--- a/src/tests/api.rs
+++ b/src/tests/api.rs
@@ -228,5 +228,8 @@ fn exercise_full_api() {
             let _: bool = math.dollar_math;
             let _: String = math.literal;
         }
+        nodes::NodeValue::WikiLink(nl) => {
+            let _: String = nl.url;
+        }
     }
 }

--- a/src/tests/commonmark.rs
+++ b/src/tests/commonmark.rs
@@ -55,3 +55,12 @@ fn math(markdown: &str, cm: &str) {
 
     commonmark(markdown, cm, Some(&options));
 }
+
+#[test_case("This [[url]] that", "This [[url|url]] that\n")]
+#[test_case("This [[url|link label]] that", "This [[url|link%20label]] that\n")]
+fn wikilinks(markdown: &str, cm: &str) {
+    let mut options = Options::default();
+    options.extension.wikilinks_title_before_pipe = true;
+
+    commonmark(markdown, cm, Some(&options));
+}

--- a/src/tests/fixtures/wikilinks_title_after_pipe.md
+++ b/src/tests/fixtures/wikilinks_title_after_pipe.md
@@ -1,0 +1,47 @@
+---
+title: Wikilinks
+based_on: https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/wikilinks_title_after_pipe.md
+---
+
+# Wikilinks, title after pipe
+
+Wikilinks can have one of the following forms:
+
+    [[https://example.org]]
+    [[https://example.org|title]]
+    [[name of page]]
+    [[name of page|title]]
+
+With this version of wikilinks, the title comes after the pipe.
+
+```````````````````````````````` example
+[[https://example.org]]
+.
+<p><a href="https://example.org">https://example.org</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+[[https://example.org|title]]
+.
+<p><a href="https://example.org">title</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+[[Name of page]]
+.
+<p><a href="Name%20of%20page">Name of page</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+[[Name of page|Title]]
+.
+<p><a href="Name%20of%20page">Title</a></p>
+````````````````````````````````
+
+HTML entities are recognized both in the name of page and in the link title.
+
+```````````````````````````````` example
+[[Gesch&uuml;tztes Leerzeichen|&#xDC;ber &amp;nbsp;]]
+.
+<p><a href="Gesch%C3%BCtztes%20Leerzeichen">Über &amp;nbsp;</a></p>
+````````````````````````````````

--- a/src/tests/fixtures/wikilinks_title_after_pipe.md
+++ b/src/tests/fixtures/wikilinks_title_after_pipe.md
@@ -17,25 +17,25 @@ With this version of wikilinks, the title comes after the pipe.
 ```````````````````````````````` example
 [[https://example.org]]
 .
-<p><a href="https://example.org">https://example.org</a></p>
+<p><a href="https://example.org" data-wikilink="true">https://example.org</a></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
 [[https://example.org|title]]
 .
-<p><a href="https://example.org">title</a></p>
+<p><a href="https://example.org" data-wikilink="true">title</a></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
 [[Name of page]]
 .
-<p><a href="Name%20of%20page">Name of page</a></p>
+<p><a href="Name%20of%20page" data-wikilink="true">Name of page</a></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
 [[Name of page|Title]]
 .
-<p><a href="Name%20of%20page">Title</a></p>
+<p><a href="Name%20of%20page" data-wikilink="true">Title</a></p>
 ````````````````````````````````
 
 HTML entities are recognized both in the name of page and in the link title.
@@ -43,5 +43,5 @@ HTML entities are recognized both in the name of page and in the link title.
 ```````````````````````````````` example
 [[Gesch&uuml;tztes Leerzeichen|&#xDC;ber &amp;nbsp;]]
 .
-<p><a href="Gesch%C3%BCtztes%20Leerzeichen">Über &amp;nbsp;</a></p>
+<p><a href="Gesch%C3%BCtztes%20Leerzeichen" data-wikilink="true">Über &amp;nbsp;</a></p>
 ````````````````````````````````

--- a/src/tests/fixtures/wikilinks_title_before_pipe.md
+++ b/src/tests/fixtures/wikilinks_title_before_pipe.md
@@ -17,25 +17,25 @@ With this version of wikilinks, the title comes before the pipe.
 ```````````````````````````````` example
 [[https://example.org]]
 .
-<p><a href="https://example.org">https://example.org</a></p>
+<p><a href="https://example.org" data-wikilink="true">https://example.org</a></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
 [[title|https://example.org]]
 .
-<p><a href="https://example.org">title</a></p>
+<p><a href="https://example.org" data-wikilink="true">title</a></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
 [[Name of page]]
 .
-<p><a href="Name%20of%20page">Name of page</a></p>
+<p><a href="Name%20of%20page" data-wikilink="true">Name of page</a></p>
 ````````````````````````````````
 
 ```````````````````````````````` example
 [[Title|Name of page]]
 .
-<p><a href="Name%20of%20page">Title</a></p>
+<p><a href="Name%20of%20page" data-wikilink="true">Title</a></p>
 ````````````````````````````````
 
 Regular links should still work!
@@ -51,5 +51,5 @@ HTML entities are recognized both in the name of page and in the link title.
 ```````````````````````````````` example
 [[&#xDC;ber &amp;nbsp;|Gesch&uuml;tztes Leerzeichen]]
 .
-<p><a href="Gesch%C3%BCtztes%20Leerzeichen">Über &amp;nbsp;</a></p>
+<p><a href="Gesch%C3%BCtztes%20Leerzeichen" data-wikilink="true">Über &amp;nbsp;</a></p>
 ````````````````````````````````

--- a/src/tests/fixtures/wikilinks_title_before_pipe.md
+++ b/src/tests/fixtures/wikilinks_title_before_pipe.md
@@ -1,0 +1,55 @@
+---
+title: Wikilinks
+based_on: https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/wikilinks_title_before_pipe.md
+---
+
+# Wikilinks, title before pipe
+
+Wikilinks can have one of the following forms:
+
+    [[https://example.org]]
+    [[title|https://example.org]]
+    [[name of page]]
+    [[title|name of page]]
+
+With this version of wikilinks, the title comes before the pipe.
+
+```````````````````````````````` example
+[[https://example.org]]
+.
+<p><a href="https://example.org">https://example.org</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+[[title|https://example.org]]
+.
+<p><a href="https://example.org">title</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+[[Name of page]]
+.
+<p><a href="Name%20of%20page">Name of page</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+[[Title|Name of page]]
+.
+<p><a href="Name%20of%20page">Title</a></p>
+````````````````````````````````
+
+Regular links should still work!
+
+```````````````````````````````` example
+[Title](Name%20of%20page)
+.
+<p><a href="Name%20of%20page">Title</a></p>
+````````````````````````````````
+
+HTML entities are recognized both in the name of page and in the link title.
+
+```````````````````````````````` example
+[[&#xDC;ber &amp;nbsp;|Gesch&uuml;tztes Leerzeichen]]
+.
+<p><a href="Gesch%C3%BCtztes%20Leerzeichen">Über &amp;nbsp;</a></p>
+````````````````````````````````

--- a/src/tests/wikilinks.rs
+++ b/src/tests/wikilinks.rs
@@ -176,7 +176,7 @@ fn sourcepos() {
             (paragraph (1:1-1:43) [
                 (text (1:1-1:5) "This ")
                 (wikilink (1:6-1:38) [
-                    (text (1:6-1:38) "link label")
+                    (text (1:27-1:36) "link label")
                 ])
                 (text (1:39-1:43) " that")
             ])
@@ -190,9 +190,23 @@ fn sourcepos() {
             (paragraph (1:1-1:43) [
                 (text (1:1-1:5) "This ")
                 (wikilink (1:6-1:38) [
-                    (text (1:6-1:38) "link label")
+                    (text (1:8-1:17) "link label")
                 ])
                 (text (1:39-1:43) " that")
+            ])
+        ])
+    );
+
+    assert_ast_match!(
+        [extension.wikilinks_title_before_pipe],
+        "This [[http://example.com]] that\n",
+        (document (1:1-1:32) [
+            (paragraph (1:1-1:32) [
+                (text (1:1-1:5) "This ")
+                (wikilink (1:6-1:27) [
+                    (text (1:8-1:25) "http://example.com")
+                ])
+                (text (1:28-1:32) " that")
             ])
         ])
     );

--- a/src/tests/wikilinks.rs
+++ b/src/tests/wikilinks.rs
@@ -74,6 +74,18 @@ fn wikilinks_supercedes_relaxed_autolinks() {
 }
 
 #[test]
+fn wikilinks_exceeds_label_limit() {
+    let long_label = format!("[[{:b<1100}]]", "a");
+    let expected = format!("<p>{}</p>\n", long_label);
+
+    html_opts!(
+        [extension.wikilinks_title_after_pipe],
+        &long_label,
+        &expected,
+    );
+}
+
+#[test]
 fn sourcepos() {
     assert_ast_match!(
         [extension.wikilinks_title_after_pipe],

--- a/src/tests/wikilinks.rs
+++ b/src/tests/wikilinks.rs
@@ -1,0 +1,77 @@
+use super::*;
+
+#[test]
+fn wikilinks_does_not_unescape_html_entities_in_link_text() {
+    html_opts!(
+        [extension.wikilinks_title_after_pipe],
+        concat!("This is [[&lt;script&gt;alert(0)&lt;/script&gt;|a &lt;link]]",),
+        concat!("<p>This is <a href=\"%3Cscript%3Ealert(0)%3C/script%3E\">a &lt;link</a></p>\n"),
+    );
+
+    html_opts!(
+        [extension.wikilinks_title_before_pipe],
+        concat!("This is [[a &lt;link|&lt;script&gt;alert(0)&lt;/script&gt;]]",),
+        concat!("<p>This is <a href=\"%3Cscript%3Ealert(0)%3C/script%3E\">a &lt;link</a></p>\n"),
+    );
+}
+
+#[test]
+fn wikilinks_sanitizes_the_href_attribute_case_1() {
+    html_opts!(
+        [extension.wikilinks_title_after_pipe],
+        concat!("[[http:\'\"injected=attribute&gt;&lt;img/src=\"0\"onerror=\"alert(0)\"&gt;https://example.com|a]]",),
+        concat!("<p><a href=\"http:&#x27;%22injected=attribute%3E%3Cimg/src=%220%22onerror=%22alert(0)%22%3Ehttps://example.com\">a</a></p>\n"),
+    );
+
+    html_opts!(
+        [extension.wikilinks_title_before_pipe],
+        concat!("[[a|http:\'\"injected=attribute&gt;&lt;img/src=\"0\"onerror=\"alert(0)\"&gt;https://example.com]]",),
+        concat!("<p><a href=\"http:&#x27;%22injected=attribute%3E%3Cimg/src=%220%22onerror=%22alert(0)%22%3Ehttps://example.com\">a</a></p>\n"),
+    );
+}
+
+#[test]
+fn wikilinks_sanitizes_the_href_attribute_case_2() {
+    html_opts!(
+        [extension.wikilinks_title_after_pipe],
+        concat!("<i>[[\'\"&gt;&lt;svg&gt;&lt;i/class=gl-show-field-errors&gt;&lt;input/title=\"&lt;script&gt;alert(0)&lt;/script&gt;\"/&gt;&lt;/svg&gt;https://example.com|a]]",),
+        concat!("<p><!-- raw HTML omitted --><a href=\"&#x27;%22%3E%3Csvg%3E%3Ci/class=gl-show-field-errors%3E%3Cinput/title=%22%3Cscript%3Ealert(0)%3C/script%3E%22/%3E%3C/svg%3Ehttps://example.com\">a</a></p>\n"),
+    );
+
+    html_opts!(
+        [extension.wikilinks_title_before_pipe],
+        concat!("<i>[[a|\'\"&gt;&lt;svg&gt;&lt;i/class=gl-show-field-errors&gt;&lt;input/title=\"&lt;script&gt;alert(0)&lt;/script&gt;\"/&gt;&lt;/svg&gt;https://example.com]]",),
+        concat!("<p><!-- raw HTML omitted --><a href=\"&#x27;%22%3E%3Csvg%3E%3Ci/class=gl-show-field-errors%3E%3Cinput/title=%22%3Cscript%3Ealert(0)%3C/script%3E%22/%3E%3C/svg%3Ehttps://example.com\">a</a></p>\n"),
+    );
+}
+
+#[test]
+fn sourcepos() {
+    assert_ast_match!(
+        [extension.wikilinks_title_after_pipe],
+        "This [[http://example.com|link text]] that\n",
+        (document (1:1-1:42) [
+            (paragraph (1:1-1:42) [
+                (text (1:1-1:5) "This ")
+                (link (1:6-1:37) [
+                    (text (1:6-1:37) "link text")
+                ])
+                (text (1:38-1:42) " that")
+            ])
+        ])
+    );
+
+    assert_ast_match!(
+        [extension.wikilinks_title_before_pipe],
+        "This [[link text|http://example.com]] that\n",
+        (document (1:1-1:42) [
+            (paragraph (1:1-1:42) [
+                (text (1:1-1:5) "This ")
+                (link (1:6-1:37) [
+                    (text (1:6-1:37) "link text")
+                ])
+                (text (1:38-1:42) " that")
+            ])
+        ])
+    );
+}

--- a/src/tests/wikilinks.rs
+++ b/src/tests/wikilinks.rs
@@ -49,6 +49,31 @@ fn wikilinks_sanitizes_the_href_attribute_case_2() {
 }
 
 #[test]
+fn wikilinks_supercedes_relaxed_autolinks() {
+    html_opts!(
+        [
+            extension.wikilinks_title_after_pipe,
+            parse.relaxed_autolinks
+        ],
+        concat!("[[http://example.com]]",),
+        concat!(
+            "<p><a href=\"http://example.com\" data-wikilink=\"true\">http://example.com</a></p>\n"
+        ),
+    );
+
+    html_opts!(
+        [
+            extension.wikilinks_title_before_pipe,
+            parse.relaxed_autolinks
+        ],
+        concat!("[[http://example.com]]",),
+        concat!(
+            "<p><a href=\"http://example.com\" data-wikilink=\"true\">http://example.com</a></p>\n"
+        ),
+    );
+}
+
+#[test]
 fn sourcepos() {
     assert_ast_match!(
         [extension.wikilinks_title_after_pipe],

--- a/src/tests/wikilinks.rs
+++ b/src/tests/wikilinks.rs
@@ -74,6 +74,88 @@ fn wikilinks_supercedes_relaxed_autolinks() {
 }
 
 #[test]
+fn wikilinks_only_url_in_tables() {
+    html_opts!(
+        [extension.wikilinks_title_after_pipe, extension.table],
+        concat!("| header  |\n", "| ------- |\n", "| [[url]] |\n",),
+        concat!(
+            "<table>\n",
+            "<thead>\n",
+            "<tr>\n",
+            "<th>header</th>\n",
+            "</tr>\n",
+            "</thead>\n",
+            "<tbody>\n",
+            "<tr>\n",
+            "<td><a href=\"url\" data-wikilink=\"true\">url</a></td>\n",
+            "</tr>\n",
+            "</tbody>\n",
+            "</table>\n",
+        ),
+    );
+
+    html_opts!(
+        [extension.wikilinks_title_before_pipe, extension.table],
+        concat!("| header  |\n", "| ------- |\n", "| [[url]] |\n",),
+        concat!(
+            "<table>\n",
+            "<thead>\n",
+            "<tr>\n",
+            "<th>header</th>\n",
+            "</tr>\n",
+            "</thead>\n",
+            "<tbody>\n",
+            "<tr>\n",
+            "<td><a href=\"url\" data-wikilink=\"true\">url</a></td>\n",
+            "</tr>\n",
+            "</tbody>\n",
+            "</table>\n",
+        ),
+    );
+}
+
+#[test]
+fn wikilinks_full_in_tables_not_supported() {
+    html_opts!(
+        [extension.wikilinks_title_after_pipe, extension.table],
+        concat!("| header  |\n", "| ------- |\n", "| [[url|link label]] |\n",),
+        concat!(
+            "<table>\n",
+            "<thead>\n",
+            "<tr>\n",
+            "<th>header</th>\n",
+            "</tr>\n",
+            "</thead>\n",
+            "<tbody>\n",
+            "<tr>\n",
+            "<td>[[url</td>\n",
+            "</tr>\n",
+            "</tbody>\n",
+            "</table>\n",
+        ),
+    );
+
+    html_opts!(
+        [extension.wikilinks_title_before_pipe, extension.table],
+        concat!("| header  |\n", "| ------- |\n", "| [[link label|url]] |\n",),
+        concat!(
+            "<table>\n",
+            "<thead>\n",
+            "<tr>\n",
+            "<th>header</th>\n",
+            "</tr>\n",
+            "</thead>\n",
+            "<tbody>\n",
+            "<tr>\n",
+            "<td>[[link label</td>\n",
+            "</tr>\n",
+            "</tbody>\n",
+            "</table>\n",
+        ),
+    );
+}
+
+#[test]
 fn wikilinks_exceeds_label_limit() {
     let long_label = format!("[[{:b<1100}]]", "a");
     let expected = format!("<p>{}</p>\n", long_label);

--- a/src/tests/wikilinks.rs
+++ b/src/tests/wikilinks.rs
@@ -4,7 +4,7 @@ use super::*;
 // These cases don't work roundtrip, because converting to commonmark
 // automatically escapes certain characters.
 #[test]
-fn wikilinks_does_not_unescape_html_entities_in_link_text() {
+fn wikilinks_does_not_unescape_html_entities_in_link_label() {
     html_opts!(
         [extension.wikilinks_title_after_pipe, render.sourcepos],
         concat!("This is [[&lt;script&gt;alert(0)&lt;/script&gt;|a &lt;link]]",),
@@ -89,28 +89,28 @@ fn wikilinks_exceeds_label_limit() {
 fn sourcepos() {
     assert_ast_match!(
         [extension.wikilinks_title_after_pipe],
-        "This [[http://example.com|link text]] that\n",
-        (document (1:1-1:42) [
-            (paragraph (1:1-1:42) [
+        "This [[http://example.com|link label]] that\n",
+        (document (1:1-1:43) [
+            (paragraph (1:1-1:43) [
                 (text (1:1-1:5) "This ")
-                (link (1:6-1:37) [
-                    (text (1:6-1:37) "link text")
+                (wikilink (1:6-1:38) [
+                    (text (1:6-1:38) "link label")
                 ])
-                (text (1:38-1:42) " that")
+                (text (1:39-1:43) " that")
             ])
         ])
     );
 
     assert_ast_match!(
         [extension.wikilinks_title_before_pipe],
-        "This [[link text|http://example.com]] that\n",
-        (document (1:1-1:42) [
-            (paragraph (1:1-1:42) [
+        "This [[link label|http://example.com]] that\n",
+        (document (1:1-1:43) [
+            (paragraph (1:1-1:43) [
                 (text (1:1-1:5) "This ")
-                (link (1:6-1:37) [
-                    (text (1:6-1:37) "link text")
+                (wikilink (1:6-1:38) [
+                    (text (1:6-1:38) "link label")
                 ])
-                (text (1:38-1:42) " that")
+                (text (1:39-1:43) " that")
             ])
         ])
     );

--- a/src/tests/wikilinks.rs
+++ b/src/tests/wikilinks.rs
@@ -1,17 +1,20 @@
 use super::*;
 
+// html_opts! does a roundtrip check unless sourcepos is set.
+// These cases don't work roundtrip, because converting to commonmark
+// automatically escapes certain characters.
 #[test]
 fn wikilinks_does_not_unescape_html_entities_in_link_text() {
     html_opts!(
-        [extension.wikilinks_title_after_pipe],
+        [extension.wikilinks_title_after_pipe, render.sourcepos],
         concat!("This is [[&lt;script&gt;alert(0)&lt;/script&gt;|a &lt;link]]",),
-        concat!("<p>This is <a href=\"%3Cscript%3Ealert(0)%3C/script%3E\">a &lt;link</a></p>\n"),
+        concat!("<p data-sourcepos=\"1:1-1:60\">This is <a data-sourcepos=\"1:9-1:60\" href=\"%3Cscript%3Ealert(0)%3C/script%3E\" data-wikilink=\"true\">a &lt;link</a></p>\n"),
     );
 
     html_opts!(
-        [extension.wikilinks_title_before_pipe],
+        [extension.wikilinks_title_before_pipe, render.sourcepos],
         concat!("This is [[a &lt;link|&lt;script&gt;alert(0)&lt;/script&gt;]]",),
-        concat!("<p>This is <a href=\"%3Cscript%3Ealert(0)%3C/script%3E\">a &lt;link</a></p>\n"),
+        concat!("<p data-sourcepos=\"1:1-1:60\">This is <a data-sourcepos=\"1:9-1:60\" href=\"%3Cscript%3Ealert(0)%3C/script%3E\" data-wikilink=\"true\">a &lt;link</a></p>\n"),
     );
 }
 
@@ -20,13 +23,13 @@ fn wikilinks_sanitizes_the_href_attribute_case_1() {
     html_opts!(
         [extension.wikilinks_title_after_pipe],
         concat!("[[http:\'\"injected=attribute&gt;&lt;img/src=\"0\"onerror=\"alert(0)\"&gt;https://example.com|a]]",),
-        concat!("<p><a href=\"http:&#x27;%22injected=attribute%3E%3Cimg/src=%220%22onerror=%22alert(0)%22%3Ehttps://example.com\">a</a></p>\n"),
+        concat!("<p><a href=\"http:&#x27;%22injected=attribute%3E%3Cimg/src=%220%22onerror=%22alert(0)%22%3Ehttps://example.com\" data-wikilink=\"true\">a</a></p>\n"),
     );
 
     html_opts!(
         [extension.wikilinks_title_before_pipe],
         concat!("[[a|http:\'\"injected=attribute&gt;&lt;img/src=\"0\"onerror=\"alert(0)\"&gt;https://example.com]]",),
-        concat!("<p><a href=\"http:&#x27;%22injected=attribute%3E%3Cimg/src=%220%22onerror=%22alert(0)%22%3Ehttps://example.com\">a</a></p>\n"),
+        concat!("<p><a href=\"http:&#x27;%22injected=attribute%3E%3Cimg/src=%220%22onerror=%22alert(0)%22%3Ehttps://example.com\" data-wikilink=\"true\">a</a></p>\n"),
     );
 }
 
@@ -35,13 +38,13 @@ fn wikilinks_sanitizes_the_href_attribute_case_2() {
     html_opts!(
         [extension.wikilinks_title_after_pipe],
         concat!("<i>[[\'\"&gt;&lt;svg&gt;&lt;i/class=gl-show-field-errors&gt;&lt;input/title=\"&lt;script&gt;alert(0)&lt;/script&gt;\"/&gt;&lt;/svg&gt;https://example.com|a]]",),
-        concat!("<p><!-- raw HTML omitted --><a href=\"&#x27;%22%3E%3Csvg%3E%3Ci/class=gl-show-field-errors%3E%3Cinput/title=%22%3Cscript%3Ealert(0)%3C/script%3E%22/%3E%3C/svg%3Ehttps://example.com\">a</a></p>\n"),
+        concat!("<p><!-- raw HTML omitted --><a href=\"&#x27;%22%3E%3Csvg%3E%3Ci/class=gl-show-field-errors%3E%3Cinput/title=%22%3Cscript%3Ealert(0)%3C/script%3E%22/%3E%3C/svg%3Ehttps://example.com\" data-wikilink=\"true\">a</a></p>\n"),
     );
 
     html_opts!(
         [extension.wikilinks_title_before_pipe],
         concat!("<i>[[a|\'\"&gt;&lt;svg&gt;&lt;i/class=gl-show-field-errors&gt;&lt;input/title=\"&lt;script&gt;alert(0)&lt;/script&gt;\"/&gt;&lt;/svg&gt;https://example.com]]",),
-        concat!("<p><!-- raw HTML omitted --><a href=\"&#x27;%22%3E%3Csvg%3E%3Ci/class=gl-show-field-errors%3E%3Cinput/title=%22%3Cscript%3Ealert(0)%3C/script%3E%22/%3E%3C/svg%3Ehttps://example.com\">a</a></p>\n"),
+        concat!("<p><!-- raw HTML omitted --><a href=\"&#x27;%22%3E%3Csvg%3E%3Ci/class=gl-show-field-errors%3E%3Cinput/title=%22%3Cscript%3Ealert(0)%3C/script%3E%22/%3E%3C/svg%3Ehttps://example.com\" data-wikilink=\"true\">a</a></p>\n"),
     );
 }
 

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -273,6 +273,11 @@ impl<'o> XmlFormatter<'o> {
                     write!(self.output, "</{}", ast.value.xml_node_name())?;
                     was_literal = true;
                 }
+                NodeValue::WikiLink(ref nl) => {
+                    self.output.write_all(b" destination=\"")?;
+                    self.escape(nl.url.as_bytes())?;
+                    self.output.write_all(b"\"")?;
+                }
             }
 
             if node.first_child().is_some() {


### PR DESCRIPTION
Add extensions to support both styles of wikilinks

- `[[display text|target page]]` _[GitHub style]_
- `[[target page|display text]]` _[regular wiki link]_

most likely with `wikilinks_title_before_pipe` and `wikilinks_title_after_pipe` extension names.

Inspired by [commonmark-hs](https://github.com/jgm/commonmark-hs/blob/master/commonmark-extensions/test/wikilinks_title_before_pipe.md)