### PR TITLE
Address autolink edge cases.

### DIFF
--- a/src/parser/autolink.rs
+++ b/src/parser/autolink.rs
@@ -134,7 +134,10 @@ fn check_domain(data: &[u8], allow_short: bool) -> Option<usize> {
     let mut uscore2 = 0;
 
     for (i, c) in unsafe { str::from_utf8_unchecked(data) }.char_indices() {
-        if c == '_' {
+        if c == '\\' && i < data.len() - 1 {
+            // Ignore escaped characters per https://github.com/github/cmark-gfm/pull/292.
+            // Not sure I love this, but it tracks upstream ..
+        } else if c == '_' {
             uscore2 += 1;
         } else if c == '.' {
             uscore1 = uscore2;

--- a/src/parser/autolink.rs
+++ b/src/parser/autolink.rs
@@ -6,6 +6,8 @@ use std::str;
 use typed_arena::Arena;
 use unicode_categories::UnicodeCategories;
 
+// TODO: this can probably be cleaned up a lot. It used to handle all three of
+// {url,www,email}_match, but now just the last of those.
 pub(crate) fn process_autolinks<'a>(
     arena: &'a Arena<AstNode<'a>>,
     node: &'a AstNode<'a>,
@@ -40,12 +42,6 @@ pub(crate) fn process_autolinks<'a>(
             }
 
             match contents[i] {
-                b'w' => {
-                    post_org = www_match(arena, contents, i, relaxed_autolinks);
-                    if post_org.is_some() {
-                        break;
-                    }
-                }
                 b'@' => {
                     post_org = email_match(arena, contents, i, relaxed_autolinks);
                     if post_org.is_some() {
@@ -75,7 +71,7 @@ pub(crate) fn process_autolinks<'a>(
     }
 }
 
-fn www_match<'a>(
+pub fn www_match<'a>(
     arena: &'a Arena<AstNode<'a>>,
     contents: &[u8],
     i: usize,

--- a/src/parser/autolink.rs
+++ b/src/parser/autolink.rs
@@ -40,12 +40,6 @@ pub(crate) fn process_autolinks<'a>(
             }
 
             match contents[i] {
-                b':' => {
-                    post_org = url_match(arena, contents, i, relaxed_autolinks);
-                    if post_org.is_some() {
-                        break;
-                    }
-                }
                 b'w' => {
                     post_org = www_match(arena, contents, i, relaxed_autolinks);
                     if post_org.is_some() {
@@ -245,7 +239,7 @@ fn autolink_delim(data: &[u8], mut link_end: usize, relaxed_autolinks: bool) -> 
     link_end
 }
 
-fn url_match<'a>(
+pub fn url_match<'a>(
     arena: &'a Arena<AstNode<'a>>,
     contents: &[u8],
     i: usize,

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1250,9 +1250,11 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
             self.pos,
             self.options.parse.relaxed_autolinks,
         )?;
-        match node.last_child().unwrap().data.borrow_mut().value {
-            NodeValue::Text(ref mut prev) => prev.truncate(prev.len() - reverse),
-            _ => unreachable!(),
+        if reverse > 0 {
+            match node.last_child().unwrap().data.borrow_mut().value {
+                NodeValue::Text(ref mut prev) => prev.truncate(prev.len() - reverse),
+                _ => unreachable!(),
+            }
         }
 
         self.pos += skip - reverse;

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1230,11 +1230,10 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
     }
 
     pub fn handle_autolink_colon(&mut self, node: &'a AstNode<'a>) -> Option<&'a AstNode<'a>> {
-        // XXX: relaxed_autolinks
-        if self.within_brackets {
+        if !self.options.parse.relaxed_autolinks && self.within_brackets {
             return None;
         }
-        let (post, reverse, skip) = autolink::url_match(self.arena, self.input, self.pos, false)?;
+        let (post, reverse, skip) = autolink::url_match(self.arena, self.input, self.pos, self.options.parse.relaxed_autolinks)?;
         match node.last_child().unwrap().data.borrow_mut().value {
             NodeValue::Text(ref mut prev) => prev.truncate(prev.len() - reverse),
             _ => unreachable!(),

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -271,6 +271,7 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
                         self.pos - 1,
                     );
                     self.push_bracket(true, inl);
+                    self.within_brackets = true;
                     Some(inl)
                 } else {
                     Some(self.make_inline(

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1221,23 +1221,20 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
 
     #[cfg(feature = "shortcodes")]
     pub fn handle_shortcodes_colon(&mut self) -> Option<&'a AstNode<'a>> {
-        if let Some(matchlen) = scanners::shortcode(&self.input[self.pos + 1..]) {
-            let shortcode = unsafe {
-                str::from_utf8_unchecked(&self.input[self.pos + 1..self.pos + 1 + matchlen - 1])
-            };
+        let matchlen = scanners::shortcode(&self.input[self.pos + 1..])?;
 
-            if let Ok(nsc) = NodeShortCode::try_from(shortcode) {
-                self.pos += 1 + matchlen;
-                let inl = self.make_inline(
-                    NodeValue::ShortCode(nsc),
-                    self.pos - 1 - matchlen,
-                    self.pos - 1,
-                );
-                return Some(inl);
-            }
-        }
+        let shortcode = unsafe {
+            str::from_utf8_unchecked(&self.input[self.pos + 1..self.pos + 1 + matchlen - 1])
+        };
 
-        None
+        let nsc = NodeShortCode::try_from(shortcode).ok()?;
+        self.pos += 1 + matchlen;
+
+        Some(self.make_inline(
+            NodeValue::ShortCode(nsc),
+            self.pos - 1 - matchlen,
+            self.pos - 1,
+        ))
     }
 
     pub fn handle_autolink_with<F>(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -140,45 +140,6 @@ macro_rules! html_opts {
             $(opts.$optclass.$optname = true;)*
         });
     };
-    ([all], $lhs:expr, $rhs:expr) => {
-        $crate::tests::html_opts_w($lhs, $rhs, &$crate::Options {
-            extension: $crate::ExtensionOptions {
-                strikethrough: true,
-                tagfilter: true,
-                table: true,
-                autolink: true,
-                tasklist: true,
-                superscript: true,
-                header_ids: Some("user-content-".to_string()),
-                footnotes: true,
-                description_lists: true,
-                multiline_block_quotes: true,
-                math_dollars: true,
-                math_code: true,
-                front_matter_delimiter: Some("---".to_string()),
-                shortcodes: true,
-                wikilinks_title_after_pipe: true,
-                wikilinks_title_before_pipe: true,
-            },
-            parse: $crate::ParseOptions {
-                smart: true,
-                default_info_string: Some("rust".to_string()),
-                relaxed_tasklist_matching: true,
-                relaxed_autolinks: true,
-            },
-            render: $crate::RenderOptions {
-                hardbreaks: true,
-                github_pre_lang: true,
-                full_info_string: true,
-                width: 80,
-                unsafe_: true,
-                escape: true,
-                list_style: $crate::ListStyleType::Star,
-                sourcepos: true,
-                escaped_char_spans: true,
-            },
-        });
-    }
 }
 
 pub(crate) use html_opts;

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -273,3 +273,12 @@ fn autolink_cmark_edge() {
         "<p>See &lt;&lt;&lt;<a href=\"http://example.com/\">http://example.com/</a>&gt;&gt;&gt;</p>\n",
     );
 }
+
+#[test]
+fn autolink_cmark_edge_2() {
+    html_opts!(
+        [extension.autolink],
+        "http://example.com/src/_mocks_/vscode.js",
+        "<p><a href=\"http://example.com/src/_mocks_/vscode.js\">http://example.com/src/_mocks_/vscode.js</a></p>\n",
+    );
+}

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -306,7 +306,6 @@ fn autolink_cmark_edge_423() {
     );
 }
 
-
 #[test]
 fn autolink_cmark_edge_58() {
     html_opts!(

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -286,7 +286,7 @@ fn autolink_cmark_edge_388() {
 #[test]
 fn autolink_cmark_edge_423() {
     html_opts!(
-        [extension.autolink],
+        [extension.autolink, extension.strikethrough],
         concat!(
             "Here's an autolink: ",
             "https://www.unicode.org/review/pri453/feedback.html#:~:text=Fri%20Jun%2024%2009:56:01%20CDT%202022",
@@ -302,6 +302,21 @@ fn autolink_cmark_edge_423() {
             r#"<a href="https://www.unicode.org/review/pri453/feedback.html#:~:text=Fri%20Jun%2024%2009:56:01%20CDT%202022">"#,
             "https://www.unicode.org/review/pri453/feedback.html#:~:text=Fri%20Jun%2024%2009:56:01%20CDT%202022",
             "</a>.</p>\n",
+        ),
+    );
+}
+
+
+#[test]
+fn autolink_cmark_edge_58() {
+    html_opts!(
+        [extension.autolink, extension.superscript],
+        "https://www.wolframalpha.com/input/?i=x^2+(y-(x^2)^(1/3))^2=1",
+        concat!(
+            "<p>",
+            r#"<a href="https://www.wolframalpha.com/input/?i=x%5E2+(y-(x%5E2)%5E(1/3))%5E2=1">"#,
+            "https://www.wolframalpha.com/input/?i=x^2+(y-(x^2)^(1/3))^2=1",
+            "</a></p>\n",
         ),
     );
 }

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -113,7 +113,7 @@ fn autolink_ignore_links_in_brackets() {
     ];
 
     for example in examples {
-        html_opts!([extension.autolink], example[0], example[1]);
+        html_opts!([extension.autolink], example[0], example[1], no_roundtrip);
     }
 }
 

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -321,10 +321,19 @@ fn autolink_cmark_edge_58() {
 }
 
 #[test]
-fn autolink_failing_spec() {
+fn autolink_failing_spec_image() {
     html_opts!(
         [extension.autolink],
         "![http://inline.com/image](http://inline.com/image)",
         "<p><img src=\"http://inline.com/image\" alt=\"http://inline.com/image\" /></p>\n",
+    );
+}
+
+#[test]
+fn autolink_failing_spec_underscores() {
+    html_opts!(
+        [extension.autolink],
+        "Underscores not allowed in host name www.xxx.yyy._zzz",
+        "<p>Underscores not allowed in host name www.xxx.yyy._zzz</p>\n",
     );
 }

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -325,6 +325,6 @@ fn autolink_failing_spec() {
     html_opts!(
         [extension.autolink],
         "![http://inline.com/image](http://inline.com/image)",
-        "<p><img src=\"http://inline.com/image\" alt=\"http://inline.com/image\" /></p>",
+        "<p><img src=\"http://inline.com/image\" alt=\"http://inline.com/image\" /></p>\n",
     );
 }

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -264,3 +264,12 @@ fn sourcepos_correctly_restores_context() {
         ])
     );
 }
+
+#[test]
+fn autolink_cmark_edge() {
+    html_opts!(
+        [extension.autolink],
+        "See &lt;&lt;&lt;http://example.com/&gt;&gt;&gt;",
+        "<p>See &lt;&lt;&lt;<a href=\"http://example.com/\">http://example.com/</a>&gt;&gt;&gt;</p>\n",
+    );
+}

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -266,7 +266,7 @@ fn sourcepos_correctly_restores_context() {
 }
 
 #[test]
-fn autolink_cmark_edge() {
+fn autolink_cmark_edge_382() {
     html_opts!(
         [extension.autolink],
         "See &lt;&lt;&lt;http://example.com/&gt;&gt;&gt;",
@@ -275,10 +275,33 @@ fn autolink_cmark_edge() {
 }
 
 #[test]
-fn autolink_cmark_edge_2() {
+fn autolink_cmark_edge_388() {
     html_opts!(
         [extension.autolink],
         "http://example.com/src/_mocks_/vscode.js",
         "<p><a href=\"http://example.com/src/_mocks_/vscode.js\">http://example.com/src/_mocks_/vscode.js</a></p>\n",
+    );
+}
+
+#[test]
+fn autolink_cmark_edge_423() {
+    html_opts!(
+        [extension.autolink],
+        concat!(
+            "Here's an autolink: ",
+            "https://www.unicode.org/review/pri453/feedback.html#:~:text=Fri%20Jun%2024%2009:56:01%20CDT%202022",
+            " and another one ",
+            "https://www.unicode.org/review/pri453/feedback.html#:~:text=Fri%20Jun%2024%2009:56:01%20CDT%202022",
+            ".",
+        ),
+        concat!(
+            "<p>Here's an autolink: ",
+            r#"<a href="https://www.unicode.org/review/pri453/feedback.html#:~:text=Fri%20Jun%2024%2009:56:01%20CDT%202022">"#,
+            "https://www.unicode.org/review/pri453/feedback.html#:~:text=Fri%20Jun%2024%2009:56:01%20CDT%202022",
+            "</a> and another one ",
+            r#"<a href="https://www.unicode.org/review/pri453/feedback.html#:~:text=Fri%20Jun%2024%2009:56:01%20CDT%202022">"#,
+            "https://www.unicode.org/review/pri453/feedback.html#:~:text=Fri%20Jun%2024%2009:56:01%20CDT%202022",
+            "</a>.</p>\n",
+        ),
     );
 }

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -337,3 +337,13 @@ fn autolink_failing_spec_underscores() {
         "<p>Underscores not allowed in host name www.xxx.yyy._zzz</p>\n",
     );
 }
+
+#[test]
+fn autolink_fuzz_leading_colon() {
+    html_opts!(
+        [extension.autolink, parse.relaxed_autolinks],
+        "://-",
+        "<p><a href=\"://-\">://-</a></p>\n",
+        no_roundtrip,
+    );
+}

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -319,3 +319,12 @@ fn autolink_cmark_edge_58() {
         ),
     );
 }
+
+#[test]
+fn autolink_failing_spec() {
+    html_opts!(
+        [extension.autolink],
+        "![http://inline.com/image](http://inline.com/image)",
+        "<p><img src=\"http://inline.com/image\" alt=\"http://inline.com/image\" /></p>",
+    );
+}

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -347,3 +347,13 @@ fn autolink_fuzz_leading_colon() {
         no_roundtrip,
     );
 }
+
+#[test]
+fn autolink_fuzz_we() {
+    html_opts!(
+        [extension.autolink, parse.relaxed_autolinks],
+        "we://w",
+        "<p><a href=\"we://w\">we://w</a></p>\n",
+        no_roundtrip,
+    );
+}

--- a/src/tests/header_ids.rs
+++ b/src/tests/header_ids.rs
@@ -21,6 +21,7 @@ fn header_ids() {
             "<h6><a href=\"#hello-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello-1\"></a>Hello.</h6>\n",
             "<h1><a href=\"#isnt-it-grand\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-isnt-it-grand\"></a>Isn't it grand?</h1>\n"
         ),
+        true,
         |opts| opts.extension.header_ids = Some("user-content-".to_owned()),
     );
 }


### PR DESCRIPTION
Start of a spike to try addressing autolink edge cases by bringing in the pre-postprocessing (ahem) step from cmark-gfm, and then aligning the postprocessing ones.

Fixes #382, fixes #388, fixes #423, fixes #58 (!).

TODO:

* [x] fix `we://w` all_options case.
* [x] keep fuzzing.