### PR TITLE
AST validation

### DIFF
--- a/src/cm.rs
+++ b/src/cm.rs
@@ -20,6 +20,14 @@ pub fn format_document<'a>(
     options: &Options,
     output: &mut dyn Write,
 ) -> io::Result<()> {
+    // Formatting an ill-formed AST might lead to invalid output. However, we don't want to pay for
+    // validation in normal workflow. As a middleground, we validate the AST in debug builds. See
+    // https://github.com/kivikakk/comrak/issues/371.
+    #[cfg(debug_assertions)]
+    root.validate().unwrap_or_else(|e| {
+        panic!("The document to format is ill-formed: {:?}", e);
+    });
+
     format_document_with_plugins(root, options, output, &Plugins::default())
 }
 

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -108,7 +108,7 @@ pub enum NodeValue {
     /// in a document will be contained in a `Text` node.
     Text(String),
 
-    /// **Inline**. [Task list item](https://github.github.com/gfm/#task-list-items-extension-).
+    /// **Block**. [Task list item](https://github.github.com/gfm/#task-list-items-extension-).
     /// The value is the symbol that was used in the brackets to mark a task item as checked, or
     /// None if the item is unchecked.
     TaskItem(Option<char>),
@@ -660,6 +660,54 @@ impl<'a> From<Ast> for AstNode<'a> {
     /// Create a new AST node with the given Ast.
     fn from(ast: Ast) -> Self {
         Node::new(RefCell::new(ast))
+    }
+}
+
+/// Validation errors produced by [Node::validate].
+#[derive(Debug, Clone)]
+pub enum ValidationError<'a> {
+    /// Children were found for a node that isn't supposed to have chilrden.
+    UnexpectedChildren(&'a AstNode<'a>),
+    /// The type of a child node is not allowed in the parent node. This can happen when an inline
+    /// node is found in a block container, a block is found in an inline node, etc.
+    InvalidChildType {
+        /// The parent node.
+        parent: &'a AstNode<'a>,
+        /// The child node.
+        child: &'a AstNode<'a>,
+    },
+}
+
+impl<'a> Node<'a, RefCell<Ast>> {
+    /// The comrak representation of a markdown node in Rust isn't strict enough to rule out
+    /// invalid trees according to the CommonMark specification. One simple example is that block
+    /// containers, such as lists, should only contain blocks, but it's possible to put naked
+    /// inline text in a list item. Such invalid trees can lead comrak to generate incorrect output
+    /// if rendered.
+    ///
+    /// This method performs additional structural checks to ensure that a markdown AST is valid
+    /// according to the CommonMark specification.
+    ///
+    /// Note that those invalid trees can only be generated programmatically. Parsing markdown with
+    /// comrak, on the other hand, should always produce a valid tree.
+    pub fn validate(&'a self) -> Result<(), ValidationError<'a>> {
+        let mut stack = vec![self];
+
+        while let Some(node) = stack.pop() {
+            // Check that this node type is valid wrt to the type of its parent.
+            if let Some(parent) = node.parent() {
+                if !can_contain_type(parent, &node.data.borrow().value) {
+                    return Err(ValidationError::InvalidChildType {
+                        parent,
+                        child: node,
+                    });
+                }
+            }
+
+            stack.extend(node.children());
+        }
+
+        Ok(())
     }
 }
 

--- a/src/tests/commonmark.rs
+++ b/src/tests/commonmark.rs
@@ -26,9 +26,8 @@ fn commonmark_avoids_spurious_backslash() {
 
     let p1 = ast(NodeValue::Paragraph);
     p1.append(ast(NodeValue::Text("Line 1".to_owned())));
+    p1.append(ast(NodeValue::LineBreak));
     root.append(p1);
-
-    root.append(ast(NodeValue::LineBreak));
 
     let p2 = ast(NodeValue::Paragraph);
     p2.append(ast(NodeValue::Text("Line 2".to_owned())));


### PR DESCRIPTION
This draft PR implements a simple validation procedure for CommonMark ASTs, following the discussions in #371. The idea is to perform the additional checks that the nature of a block and the nature of its children (or the absence thereof) match, which isn't currently possible to enforce (or at least not in a agreable way) using static types.

@kivikakk The logic is pretty simple, but the tests seem to loop forever, so it sounds like there's an infinite loop somewhere. However the function is a pretty dumb tree traversal, so I wonder if I'm missing something (like `children()` is actually returning descendants, but given the API and the existence of `descendants()`, this doesn't seem to be the case).