### PR TITLE
Support both upstream CommonMark and GFM's differences in the base spec.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/cmark-gfm"]
 	path = vendor/cmark-gfm
-	url = https://github.com/github/cmark-gfm.git
+	url = https://github.com/kivikakk/cmark-gfm.git
 [submodule "vendor/pulldown-cmark"]
 	path = vendor/pulldown-cmark
 	url = https://github.com/raphlinus/pulldown-cmark.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "vendor/markdown-it"]
 	path = vendor/markdown-it
 	url = https://github.com/rlidwka/markdown-it.rs.git
+[submodule "vendor/commonmark-spec"]
+	path = vendor/commonmark-spec
+	url = https://github.com/commonmark/commonmark-spec

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "caseless"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808dab3318747be122cb31d36de18d4d1c81277a76f8332a02b81a3d73463d7f"
+dependencies = [
+ "regex",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +133,7 @@ name = "comrak"
 version = "0.24.1"
 dependencies = [
  "arbitrary",
+ "caseless",
  "clap",
  "derive_builder",
  "emojis",
@@ -810,6 +821,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "toml"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +889,15 @@ name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode_categories"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ slug = "0.1.4"
 emojis = { version = "0.6.2", optional = true }
 arbitrary = { version = "1", optional = true, features = ["derive"] }
 derive_builder = "0.20.0"
+caseless = "0.2.1"
 
 [dev-dependencies]
 ntest = "0.9"

--- a/README.md
+++ b/README.md
@@ -325,9 +325,9 @@ This will build and run benchmarks across all, and report the time taken by each
 
 ## Contributing
 
-Contributions are highly encouraged; where possible I practice [Optimistic Merging](http://hintjens.com/blog:106) as
-described by Peter Hintjens. Please keep the [code of conduct](CODE_OF_CONDUCT.md) in mind when interacting with this
-project.
+Contributions are **highly encouraged**; if you'd like to assist, consider checking out the [`good first issue` label](https://github.com/kivikakk/comrak/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)\! I'm happy to help provide direction and guidance throughout, even if (especially if\!) you're new to Rust or open source.
+
+Where possible I practice [Optimistic Merging](http://hintjens.com/blog:106) as described by Peter Hintjens. Please keep the [code of conduct](CODE_OF_CONDUCT.md) in mind too.
 
 Thank you to Comrak's many contributors for PRs and issues opened\!
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # [Comrak](https://github.com/kivikakk/comrak)
 
-[![Build Status](https://github.com/kivikakk/comrak/actions/workflows/rust.yml/badge.svg)](https://github.com/kivikakk/comrak/actions/workflows/rust.yml) ![Spec
-Status: 671/671](https://img.shields.io/badge/specs-671%2F671-brightgreen.svg)
+[![Build status](https://github.com/kivikakk/comrak/actions/workflows/rust.yml/badge.svg)](https://github.com/kivikakk/comrak/actions/workflows/rust.yml)
+[![CommonMark: 652/652](https://img.shields.io/badge/commonmark-652%2F652-brightgreen.svg)](https://github.com/commonmark/commonmark-spec/blob/9103e341a973013013bb1a80e13567007c5cef6f/spec.txt)
+[![GFM: 670/670](https://img.shields.io/badge/gfm-670%2F670-brightgreen.svg)](https://github.com/kivikakk/cmark-gfm/blob/2f13eeedfe9906c72a1843b03552550af7bee29a/test/spec.txt)
 [![crates.io version](https://img.shields.io/crates/v/comrak.svg)](https://crates.io/crates/comrak)
 [![docs.rs](https://docs.rs/comrak/badge.svg)](https://docs.rs/comrak)
 
-Rust port of [github's `cmark-gfm`](https://github.com/github/cmark). *Currently synced with release `0.29.0.gfm.13`*.
+Rust port of [github's `cmark-gfm`](https://github.com/github/cmark-gfm).
+
+Compliant with [CommonMark 0.31.2](https://spec.commonmark.org/0.31.2/) in default mode.
+GFM support synced with release `0.29.0.gfm.13`.
 
 - [Installation](#installation)
 - [Usage](#usage)
@@ -54,7 +58,7 @@ Options:
   -c, --config-file <PATH>
           Path to config file containing command-line arguments, or 'none'
           
-          [default: /home/runner/.config/comrak/config]
+          [default: /Users/kivikakk/.config/comrak/config]
 
   -i, --inplace
           To perform an in-place formatting
@@ -73,7 +77,11 @@ Options:
 
       --gfm
           Enable GitHub-flavored markdown extensions: strikethrough, tagfilter, table, autolink, and
-          tasklist. Also enables --github-pre-lang
+          tasklist. Also enables --github-pre-lang and --gfm-quirks
+
+      --gfm-quirks
+          Enables GFM-style quirks in output HTML, such as not nesting <strong> tags, which
+          otherwise breaks CommonMark compatibility
 
       --relaxed-tasklist-character
           Enable relaxing which character is allowed in a tasklists
@@ -104,7 +112,7 @@ Options:
           
           [possible values: strikethrough, tagfilter, table, autolink, tasklist, superscript,
           footnotes, description-lists, multiline-block-quotes, math-dollars, math-code,
-          wikilinks-title-after-pipe, wikilinks-title-before-pipe]
+          wikilinks-title-after-pipe, wikilinks-title-before-pipe, underline, spoiler, greentext]
 
   -t, --to <FORMAT>
           Specify output format
@@ -139,6 +147,12 @@ Options:
 
       --sourcepos
           Include source position attribute in HTML and XML output
+
+      --ignore-setext
+          Ignore setext headers
+
+      --ignore-empty-links
+          Ignore empty links
 
   -h, --help
           Print help information (use `-h` for a summary)

--- a/README.md
+++ b/README.md
@@ -11,14 +11,6 @@ Rust port of [github's `cmark-gfm`](https://github.com/github/cmark-gfm).
 Compliant with [CommonMark 0.31.2](https://spec.commonmark.org/0.31.2/) in default mode.
 GFM support synced with release `0.29.0.gfm.13`.
 
-- [Installation](#installation)
-- [Usage](#usage)
-- [Security](#security)
-- [Extensions](#extensions)
-- [Related projects](#related-projects)
-- [Contributing](#contributing)
-- [Legal](#legal)
-
 ## Installation
 
 Specify it as a requirement in `Cargo.toml`:
@@ -187,7 +179,6 @@ assert_eq!(markdown_to_html("Hello, **世界**!", &Options::default()),
 Or you can parse the input into an AST yourself, manipulate it, and then use your desired formatter:
 
 ``` rust
-extern crate comrak;
 use comrak::nodes::NodeValue;
 use comrak::{format_html, parse_document, Arena, Options};
 
@@ -219,6 +210,13 @@ fn main() {
     let html = replace_text(&doc, &orig, &repl);
 
     println!("{}", html);
+    // Output:
+    //
+    // <p>This is your input.</p>
+    // <ol>
+    // <li>Also <a href="#">your</a> input.</li>
+    // <li>Certainly <em>your</em> input.</li>
+    // </ol>
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,22 +30,31 @@ comrak = "0.24"
 
 Comrak's library supports Rust <span class="msrv">1.62.1</span>+.
 
-### Mac & Linux Binaries
+### CLI
 
-``` bash
-curl https://webinstall.dev/comrak | bash
-```
+- Anywhere with a Rust toolchain:
+  - `cargo install comrak`
+- Many Unix distributions:
+  - `pacman -S comrak`
+  - `brew install comrak`
+  - `dnf install comrak`
+  - `nix run nixpkgs#comrak`
 
-### Windows 10 Binaries
-
-``` powershell
-curl.exe -A "MS" https://webinstall.dev/comrak | powershell
-```
+You can also find builds I've published in [GitHub Releases](https://github.com/kivikakk/comrak/releases), but they're limited to machines I have access to at the time of making them\! [webinstall.dev](https://webinstall.dev/comrak/) offers `curl | shell`-style installation of the latest of these for your OS.
 
 ## Usage
 
+<details>
+
+<summary>Click to expand the CLI <code>--help</code> output.
+
 ``` console
 $ comrak --help
+```
+
+</summary>
+
+```
 A 100% CommonMark-compatible GitHub Flavored Markdown parser and formatter
 
 Usage: comrak [OPTIONS] [FILE]...
@@ -165,6 +174,8 @@ By default, Comrak will attempt to read command-line options from a config file 
 the file does not exist.
 ```
 
+</details>
+
 And there's a Rust interface. You can use `comrak::markdown_to_html` directly:
 
 ``` rust
@@ -211,39 +222,14 @@ fn main() {
 }
 ```
 
-## Benchmarking
-
-For running benchmarks, you will need to [install hyperfine](https://github.com/sharkdp/hyperfine#installation) and optionally cmake.
-
-If you want to just run the benchmark for `comrak`, with the current state of the repo, you can simply run
-
-``` bash
-make bench-comrak
-```
-
-This will build comrak in release mode, and run benchmark on it. You will see the time measurements as reported by hyperfine in the console.
-
-Makefile also provides a way to run benchmarks for `comrak` current state (with your changes), `comrak` main branch, [`cmark-gfm`](https://github.com/github/cmark-gfm), [`pulldown-cmark`](https://github.com/raphlinus/pulldown-cmark) and [`markdown-it.rs`](https://github.com/rlidwka/markdown-it.rs). For this you will need to install `cmake`. After that make sure that you have set-up the git submodules. In case you have not installed submodules when cloning, you can do it by running
-
-``` bash
-git submodule update --init
-```
-
-After this is done, you can run
-
-``` bash
-make bench-all
-```
-
-which will run benchmarks across all, and report the time take by each as well as relative time.
-
-Apart from this, CI is also setup for running benchmarks when a pull request is first opened. It will add a comment with the results on the pull request in a tabular format comparing the 5 versions. After that you can manually trigger this CI by commenting `/run-bench` on the PR, this will update the existing comment with new results. Note benchmarks won't be automatically run on each push.
+For a slightly more real-world example, see how I [generate my GitHub user README](https://github.com/kivikakk/kivikakk) from a base document with embedded YAML, which itself has embedded Markdown, or
+[check out some of Comrak's dependents on crates.io](https://crates.io/crates/comrak/reverse_dependencies) or [on GitHub](https://github.com/kivikakk/comrak/network/dependents).
 
 ## Security
 
 As with [`cmark`](https://github.com/commonmark/cmark) and [`cmark-gfm`](https://github.com/github/cmark-gfm#security),
 Comrak will scrub raw HTML and potentially dangerous links. This change was introduced in Comrak 0.4.0 in support of a
-safe-by-default posture.
+safe-by-default posture, and later adopted by our contemporaries. :)
 
 To allow these, use the `unsafe_` option (or `--unsafe` with the command line program). If doing so, we recommend the
 use of a sanitisation library like [`ammonia`](https://github.com/notriddle/ammonia) configured specific to your needs.
@@ -266,29 +252,33 @@ Comrak additionally supports its own extensions, which are yet to be specced out
 - Footnotes
 - Description lists
 - Front matter
-- Shortcodes
+- Multi-line blockquotes
 - Math
-- Multiline Blockquotes
+- Emoji shortcodes
+- Wikilinks
+- Underline
+- Spoiler text
+- "Greentext"
 
 By default none are enabled; they are individually enabled with each parse by setting the appropriate values in the
-[`ComrakExtensionOptions` struct](https://docs.rs/comrak/newest/comrak/type.ComrakExtensionOptions.html).
+[`ExtensionOptions` struct](https://docs.rs/comrak/latest/comrak/struct.ExtensionOptions.html).
 
 ## Plugins
 
-### Codefence syntax highlighter
+### Fenced code block syntax highlighting
 
-At the moment syntax highlighting of codefence blocks is the only feature that can be enhanced with plugins.
+You can provide your own syntax highlighting engine.
 
 Create an implementation of the `SyntaxHighlighterAdapter` trait, and then provide an instance of such adapter to
-`Plugins.render.codefence_syntax_highlighter`. For formatting a markdown document with plugins, use the
-`markdown_to_html_with_plugins` function, which accepts your plugin as a parameter.
+`Plugins.render.codefence_syntax_highlighter`. For formatting a Markdown document with plugins, use the
+`markdown_to_html_with_plugins` function, which accepts your plugins object as a parameter.
 
 See the `syntax_highlighter.rs` and `syntect.rs` examples for more details.
 
 #### Syntect
 
 [`syntect`](https://github.com/trishume/syntect) is a syntax highlighting library for Rust. By default, `comrak` offers
-a plugin for it. In order to utilize it, create an instance of `plugins::syntect::SyntectAdapter` and use it as your
+a plugin for it. In order to utilize it, create an instance of `plugins::syntect::SyntectAdapter` and use it in your
 `Plugins` option.
 
 ## Related projects
@@ -298,8 +288,8 @@ in terms of code structure. The upside of this is that a change in `cmark-gfm` h
 Likewise, any bug in `cmark-gfm` is likely to be reproduced in Comrak. This could be considered a pro or a con,
 depending on your use case.
 
-The downside, of course, is that the code is not what I'd call idiomatic Rust (*so many `RefCell`s*), and while
-contributors and I have made it as fast as possible, it simply won't be as fast as some other CommonMark parsers
+The downside, of course, is that the code often diverges from idiomatic Rust, especially in the AST's extensive use of `RefCell`, and while
+contributors have made it as fast as possible, it simply won't be as fast as some other CommonMark parsers
 depending on your use-case. Here are some other projects to consider:
 
 - [Raph Levien](https://github.com/raphlinus)'s [`pulldown-cmark`](https://github.com/google/pulldown-cmark). It's
@@ -309,8 +299,31 @@ depending on your use-case. Here are some other projects to consider:
 - Know of another library? Please open a PR to add it\!
 
 As far as I know, Comrak is the only library to implement all of the [GitHub Flavored Markdown
-extensions](https://github.github.com/gfm) to the spec, but this tends to only be important if you want to reproduce
-GitHub's Markdown rendering exactly, e.g. in a GitHub client app.
+extensions](https://github.github.com/gfm) rigorously.
+
+## Benchmarking
+
+You'll need to [install hyperfine](https://github.com/sharkdp/hyperfine#installation), and CMake if you want to compare against `cmark-gfm`.
+
+If you want to just run the benchmark for the `comrak` binary itself, run:
+
+``` bash
+make bench-comrak
+```
+
+This will build Comrak in release mode, and run benchmark on it. You will see the time measurements as reported by hyperfine in the console.
+
+The `Makefile` also provides a way to run benchmarks for `comrak` current state (with your changes), `comrak` main branch, [`cmark-gfm`](https://github.com/github/cmark-gfm), [`pulldown-cmark`](https://github.com/raphlinus/pulldown-cmark) and [`markdown-it.rs`](https://github.com/rlidwka/markdown-it.rs). You'll need CMake, and ensure [submodules are prepared](https://stackoverflow.com/a/10168693/499609).
+
+``` bash
+make bench-all
+```
+
+This will build and run benchmarks across all, and report the time taken by each as well as relative time.
+
+<!-- XXX: The following isn't really true at the moment, due to https://github.com/kivikakk/comrak/issues/339 -->
+
+<!-- Apart from this, CI is also setup for running benchmarks when a pull request is first opened. It will add a comment with the results on the pull request in a tabular format comparing the 5 versions. After that you can manually trigger this CI by commenting `/run-bench` on the PR, this will update the existing comment with new results. Note benchmarks won't be automatically run on each push. -->
 
 ## Contributing
 
@@ -322,7 +335,7 @@ Thank you to Comrak's many contributors for PRs and issues opened\!
 
 ### Code Contributors
 
-<a href="https://github.com/kivikakk/comrak/graphs/contributors"><img src="https://opencollective.com/comrak/contributors.svg?width=890&button=false" /></a>
+[![Small chart showing Comrak contributors.](https://opencollective.com/comrak/contributors.svg?width=890&button=false)](https://github.com/kivikakk/comrak/graphs/contributors)
 
 ### Financial Contributors
 

--- a/examples/update-readme.rs
+++ b/examples/update-readme.rs
@@ -10,7 +10,8 @@ use comrak::{format_commonmark, parse_document, Arena, Options};
 
 const DEPENDENCIES: &str = "[dependencies]\ncomrak = ";
 const HELP: &str = "$ comrak --help\n";
-const HELP_START: &str = "A 100% CommonMark-compatible GitHub Flavored Markdown parser and formatter\n";
+const HELP_START: &str =
+    "A 100% CommonMark-compatible GitHub Flavored Markdown parser and formatter\n";
 
 fn main() -> Result<(), Box<dyn Error>> {
     let arena = Arena::new();

--- a/examples/update-readme.rs
+++ b/examples/update-readme.rs
@@ -10,6 +10,7 @@ use comrak::{format_commonmark, parse_document, Arena, Options};
 
 const DEPENDENCIES: &str = "[dependencies]\ncomrak = ";
 const HELP: &str = "$ comrak --help\n";
+const HELP_START: &str = "A 100% CommonMark-compatible GitHub Flavored Markdown parser and formatter\n";
 
 fn main() -> Result<(), Box<dyn Error>> {
     let arena = Arena::new();
@@ -23,6 +24,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .unwrap();
 
     let mut in_msrv = false;
+    let mut next_block_is_help_body = false;
+
     for node in doc.descendants() {
         match node.data.borrow_mut().value {
             NodeValue::CodeBlock(ref mut ncb) => {
@@ -33,12 +36,20 @@ fn main() -> Result<(), Box<dyn Error>> {
                     version_parts.pop();
                     write!(content, "\"{}\"", version_parts.join(".")).unwrap();
                     ncb.literal = content;
+                    continue;
                 }
 
                 // Look for a console code block whose contents starts with the HELP string.
-                // Replace its contents with the same string and the actual command output.
+                // The *next* code block contains our help, minus the starting string.
                 if ncb.info == "console" && ncb.literal.starts_with(HELP) {
-                    let mut content = HELP.to_string();
+                    next_block_is_help_body = true;
+                    continue;
+                }
+
+                if next_block_is_help_body {
+                    next_block_is_help_body = false;
+                    assert!(ncb.info == "" && ncb.literal.starts_with(HELP_START));
+                    let mut content = String::new();
                     let mut cmd = std::process::Command::new("cargo");
                     content.push_str(
                         str::from_utf8(
@@ -50,6 +61,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         .unwrap(),
                     );
                     ncb.literal = content;
+                    continue;
                 }
             }
             NodeValue::HtmlInline(ref mut s) => {
@@ -68,8 +80,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     }
 
+    let mut options = Options::default();
+    options.render.prefer_fenced = true;
+
     let mut out = vec![];
-    format_commonmark(doc, &Options::default(), &mut out)?;
+    format_commonmark(doc, &options, &mut out)?;
     std::fs::write("README.md", &out)?;
 
     Ok(())

--- a/script/cibuild
+++ b/script/cibuild
@@ -16,7 +16,11 @@ PROGRAM_ARG="--program=../../../target/release/comrak --syntax-highlighting none
 
 set +e
 
-python3 spec_tests.py --no-normalize --spec spec.txt "$PROGRAM_ARG" \
+# Upstream CommonMark specs.
+python3 spec_tests.py --no-normalize --spec ../../commonmark-spec/spec.txt "$PROGRAM_ARG" \
+	|| failed=1
+
+python3 spec_tests.py --no-normalize --spec spec.txt "$PROGRAM_ARG --gfm" \
 	|| failed=1
 python3 pathological_tests.py "$PROGRAM_ARG" \
 	|| failed=1

--- a/script/cibuild
+++ b/script/cibuild
@@ -20,7 +20,7 @@ set +e
 python3 spec_tests.py --no-normalize --spec ../../commonmark-spec/spec.txt "$PROGRAM_ARG" \
 	|| failed=1
 
-python3 spec_tests.py --no-normalize --spec spec.txt "$PROGRAM_ARG --gfm" \
+python3 spec_tests.py --no-normalize --spec spec.txt "$PROGRAM_ARG --gfm-quirks" \
 	|| failed=1
 python3 pathological_tests.py "$PROGRAM_ARG" \
 	|| failed=1

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -531,6 +531,7 @@ impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
                     && !(isspace(literal[literal.len() - 1])
                         && isspace(literal[literal.len() - 2])))
                 && !first_in_list_item
+                && !self.options.render.prefer_fenced
             {
                 write!(self, "    ").unwrap();
                 write!(self.prefix, "    ").unwrap();

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -36,7 +36,11 @@ pub fn unescape(text: &[u8]) -> Option<(Vec<u8>, usize)> {
             0
         };
 
-        if (1..=8).contains(&num_digits) && i < text.len() && text[i] == b';' {
+        if i < text.len()
+            && text[i] == b';'
+            && (((text[1] == b'x' || text[1] == b'X') && (1..=6).contains(&num_digits))
+                || (1..=7).contains(&num_digits))
+        {
             if codepoint == 0 || (0xD800..=0xE000).contains(&codepoint) || codepoint >= 0x110000 {
                 codepoint = 0xFFFD;
             }

--- a/src/html.rs
+++ b/src/html.rs
@@ -289,7 +289,7 @@ pub fn escape(output: &mut dyn Write, buffer: &[u8]) -> io::Result<()> {
 /// The inclusion of characters like "%" in those which are not escaped is
 /// explained somewhat here:
 ///
-/// https://github.com/github/cmark-gfm/blob/c32ef78bae851cb83b7ad52d0fbff880acdcd44a/src/houdini_href_e.c#L7-L31
+/// <https://github.com/github/cmark-gfm/blob/c32ef78bae851cb83b7ad52d0fbff880acdcd44a/src/houdini_href_e.c#L7-L31>
 ///
 /// In other words, if a CommonMark user enters:
 ///

--- a/src/html.rs
+++ b/src/html.rs
@@ -774,8 +774,9 @@ impl<'o> HtmlFormatter<'o> {
             }
             NodeValue::Strong => {
                 let parent_node = node.parent();
-                if parent_node.is_none()
-                    || !matches!(parent_node.unwrap().data.borrow().value, NodeValue::Strong)
+                if !self.options.render.gfm_quirks
+                    || (parent_node.is_none()
+                        || !matches!(parent_node.unwrap().data.borrow().value, NodeValue::Strong))
                 {
                     if entering {
                         self.output.write_all(b"<strong")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,13 +154,13 @@ pub fn markdown_to_commonmark(md: &str, options: &Options) -> String {
 }
 
 /// Render Markdown to CommonMark XML.
-/// See https://github.com/commonmark/commonmark-spec/blob/master/CommonMark.dtd.
+/// See <https://github.com/commonmark/commonmark-spec/blob/master/CommonMark.dtd>.
 pub fn markdown_to_commonmark_xml(md: &str, options: &Options) -> String {
     markdown_to_commonmark_xml_with_plugins(md, options, &Plugins::default())
 }
 
 /// Render Markdown to CommonMark XML using plugins.
-/// See https://github.com/commonmark/commonmark-spec/blob/master/CommonMark.dtd.
+/// See <https://github.com/commonmark/commonmark-spec/blob/master/CommonMark.dtd>.
 pub fn markdown_to_commonmark_xml_with_plugins(
     md: &str,
     options: &Options,

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,11 +57,15 @@ struct Cli {
     full_info_string: bool,
 
     /// Enable GitHub-flavored markdown extensions: strikethrough, tagfilter,
-    /// table, autolink, and tasklist. Also enables --github-pre-lang, and
-    /// enables GFM-style quirks in output HTML, such as not nesting <strong>
-    /// tags, which otherwise breaks CommonMark compatibility.
+    /// table, autolink, and tasklist. Also enables --github-pre-lang and
+    /// --gfm-quirks.
     #[arg(long)]
     gfm: bool,
+
+    /// Enables GFM-style quirks in output HTML, such as not nesting <strong>
+    /// tags, which otherwise breaks CommonMark compatibility.
+    #[arg(long)]
+    gfm_quirks: bool,
 
     /// Enable relaxing which character is allowed in a tasklists.
     #[arg(long)]
@@ -286,7 +290,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .escaped_char_spans(cli.escaped_char_spans)
         .ignore_setext(cli.ignore_setext)
         .ignore_empty_links(cli.ignore_empty_links)
-        .gfm_quirks(cli.gfm)
+        .gfm_quirks(cli.gfm_quirks || cli.gfm)
         .build()?;
 
     let options = Options {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,8 +56,10 @@ struct Cli {
     #[arg(long)]
     full_info_string: bool,
 
-    /// Enable GitHub-flavored markdown extensions: strikethrough, tagfilter, table, autolink, and tasklist.
-    /// Also enables --github-pre-lang.
+    /// Enable GitHub-flavored markdown extensions: strikethrough, tagfilter,
+    /// table, autolink, and tasklist. Also enables --github-pre-lang, and
+    /// enables GFM-style quirks in output HTML, such as not nesting <strong>
+    /// tags, which otherwise breaks CommonMark compatibility.
     #[arg(long)]
     gfm: bool,
 
@@ -284,6 +286,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .escaped_char_spans(cli.escaped_char_spans)
         .ignore_setext(cli.ignore_setext)
         .ignore_empty_links(cli.ignore_empty_links)
+        .gfm_quirks(cli.gfm)
         .build()?;
 
     let options = Options {

--- a/src/parser/autolink.rs
+++ b/src/parser/autolink.rs
@@ -161,7 +161,7 @@ fn check_domain(data: &[u8], allow_short: bool) -> Option<usize> {
 }
 
 fn is_valid_hostchar(ch: char) -> bool {
-    !ch.is_whitespace() && !ch.is_punctuation()
+    !ch.is_whitespace() && !(ch.is_punctuation() || ch.is_symbol())
 }
 
 fn autolink_delim(data: &[u8], mut link_end: usize, relaxed_autolinks: bool) -> usize {

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1010,8 +1010,10 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
         if c == b'_' {
             (
                 numdelims,
-                left_flanking && (!right_flanking || before_char.is_punctuation() || before_char.is_symbol()),
-                right_flanking && (!left_flanking || after_char.is_punctuation() || after_char.is_symbol()),
+                left_flanking
+                    && (!right_flanking || before_char.is_punctuation() || before_char.is_symbol()),
+                right_flanking
+                    && (!left_flanking || after_char.is_punctuation() || after_char.is_symbol()),
             )
         } else if c == b'\'' || c == b'"' {
             (

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1530,7 +1530,7 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
         }
 
         // Need to normalize both to lookup in refmap and to call callback
-        let lab = strings::normalize_label(&lab, Case::DontPreserve);
+        let lab = strings::normalize_label(&lab, Case::Fold);
         let mut reff = if found_label {
             self.refmap.lookup(&lab)
         } else {

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -998,20 +998,20 @@ impl<'a, 'r, 'o, 'd, 'i, 'c, 'subj> Subject<'a, 'r, 'o, 'd, 'i, 'c, 'subj> {
 
         let left_flanking = numdelims > 0
             && !after_char.is_whitespace()
-            && !(after_char.is_punctuation()
+            && !((after_char.is_punctuation() || after_char.is_symbol())
                 && !before_char.is_whitespace()
-                && !before_char.is_punctuation());
+                && !(before_char.is_punctuation() || before_char.is_symbol()));
         let right_flanking = numdelims > 0
             && !before_char.is_whitespace()
-            && !(before_char.is_punctuation()
+            && !((before_char.is_punctuation() || before_char.is_symbol())
                 && !after_char.is_whitespace()
-                && !after_char.is_punctuation());
+                && !(after_char.is_punctuation() || after_char.is_symbol()));
 
         if c == b'_' {
             (
                 numdelims,
-                left_flanking && (!right_flanking || before_char.is_punctuation()),
-                right_flanking && (!left_flanking || after_char.is_punctuation()),
+                left_flanking && (!right_flanking || before_char.is_punctuation() || before_char.is_symbol()),
+                right_flanking && (!left_flanking || after_char.is_punctuation() || after_char.is_symbol()),
             )
         } else if c == b'\'' || c == b'"' {
             (

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2147,7 +2147,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
         match node.data.borrow().value {
             NodeValue::FootnoteDefinition(ref nfd) => {
                 map.insert(
-                    strings::normalize_label(&nfd.name, Case::DontPreserve),
+                    strings::normalize_label(&nfd.name, Case::Fold),
                     FootnoteDefinition {
                         ix: None,
                         node,
@@ -2173,7 +2173,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
         let mut replace = None;
         match ast.value {
             NodeValue::FootnoteReference(ref mut nfr) => {
-                let normalized = strings::normalize_label(&nfr.name, Case::DontPreserve);
+                let normalized = strings::normalize_label(&nfr.name, Case::Fold);
                 if let Some(ref mut footnote) = map.get_mut(&normalized) {
                     let ix = match footnote.ix {
                         Some(ix) => ix,
@@ -2405,7 +2405,7 @@ impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
             }
         }
 
-        lab = strings::normalize_label(&lab, Case::DontPreserve);
+        lab = strings::normalize_label(&lab, Case::Fold);
         if !lab.is_empty() {
             subj.refmap.map.entry(lab).or_insert(Reference {
                 url: String::from_utf8(strings::clean_url(url)).unwrap(),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -782,6 +782,27 @@ pub struct RenderOptions {
     ///            "<p><strong>abcd</strong> <em><em>foo</em></em></p>\n");
     /// ```
     pub gfm_quirks: bool,
+
+    /// Prefer fenced code blocks when outputting CommonMark.
+    ///
+    /// ```rust
+    /// # use std::str;
+    /// # use comrak::{Arena, Options, format_commonmark, parse_document};
+    /// let arena = Arena::new();
+    /// let mut options = Options::default();
+    /// let input = "```\nhello\n```\n";
+    /// let root = parse_document(&arena, input, &options);
+    ///
+    /// let mut buf = Vec::new();
+    /// format_commonmark(&root, &options, &mut buf);
+    /// assert_eq!(str::from_utf8(&buf).unwrap(), "    hello\n");
+    ///
+    /// buf.clear();
+    /// options.render.prefer_fenced = true;
+    /// format_commonmark(&root, &options, &mut buf);
+    /// assert_eq!(str::from_utf8(&buf).unwrap(), "```\nhello\n```\n");
+    /// ```
+    pub prefer_fenced: bool,
 }
 
 #[non_exhaustive]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -766,6 +766,22 @@ pub struct RenderOptions {
     /// assert_eq!(markdown_to_html(input, &options), "<p>[]()</p>\n");
     /// ```
     pub ignore_empty_links: bool,
+
+    /// Enables GFM quirks in HTML output which break CommonMark compatibility.
+    ///
+    /// ```rust
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
+    /// let input = "****abcd**** *_foo_*";
+    ///
+    /// assert_eq!(markdown_to_html(input, &options),
+    ///            "<p><strong><strong>abcd</strong></strong> <em><em>foo</em></em></p>\n");
+    ///
+    /// options.render.gfm_quirks = true;
+    /// assert_eq!(markdown_to_html(input, &options),
+    ///            "<p><strong>abcd</strong> <em><em>foo</em></em></p>\n");
+    /// ```
+    pub gfm_quirks: bool,
 }
 
 #[non_exhaustive]

--- a/src/scanners.re
+++ b/src/scanners.re
@@ -24,7 +24,7 @@
 
     tagname = [A-Za-z][A-Za-z0-9-]*;
 
-    blocktagname = 'address'|'article'|'aside'|'base'|'basefont'|'blockquote'|'body'|'caption'|'center'|'col'|'colgroup'|'dd'|'details'|'dialog'|'dir'|'div'|'dl'|'dt'|'fieldset'|'figcaption'|'figure'|'footer'|'form'|'frame'|'frameset'|'h1'|'h2'|'h3'|'h4'|'h5'|'h6'|'head'|'header'|'hr'|'html'|'iframe'|'legend'|'li'|'link'|'main'|'menu'|'menuitem'|'nav'|'noframes'|'ol'|'optgroup'|'option'|'p'|'param'|'section'|'source'|'title'|'summary'|'table'|'tbody'|'td'|'tfoot'|'th'|'thead'|'title'|'tr'|'track'|'ul';
+    blocktagname = 'address'|'article'|'aside'|'base'|'basefont'|'blockquote'|'body'|'caption'|'center'|'col'|'colgroup'|'dd'|'details'|'dialog'|'dir'|'div'|'dl'|'dt'|'fieldset'|'figcaption'|'figure'|'footer'|'form'|'frame'|'frameset'|'h1'|'h2'|'h3'|'h4'|'h5'|'h6'|'head'|'header'|'hr'|'html'|'iframe'|'legend'|'li'|'link'|'main'|'menu'|'menuitem'|'nav'|'noframes'|'ol'|'optgroup'|'option'|'p'|'param'|'search'|'section'|'title'|'summary'|'table'|'tbody'|'td'|'tfoot'|'th'|'thead'|'title'|'tr'|'track'|'ul';
 
     attributename = [a-zA-Z_:][a-zA-Z0-9:._-]*;
 

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -6178,19 +6178,14 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                             yystate = 59;
                             continue 'yyl;
                         }
-                        0x4F | 0x6F => {
+                        0x54 | 0x74 => {
                             cursor += 1;
                             yystate = 60;
                             continue 'yyl;
                         }
-                        0x54 | 0x74 => {
-                            cursor += 1;
-                            yystate = 61;
-                            continue 'yyl;
-                        }
                         0x55 | 0x75 => {
                             cursor += 1;
-                            yystate = 62;
+                            yystate = 61;
                             continue 'yyl;
                         }
                         _ => {
@@ -6210,12 +6205,12 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x41 | 0x61 => {
                             cursor += 1;
-                            yystate = 63;
+                            yystate = 62;
                             continue 'yyl;
                         }
                         0x42 | 0x62 => {
                             cursor += 1;
-                            yystate = 64;
+                            yystate = 63;
                             continue 'yyl;
                         }
                         0x44 | 0x64 => {
@@ -6225,27 +6220,27 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                         0x45 | 0x65 => {
                             cursor += 1;
-                            yystate = 65;
+                            yystate = 64;
                             continue 'yyl;
                         }
                         0x46 | 0x66 => {
                             cursor += 1;
-                            yystate = 66;
+                            yystate = 65;
                             continue 'yyl;
                         }
                         0x48 | 0x68 => {
                             cursor += 1;
-                            yystate = 67;
+                            yystate = 66;
                             continue 'yyl;
                         }
                         0x49 | 0x69 => {
                             cursor += 1;
-                            yystate = 68;
+                            yystate = 67;
                             continue 'yyl;
                         }
                         0x52 | 0x72 => {
                             cursor += 1;
-                            yystate = 69;
+                            yystate = 68;
                             continue 'yyl;
                         }
                         _ => {
@@ -6285,7 +6280,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x2D => {
                             cursor += 1;
-                            yystate = 70;
+                            yystate = 69;
                             continue 'yyl;
                         }
                         _ => {
@@ -6308,7 +6303,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x43 | 0x63 => {
                             cursor += 1;
-                            yystate = 71;
+                            yystate = 70;
                             continue 'yyl;
                         }
                         _ => {
@@ -6361,14 +6356,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                             yystate = 59;
                             continue 'yyl;
                         }
-                        0x4F | 0x6F => {
-                            cursor += 1;
-                            yystate = 60;
-                            continue 'yyl;
-                        }
                         0x55 | 0x75 => {
                             cursor += 1;
-                            yystate = 62;
+                            yystate = 61;
                             continue 'yyl;
                         }
                         _ => {
@@ -6388,12 +6378,12 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x41 | 0x61 => {
                             cursor += 1;
-                            yystate = 63;
+                            yystate = 62;
                             continue 'yyl;
                         }
                         0x42 | 0x62 => {
                             cursor += 1;
-                            yystate = 64;
+                            yystate = 63;
                             continue 'yyl;
                         }
                         0x44 | 0x64 => {
@@ -6403,22 +6393,22 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                         0x46 | 0x66 => {
                             cursor += 1;
-                            yystate = 66;
+                            yystate = 65;
                             continue 'yyl;
                         }
                         0x48 | 0x68 => {
                             cursor += 1;
-                            yystate = 67;
+                            yystate = 66;
                             continue 'yyl;
                         }
                         0x49 | 0x69 => {
                             cursor += 1;
-                            yystate = 68;
+                            yystate = 67;
                             continue 'yyl;
                         }
                         0x52 | 0x72 => {
                             cursor += 1;
-                            yystate = 69;
+                            yystate = 68;
                             continue 'yyl;
                         }
                         _ => {
@@ -6438,7 +6428,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x44 | 0x64 => {
                             cursor += 1;
-                            yystate = 72;
+                            yystate = 71;
                             continue 'yyl;
                         }
                         _ => {
@@ -6458,7 +6448,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x54 | 0x74 => {
                             cursor += 1;
-                            yystate = 73;
+                            yystate = 72;
                             continue 'yyl;
                         }
                         _ => {
@@ -6478,7 +6468,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x49 | 0x69 => {
                             cursor += 1;
-                            yystate = 74;
+                            yystate = 73;
                             continue 'yyl;
                         }
                         _ => {
@@ -6498,7 +6488,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x53 | 0x73 => {
                             cursor += 1;
-                            yystate = 75;
+                            yystate = 74;
                             continue 'yyl;
                         }
                         _ => {
@@ -6518,7 +6508,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x4F | 0x6F => {
                             cursor += 1;
-                            yystate = 76;
+                            yystate = 75;
                             continue 'yyl;
                         }
                         _ => {
@@ -6538,7 +6528,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x44 | 0x64 => {
                             cursor += 1;
-                            yystate = 77;
+                            yystate = 76;
                             continue 'yyl;
                         }
                         _ => {
@@ -6558,7 +6548,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x50 | 0x70 => {
                             cursor += 1;
-                            yystate = 78;
+                            yystate = 77;
                             continue 'yyl;
                         }
                         _ => {
@@ -6578,7 +6568,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x4E | 0x6E => {
                             cursor += 1;
-                            yystate = 79;
+                            yystate = 78;
                             continue 'yyl;
                         }
                         _ => {
@@ -6598,7 +6588,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x4C | 0x6C => {
                             cursor += 1;
-                            yystate = 80;
+                            yystate = 79;
                             continue 'yyl;
                         }
                         _ => {
@@ -6643,7 +6633,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x54 | 0x74 => {
                             cursor += 1;
-                            yystate = 81;
+                            yystate = 80;
                             continue 'yyl;
                         }
                         _ => {
@@ -6663,7 +6653,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x41 | 0x61 => {
                             cursor += 1;
-                            yystate = 82;
+                            yystate = 81;
                             continue 'yyl;
                         }
                         0x52 | 0x56 | 0x72 | 0x76 => {
@@ -6688,12 +6678,12 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x45 | 0x65 => {
                             cursor += 1;
-                            yystate = 83;
+                            yystate = 82;
                             continue 'yyl;
                         }
                         0x47 | 0x67 => {
                             cursor += 1;
-                            yystate = 84;
+                            yystate = 83;
                             continue 'yyl;
                         }
                         _ => {
@@ -6713,12 +6703,12 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x4F | 0x6F => {
                             cursor += 1;
-                            yystate = 79;
+                            yystate = 78;
                             continue 'yyl;
                         }
                         0x52 | 0x72 => {
                             cursor += 1;
-                            yystate = 85;
+                            yystate = 84;
                             continue 'yyl;
                         }
                         _ => {
@@ -6738,7 +6728,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x41 | 0x61 => {
                             cursor += 1;
-                            yystate = 86;
+                            yystate = 85;
                             continue 'yyl;
                         }
                         _ => {
@@ -6758,7 +6748,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x41 | 0x61 => {
                             cursor += 1;
-                            yystate = 87;
+                            yystate = 86;
                             continue 'yyl;
                         }
                         _ => {
@@ -6798,7 +6788,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x52 | 0x72 => {
                             cursor += 1;
-                            yystate = 88;
+                            yystate = 87;
                             continue 'yyl;
                         }
                         _ => {
@@ -6818,7 +6808,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x47 | 0x67 => {
                             cursor += 1;
-                            yystate = 89;
+                            yystate = 88;
                             continue 'yyl;
                         }
                         _ => {
@@ -6848,7 +6838,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                         0x4E | 0x6E => {
                             cursor += 1;
-                            yystate = 90;
+                            yystate = 89;
                             continue 'yyl;
                         }
                         _ => {
@@ -6868,7 +6858,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x49 | 0x69 => {
                             cursor += 1;
-                            yystate = 91;
+                            yystate = 90;
                             continue 'yyl;
                         }
                         _ => {
@@ -6888,7 +6878,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x4E | 0x6E => {
                             cursor += 1;
-                            yystate = 92;
+                            yystate = 91;
                             continue 'yyl;
                         }
                         _ => {
@@ -6928,7 +6918,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x46 | 0x66 => {
                             cursor += 1;
-                            yystate = 93;
+                            yystate = 92;
                             continue 'yyl;
                         }
                         _ => {
@@ -6948,7 +6938,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x54 | 0x74 => {
                             cursor += 1;
-                            yystate = 94;
+                            yystate = 93;
                             continue 'yyl;
                         }
                         _ => {
@@ -6991,7 +6981,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x52 | 0x72 => {
                             cursor += 1;
-                            yystate = 95;
+                            yystate = 94;
                             continue 'yyl;
                         }
                         _ => {
@@ -7011,7 +7001,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x45 | 0x65 => {
                             cursor += 1;
-                            yystate = 96;
+                            yystate = 95;
                             continue 'yyl;
                         }
                         _ => {
@@ -7031,7 +7021,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x52 | 0x72 => {
                             cursor += 1;
-                            yystate = 97;
+                            yystate = 96;
                             continue 'yyl;
                         }
                         _ => {
@@ -7049,9 +7039,14 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
+                        0x41 | 0x61 => {
+                            cursor += 1;
+                            yystate = 97;
+                            continue 'yyl;
+                        }
                         0x43 | 0x63 => {
                             cursor += 1;
-                            yystate = 78;
+                            yystate = 77;
                             continue 'yyl;
                         }
                         _ => {
@@ -7069,7 +7064,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x55 | 0x75 => {
+                        0x59 | 0x79 => {
                             cursor += 1;
                             yystate = 98;
                             continue 'yyl;
@@ -7089,7 +7084,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x59 | 0x79 => {
+                        0x4D | 0x6D => {
                             cursor += 1;
                             yystate = 99;
                             continue 'yyl;
@@ -7109,7 +7104,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x4D | 0x6D => {
+                        0x42 | 0x62 => {
                             cursor += 1;
                             yystate = 100;
                             continue 'yyl;
@@ -7129,9 +7124,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x42 | 0x62 => {
+                        0x4F | 0x6F => {
                             cursor += 1;
-                            yystate = 101;
+                            yystate = 34;
                             continue 'yyl;
                         }
                         _ => {
@@ -7149,9 +7144,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x4F | 0x6F => {
+                        0x58 | 0x78 => {
                             cursor += 1;
-                            yystate = 34;
+                            yystate = 101;
                             continue 'yyl;
                         }
                         _ => {
@@ -7169,7 +7164,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x58 | 0x78 => {
+                        0x4F | 0x6F => {
                             cursor += 1;
                             yystate = 102;
                             continue 'yyl;
@@ -7181,26 +7176,6 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     }
                 }
                 66 => {
-                    yych = unsafe {
-                        if cursor < len {
-                            *s.get_unchecked(cursor)
-                        } else {
-                            0
-                        }
-                    };
-                    match yych {
-                        0x4F | 0x6F => {
-                            cursor += 1;
-                            yystate = 103;
-                            continue 'yyl;
-                        }
-                        _ => {
-                            yystate = 5;
-                            continue 'yyl;
-                        }
-                    }
-                }
-                67 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -7221,7 +7196,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                         0x45 | 0x65 => {
                             cursor += 1;
-                            yystate = 104;
+                            yystate = 103;
                             continue 'yyl;
                         }
                         _ => {
@@ -7230,7 +7205,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                68 => {
+                67 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -7241,7 +7216,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x54 | 0x74 => {
                             cursor += 1;
-                            yystate = 101;
+                            yystate = 100;
                             continue 'yyl;
                         }
                         _ => {
@@ -7250,7 +7225,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                69 => {
+                68 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -7271,7 +7246,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                         0x41 | 0x61 => {
                             cursor += 1;
-                            yystate = 105;
+                            yystate = 104;
                             continue 'yyl;
                         }
                         _ => {
@@ -7280,8 +7255,28 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                70 => {
+                69 => {
                     return Some(2);
+                }
+                70 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x44 | 0x64 => {
+                            cursor += 1;
+                            yystate = 105;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
                 }
                 71 => {
                     yych = unsafe {
@@ -7292,7 +7287,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x44 | 0x64 => {
+                        0x52 | 0x72 => {
                             cursor += 1;
                             yystate = 106;
                             continue 'yyl;
@@ -7312,7 +7307,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x52 | 0x72 => {
+                        0x49 | 0x69 => {
                             cursor += 1;
                             yystate = 107;
                             continue 'yyl;
@@ -7332,7 +7327,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x49 | 0x69 => {
+                        0x44 | 0x64 => {
                             cursor += 1;
                             yystate = 108;
                             continue 'yyl;
@@ -7352,7 +7347,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x44 | 0x64 => {
+                        0x45 | 0x65 => {
                             cursor += 1;
                             yystate = 109;
                             continue 'yyl;
@@ -7372,7 +7367,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x45 | 0x65 => {
+                        0x43 | 0x63 => {
                             cursor += 1;
                             yystate = 110;
                             continue 'yyl;
@@ -7392,9 +7387,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x43 | 0x63 => {
+                        0x59 | 0x79 => {
                             cursor += 1;
-                            yystate = 111;
+                            yystate = 38;
                             continue 'yyl;
                         }
                         _ => {
@@ -7412,9 +7407,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x59 | 0x79 => {
+                        0x54 | 0x74 => {
                             cursor += 1;
-                            yystate = 38;
+                            yystate = 111;
                             continue 'yyl;
                         }
                         _ => {
@@ -7452,7 +7447,17 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x54 | 0x74 => {
+                        0x09..=0x0D | 0x20 | 0x3E => {
+                            cursor += 1;
+                            yystate = 54;
+                            continue 'yyl;
+                        }
+                        0x2F => {
+                            cursor += 1;
+                            yystate = 55;
+                            continue 'yyl;
+                        }
+                        0x47 | 0x67 => {
                             cursor += 1;
                             yystate = 113;
                             continue 'yyl;
@@ -7472,17 +7477,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x09..=0x0D | 0x20 | 0x3E => {
-                            cursor += 1;
-                            yystate = 54;
-                            continue 'yyl;
-                        }
-                        0x2F => {
-                            cursor += 1;
-                            yystate = 55;
-                            continue 'yyl;
-                        }
-                        0x47 | 0x67 => {
+                        0x41 | 0x61 => {
                             cursor += 1;
                             yystate = 114;
                             continue 'yyl;
@@ -7502,7 +7497,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x41 | 0x61 => {
+                        0x4C | 0x6C => {
                             cursor += 1;
                             yystate = 115;
                             continue 'yyl;
@@ -7542,9 +7537,14 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x4C | 0x6C => {
+                        0x43 | 0x63 => {
                             cursor += 1;
                             yystate = 117;
+                            continue 'yyl;
+                        }
+                        0x55 | 0x75 => {
+                            cursor += 1;
+                            yystate = 118;
                             continue 'yyl;
                         }
                         _ => {
@@ -7562,14 +7562,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x43 | 0x63 => {
+                        0x4D | 0x6D => {
                             cursor += 1;
-                            yystate = 118;
-                            continue 'yyl;
-                        }
-                        0x55 | 0x75 => {
-                            cursor += 1;
-                            yystate = 119;
+                            yystate = 38;
                             continue 'yyl;
                         }
                         _ => {
@@ -7589,7 +7584,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x4D | 0x6D => {
                             cursor += 1;
-                            yystate = 38;
+                            yystate = 119;
                             continue 'yyl;
                         }
                         _ => {
@@ -7607,7 +7602,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x4D | 0x6D => {
+                        0x44 | 0x64 => {
                             cursor += 1;
                             yystate = 120;
                             continue 'yyl;
@@ -7627,7 +7622,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x44 | 0x64 => {
+                        0x41 | 0x61 => {
                             cursor += 1;
                             yystate = 121;
                             continue 'yyl;
@@ -7647,7 +7642,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x41 | 0x61 => {
+                        0x45 | 0x65 => {
                             cursor += 1;
                             yystate = 122;
                             continue 'yyl;
@@ -7667,26 +7662,6 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x45 | 0x65 => {
-                            cursor += 1;
-                            yystate = 123;
-                            continue 'yyl;
-                        }
-                        _ => {
-                            yystate = 5;
-                            continue 'yyl;
-                        }
-                    }
-                }
-                90 => {
-                    yych = unsafe {
-                        if cursor < len {
-                            *s.get_unchecked(cursor)
-                        } else {
-                            0
-                        }
-                    };
-                    match yych {
                         0x4B | 0x6B => {
                             cursor += 1;
                             yystate = 38;
@@ -7698,7 +7673,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                91 => {
+                90 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -7718,7 +7693,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                92 => {
+                91 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -7728,6 +7703,26 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     };
                     match yych {
                         0x55 | 0x75 => {
+                            cursor += 1;
+                            yystate = 123;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                92 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x52 | 0x72 => {
                             cursor += 1;
                             yystate = 124;
                             continue 'yyl;
@@ -7747,7 +7742,12 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x52 | 0x72 => {
+                        0x47 | 0x67 => {
+                            cursor += 1;
+                            yystate = 113;
+                            continue 'yyl;
+                        }
+                        0x49 | 0x69 => {
                             cursor += 1;
                             yystate = 125;
                             continue 'yyl;
@@ -7767,14 +7767,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x47 | 0x67 => {
+                        0x41 | 0x61 => {
                             cursor += 1;
-                            yystate = 114;
-                            continue 'yyl;
-                        }
-                        0x49 | 0x69 => {
-                            cursor += 1;
-                            yystate = 126;
+                            yystate = 84;
                             continue 'yyl;
                         }
                         _ => {
@@ -7792,9 +7787,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x41 | 0x61 => {
+                        0x09..=0x0D | 0x20 | 0x3E => {
                             cursor += 1;
-                            yystate = 85;
+                            yystate = 126;
                             continue 'yyl;
                         }
                         _ => {
@@ -7812,7 +7807,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x09..=0x0D | 0x20 | 0x3E => {
+                        0x49 | 0x69 => {
                             cursor += 1;
                             yystate = 127;
                             continue 'yyl;
@@ -7832,7 +7827,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x49 | 0x69 => {
+                        0x52 | 0x72 => {
                             cursor += 1;
                             yystate = 128;
                             continue 'yyl;
@@ -7852,9 +7847,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x52 | 0x72 => {
+                        0x4C | 0x6C => {
                             cursor += 1;
-                            yystate = 129;
+                            yystate = 57;
                             continue 'yyl;
                         }
                         _ => {
@@ -7872,9 +7867,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x4C | 0x6C => {
+                        0x4D | 0x6D => {
                             cursor += 1;
-                            yystate = 57;
+                            yystate = 129;
                             continue 'yyl;
                         }
                         _ => {
@@ -7892,9 +7887,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x4D | 0x6D => {
+                        0x4C | 0x6C => {
                             cursor += 1;
-                            yystate = 130;
+                            yystate = 108;
                             continue 'yyl;
                         }
                         _ => {
@@ -7912,9 +7907,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x4C | 0x6C => {
+                        0x54 | 0x74 => {
                             cursor += 1;
-                            yystate = 109;
+                            yystate = 130;
                             continue 'yyl;
                         }
                         _ => {
@@ -7932,7 +7927,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x54 | 0x74 => {
+                        0x4F | 0x6F => {
                             cursor += 1;
                             yystate = 131;
                             continue 'yyl;
@@ -7952,7 +7947,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x4F | 0x6F => {
+                        0x41 | 0x61 => {
                             cursor += 1;
                             yystate = 132;
                             continue 'yyl;
@@ -7972,9 +7967,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x41 | 0x61 => {
+                        0x43 | 0x63 => {
                             cursor += 1;
-                            yystate = 133;
+                            yystate = 89;
                             continue 'yyl;
                         }
                         _ => {
@@ -7992,9 +7987,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x43 | 0x63 => {
+                        0x41 | 0x61 => {
                             cursor += 1;
-                            yystate = 90;
+                            yystate = 133;
                             continue 'yyl;
                         }
                         _ => {
@@ -8012,7 +8007,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x41 | 0x61 => {
+                        0x45 | 0x65 => {
                             cursor += 1;
                             yystate = 134;
                             continue 'yyl;
@@ -8032,9 +8027,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x45 | 0x65 => {
+                        0x43 | 0x63 => {
                             cursor += 1;
-                            yystate = 135;
+                            yystate = 100;
                             continue 'yyl;
                         }
                         _ => {
@@ -8044,26 +8039,6 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     }
                 }
                 108 => {
-                    yych = unsafe {
-                        if cursor < len {
-                            *s.get_unchecked(cursor)
-                        } else {
-                            0
-                        }
-                    };
-                    match yych {
-                        0x43 | 0x63 => {
-                            cursor += 1;
-                            yystate = 101;
-                            continue 'yyl;
-                        }
-                        _ => {
-                            yystate = 5;
-                            continue 'yyl;
-                        }
-                    }
-                }
-                109 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8083,7 +8058,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                110 => {
+                109 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8104,6 +8079,26 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                         0x46 | 0x66 => {
                             cursor += 1;
+                            yystate = 135;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                110 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x4B | 0x6B => {
+                            cursor += 1;
                             yystate = 136;
                             continue 'yyl;
                         }
@@ -8122,9 +8117,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x4B | 0x6B => {
+                        0x49 | 0x69 => {
                             cursor += 1;
-                            yystate = 137;
+                            yystate = 125;
                             continue 'yyl;
                         }
                         _ => {
@@ -8142,9 +8137,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x49 | 0x69 => {
+                        0x45 | 0x65 => {
                             cursor += 1;
-                            yystate = 126;
+                            yystate = 137;
                             continue 'yyl;
                         }
                         _ => {
@@ -8162,7 +8157,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x45 | 0x65 => {
+                        0x52 | 0x72 => {
                             cursor += 1;
                             yystate = 138;
                             continue 'yyl;
@@ -8182,7 +8177,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x52 | 0x72 => {
+                        0x49 | 0x69 => {
                             cursor += 1;
                             yystate = 139;
                             continue 'yyl;
@@ -8202,7 +8197,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x49 | 0x69 => {
+                        0x4F | 0x6F => {
                             cursor += 1;
                             yystate = 140;
                             continue 'yyl;
@@ -8222,7 +8217,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x4F | 0x6F => {
+                        0x44 | 0x64 => {
                             cursor += 1;
                             yystate = 141;
                             continue 'yyl;
@@ -8242,9 +8237,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x44 | 0x64 => {
+                        0x41 | 0x61 => {
                             cursor += 1;
-                            yystate = 142;
+                            yystate = 35;
                             continue 'yyl;
                         }
                         _ => {
@@ -8262,9 +8257,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x41 | 0x61 => {
+                        0x52 | 0x72 => {
                             cursor += 1;
-                            yystate = 35;
+                            yystate = 108;
                             continue 'yyl;
                         }
                         _ => {
@@ -8282,9 +8277,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x52 | 0x72 => {
+                        0x45 | 0x65 => {
                             cursor += 1;
-                            yystate = 109;
+                            yystate = 142;
                             continue 'yyl;
                         }
                         _ => {
@@ -8294,26 +8289,6 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     }
                 }
                 120 => {
-                    yych = unsafe {
-                        if cursor < len {
-                            *s.get_unchecked(cursor)
-                        } else {
-                            0
-                        }
-                    };
-                    match yych {
-                        0x45 | 0x65 => {
-                            cursor += 1;
-                            yystate = 143;
-                            continue 'yyl;
-                        }
-                        _ => {
-                            yystate = 5;
-                            continue 'yyl;
-                        }
-                    }
-                }
-                121 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8334,7 +8309,27 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                         0x45 | 0x65 => {
                             cursor += 1;
-                            yystate = 138;
+                            yystate = 137;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                121 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x4D | 0x6D => {
+                            cursor += 1;
+                            yystate = 108;
                             continue 'yyl;
                         }
                         _ => {
@@ -8352,9 +8347,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x4D | 0x6D => {
+                        0x4E | 0x6E => {
                             cursor += 1;
-                            yystate = 109;
+                            yystate = 132;
                             continue 'yyl;
                         }
                         _ => {
@@ -8364,26 +8359,6 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     }
                 }
                 123 => {
-                    yych = unsafe {
-                        if cursor < len {
-                            *s.get_unchecked(cursor)
-                        } else {
-                            0
-                        }
-                    };
-                    match yych {
-                        0x4E | 0x6E => {
-                            cursor += 1;
-                            yystate = 133;
-                            continue 'yyl;
-                        }
-                        _ => {
-                            yystate = 5;
-                            continue 'yyl;
-                        }
-                    }
-                }
-                124 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8404,6 +8379,26 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                         0x49 | 0x69 => {
                             cursor += 1;
+                            yystate = 143;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                124 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x41 | 0x61 => {
+                            cursor += 1;
                             yystate = 144;
                             continue 'yyl;
                         }
@@ -8422,7 +8417,30 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x41 | 0x61 => {
+                        0x4F | 0x6F => {
+                            cursor += 1;
+                            yystate = 90;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                126 => {
+                    return Some(1);
+                }
+                127 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x50 | 0x70 => {
                             cursor += 1;
                             yystate = 145;
                             continue 'yyl;
@@ -8433,29 +8451,6 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                126 => {
-                    yych = unsafe {
-                        if cursor < len {
-                            *s.get_unchecked(cursor)
-                        } else {
-                            0
-                        }
-                    };
-                    match yych {
-                        0x4F | 0x6F => {
-                            cursor += 1;
-                            yystate = 91;
-                            continue 'yyl;
-                        }
-                        _ => {
-                            yystate = 5;
-                            continue 'yyl;
-                        }
-                    }
-                }
-                127 => {
-                    return Some(1);
-                }
                 128 => {
                     yych = unsafe {
                         if cursor < len {
@@ -8465,7 +8460,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x50 | 0x70 => {
+                        0x43 | 0x63 => {
                             cursor += 1;
                             yystate = 146;
                             continue 'yyl;
@@ -8485,9 +8480,9 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x43 | 0x63 => {
+                        0x41 | 0x61 => {
                             cursor += 1;
-                            yystate = 109;
+                            yystate = 147;
                             continue 'yyl;
                         }
                         _ => {
@@ -8507,26 +8502,6 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x41 | 0x61 => {
                             cursor += 1;
-                            yystate = 147;
-                            continue 'yyl;
-                        }
-                        _ => {
-                            yystate = 5;
-                            continue 'yyl;
-                        }
-                    }
-                }
-                131 => {
-                    yych = unsafe {
-                        if cursor < len {
-                            *s.get_unchecked(cursor)
-                        } else {
-                            0
-                        }
-                    };
-                    match yych {
-                        0x41 | 0x61 => {
-                            cursor += 1;
                             yystate = 148;
                             continue 'yyl;
                         }
@@ -8536,7 +8511,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                132 => {
+                131 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8556,7 +8531,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                133 => {
+                132 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8576,7 +8551,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                134 => {
+                133 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8596,7 +8571,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                135 => {
+                134 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8616,7 +8591,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                136 => {
+                135 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8636,7 +8611,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                137 => {
+                136 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8656,7 +8631,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                138 => {
+                137 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8676,7 +8651,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                139 => {
+                138 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8696,7 +8671,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                140 => {
+                139 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8716,7 +8691,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                141 => {
+                140 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8736,6 +8711,26 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
+                141 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x53 | 0x73 => {
+                            cursor += 1;
+                            yystate = 154;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
+                }
                 142 => {
                     yych = unsafe {
                         if cursor < len {
@@ -8745,6 +8740,16 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
+                        0x09..=0x0D | 0x20 | 0x3E => {
+                            cursor += 1;
+                            yystate = 54;
+                            continue 'yyl;
+                        }
+                        0x2F => {
+                            cursor += 1;
+                            yystate = 55;
+                            continue 'yyl;
+                        }
                         0x53 | 0x73 => {
                             cursor += 1;
                             yystate = 154;
@@ -8765,36 +8770,6 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     };
                     match yych {
-                        0x09..=0x0D | 0x20 | 0x3E => {
-                            cursor += 1;
-                            yystate = 54;
-                            continue 'yyl;
-                        }
-                        0x2F => {
-                            cursor += 1;
-                            yystate = 55;
-                            continue 'yyl;
-                        }
-                        0x53 | 0x73 => {
-                            cursor += 1;
-                            yystate = 154;
-                            continue 'yyl;
-                        }
-                        _ => {
-                            yystate = 5;
-                            continue 'yyl;
-                        }
-                    }
-                }
-                144 => {
-                    yych = unsafe {
-                        if cursor < len {
-                            *s.get_unchecked(cursor)
-                        } else {
-                            0
-                        }
-                    };
-                    match yych {
                         0x54 | 0x74 => {
                             cursor += 1;
                             yystate = 155;
@@ -8806,7 +8781,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                145 => {
+                144 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8826,7 +8801,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                         }
                     }
                 }
-                146 => {
+                145 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -8837,7 +8812,27 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x54 | 0x74 => {
                             cursor += 1;
-                            yystate = 96;
+                            yystate = 95;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                146 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x48 | 0x68 => {
+                            cursor += 1;
+                            yystate = 38;
                             continue 'yyl;
                         }
                         _ => {
@@ -8857,7 +8852,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x52 | 0x72 => {
                             cursor += 1;
-                            yystate = 77;
+                            yystate = 76;
                             continue 'yyl;
                         }
                         _ => {
@@ -8937,7 +8932,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x4E | 0x6E => {
                             cursor += 1;
-                            yystate = 132;
+                            yystate = 131;
                             continue 'yyl;
                         }
                         _ => {
@@ -8997,7 +8992,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x45 | 0x65 => {
                             cursor += 1;
-                            yystate = 132;
+                            yystate = 131;
                             continue 'yyl;
                         }
                         _ => {
@@ -9017,7 +9012,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x45 | 0x65 => {
                             cursor += 1;
-                            yystate = 85;
+                            yystate = 84;
                             continue 'yyl;
                         }
                         _ => {
@@ -9137,7 +9132,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x41 | 0x61 => {
                             cursor += 1;
-                            yystate = 96;
+                            yystate = 95;
                             continue 'yyl;
                         }
                         _ => {
@@ -9160,7 +9155,7 @@ pub fn html_block_start(s: &[u8]) -> Option<usize> {
                     match yych {
                         0x54 | 0x74 => {
                             cursor += 1;
-                            yystate = 109;
+                            yystate = 108;
                             continue 'yyl;
                         }
                         _ => {

--- a/src/tests/core.rs
+++ b/src/tests/core.rs
@@ -424,6 +424,14 @@ fn reference_links() {
 }
 
 #[test]
+fn reference_links_casefold() {
+    html(
+        concat!("[ẞ]\n", "\n", "[SS]: /url	\n",),
+        "<p><a href=\"/url\">ẞ</a></p>\n",
+    );
+}
+
+#[test]
 fn safety() {
     html(
         concat!(


### PR DESCRIPTION
Fixes #329.

~~WIP; I think there's some CommonMark revisions to catch up on.~~

* [x] Example 28 (lines 690-700) Entity and numeric character references
* [x] Example 354 (lines 6347-6357) Emphasis and strong emphasis
* [x] Example 540 (lines 8129-8135) Links

This brings us to CommonMark 0.31.2.