### PR TITLE
Autolink should ignore wikilinks

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2134,6 +2134,10 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
                             this_bracket = true;
                             break;
                         }
+                        NodeValue::WikiLink(..) => {
+                            this_bracket = true;
+                            break;
+                        }
                         _ => break,
                     }
                 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2130,11 +2130,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
                                 }
                             }
                         }
-                        NodeValue::Link(..) | NodeValue::Image(..) => {
-                            this_bracket = true;
-                            break;
-                        }
-                        NodeValue::WikiLink(..) => {
+                        NodeValue::Link(..) | NodeValue::Image(..) | NodeValue::WikiLink(..) => {
                             this_bracket = true;
                             break;
                         }

--- a/src/tests/wikilinks.rs
+++ b/src/tests/wikilinks.rs
@@ -168,6 +168,25 @@ fn wikilinks_exceeds_label_limit() {
 }
 
 #[test]
+fn wikilinks_autolinker_ignored() {
+    html_opts!(
+        [extension.wikilinks_title_after_pipe, extension.autolink],
+        concat!("[[http://example.com]]",),
+        concat!(
+            "<p><a href=\"http://example.com\" data-wikilink=\"true\">http://example.com</a></p>\n"
+        ),
+    );
+
+    html_opts!(
+        [extension.wikilinks_title_before_pipe, extension.autolink],
+        concat!("[[http://example.com]]",),
+        concat!(
+            "<p><a href=\"http://example.com\" data-wikilink=\"true\">http://example.com</a></p>\n"
+        ),
+    );
+}
+
+#[test]
 fn sourcepos() {
     assert_ast_match!(
         [extension.wikilinks_title_after_pipe],


### PR DESCRIPTION
When the `autolink` extension is used, text nodes inside a WikiLink node should be ignored, the same way they are for links and images.