### PR TITLE
broken reflink callback updates & big cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ fn replace_text(document: &str, orig_string: &str, replacement: &str) -> String 
     for node in root.descendants() {
         if let NodeValue::Text(ref mut text) = node.data.borrow_mut().value {
             // If the node is a text node, perform the string replacement.
-            *text = text.replace(orig_string, replacement)
+            *text = text.replace(orig_string, replacement);
         }
     }
 

--- a/fuzz/fuzz_targets/all_options.rs
+++ b/fuzz/fuzz_targets/all_options.rs
@@ -19,10 +19,10 @@ fuzz_target!(|s: &str| {
     extension.header_ids = Some("user-content-".to_string());
     extension.footnotes = true;
     extension.description_lists = true;
+    extension.front_matter_delimiter = Some("---".to_string());
     extension.multiline_block_quotes = true;
     extension.math_dollars = true;
     extension.math_code = true;
-    extension.front_matter_delimiter = Some("---".to_string());
     extension.shortcodes = true;
     extension.wikilinks_title_after_pipe = true;
     extension.wikilinks_title_before_pipe = true;
@@ -55,6 +55,8 @@ fuzz_target!(|s: &str| {
     render.escaped_char_spans = true;
     render.ignore_setext = true;
     render.ignore_empty_links = true;
+    render.gfm_quirks = true;
+    render.prefer_fenced = true;
 
     markdown_to_html(
         s,

--- a/fuzz/fuzz_targets/cli_default.rs
+++ b/fuzz/fuzz_targets/cli_default.rs
@@ -2,9 +2,7 @@
 
 use libfuzzer_sys::fuzz_target;
 
-use comrak::{
-    markdown_to_html_with_plugins, plugins::syntect::SyntectAdapter, Plugins,
-};
+use comrak::{markdown_to_html_with_plugins, plugins::syntect::SyntectAdapter, Plugins};
 
 // Note that we end up fuzzing Syntect here.
 

--- a/fuzz/fuzz_targets/quadratic.rs
+++ b/fuzz/fuzz_targets/quadratic.rs
@@ -2,9 +2,8 @@
 #![feature(int_roundings)]
 #![no_main]
 use comrak::{
-    markdown_to_html, markdown_to_commonmark, markdown_to_commonmark_xml,
-    ExtensionOptions, Options, ParseOptions,
-    RenderOptions, ListStyleType,
+    markdown_to_commonmark, markdown_to_commonmark_xml, markdown_to_html, ExtensionOptions,
+    ListStyleType, Options, ParseOptions, RenderOptions,
 };
 use libfuzzer_sys::arbitrary::{self, Arbitrary};
 use libfuzzer_sys::fuzz_target;
@@ -297,18 +296,10 @@ fn fuzz_one_input(input: &Input, num_bytes: usize) -> (usize, Duration, f64) {
     let duration_per_byte = duration.as_secs_f64() / (byte_length as f64);
 
     if DEBUG {
-        println!(
-            "do_one: {} bytes, duration = {:?}",
-            byte_length,
-            duration
-        );
+        println!("do_one: {} bytes, duration = {:?}", byte_length, duration);
     }
 
-    (
-        byte_length,
-        duration,
-        duration_per_byte
-    )
+    (byte_length, duration, duration_per_byte)
 }
 
 /// The maximum number of steps to run in the main fuzzing loop below.

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -47,9 +47,9 @@ pub fn format_document_with_plugins<'a>(
     Ok(())
 }
 
-struct CommonMarkFormatter<'a, 'o> {
+struct CommonMarkFormatter<'a, 'o, 'c> {
     node: &'a AstNode<'a>,
-    options: &'o Options,
+    options: &'o Options<'c>,
     v: Vec<u8>,
     prefix: Vec<u8>,
     column: usize,
@@ -72,7 +72,7 @@ enum Escaping {
     Title,
 }
 
-impl<'a, 'o> Write for CommonMarkFormatter<'a, 'o> {
+impl<'a, 'o, 'c> Write for CommonMarkFormatter<'a, 'o, 'c> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.output(buf, false, Escaping::Literal);
         Ok(buf.len())
@@ -83,8 +83,8 @@ impl<'a, 'o> Write for CommonMarkFormatter<'a, 'o> {
     }
 }
 
-impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
-    fn new(node: &'a AstNode<'a>, options: &'o Options) -> Self {
+impl<'a, 'o, 'c> CommonMarkFormatter<'a, 'o, 'c> {
+    fn new(node: &'a AstNode<'a>, options: &'o Options<'c>) -> Self {
         CommonMarkFormatter {
             node,
             options,

--- a/src/html.rs
+++ b/src/html.rs
@@ -361,7 +361,7 @@ where
     Ok(())
 }
 
-impl<'o, 'c> HtmlFormatter<'o, 'c> {
+impl<'o, 'c: 'o> HtmlFormatter<'o, 'c> {
     fn new(
         options: &'o Options<'c>,
         output: &'o mut WriteWithLast<'o>,

--- a/src/html.rs
+++ b/src/html.rs
@@ -63,25 +63,24 @@ impl<'w> Write for WriteWithLast<'w> {
     }
 }
 
-/// Converts header Strings to canonical, unique, but still human-readable, anchors.
+/// Converts header strings to canonical, unique, but still human-readable,
+/// anchors.
 ///
-/// To guarantee uniqueness, an anchorizer keeps track of the anchors
-/// it has returned.  So, for example, to parse several MarkDown
-/// files, use a new anchorizer per file.
+/// To guarantee uniqueness, an anchorizer keeps track of the anchors it has
+/// returned; use one per output file.
 ///
 /// ## Example
 ///
 /// ```
-/// use comrak::Anchorizer;
-///
+/// # use comrak::Anchorizer;
 /// let mut anchorizer = Anchorizer::new();
-///
 /// // First "stuff" is unsuffixed.
 /// assert_eq!("stuff".to_string(), anchorizer.anchorize("Stuff".to_string()));
 /// // Second "stuff" has "-1" appended to make it unique.
 /// assert_eq!("stuff-1".to_string(), anchorizer.anchorize("Stuff".to_string()));
 /// ```
 #[derive(Debug, Default)]
+#[doc(hidden)]
 pub struct Anchorizer(HashSet<String>);
 
 impl Anchorizer {
@@ -96,12 +95,9 @@ impl Anchorizer {
     /// resultant anchor unique.
     ///
     /// ```
-    /// use comrak::Anchorizer;
-    ///
+    /// # use comrak::Anchorizer;
     /// let mut anchorizer = Anchorizer::new();
-    ///
     /// let source = "Ticks aren't in";
-    ///
     /// assert_eq!("ticks-arent-in".to_string(), anchorizer.anchorize(source.to_string()));
     /// ```
     pub fn anchorize(&mut self, header: String) -> String {
@@ -130,9 +126,9 @@ impl Anchorizer {
     }
 }
 
-struct HtmlFormatter<'o> {
+struct HtmlFormatter<'o, 'c> {
     output: &'o mut WriteWithLast<'o>,
-    options: &'o Options,
+    options: &'o Options<'c>,
     anchorizer: Anchorizer,
     footnote_ix: u32,
     written_footnote_ix: u32,
@@ -365,8 +361,12 @@ where
     Ok(())
 }
 
-impl<'o> HtmlFormatter<'o> {
-    fn new(options: &'o Options, output: &'o mut WriteWithLast<'o>, plugins: &'o Plugins) -> Self {
+impl<'o, 'c> HtmlFormatter<'o, 'c> {
+    fn new(
+        options: &'o Options<'c>,
+        output: &'o mut WriteWithLast<'o>,
+        plugins: &'o Plugins,
+    ) -> Self {
         HtmlFormatter {
             options,
             output,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
 //! A 100% [CommonMark](http://commonmark.org/) and [GFM](https://github.github.com/gfm/)
-//! compatible Markdown parser.  Source repository is at <https://github.com/kivikakk/comrak>.
+//! compatible Markdown parser.
 //!
-//! The design is based on [cmark-gfm](https://github.com/github/cmark-gfm), so
-//! familiarity with that will help.
+//! Source repository and detailed `README` is at <https://github.com/kivikakk/comrak>.
 //!
 //! You can use `comrak::markdown_to_html` directly:
 //!
@@ -20,31 +19,18 @@
 //! use comrak::nodes::{AstNode, NodeValue};
 //!
 //! # fn main() {
-//! // The returned nodes are created in the supplied Arena, and are bound by its lifetime.
 //! let arena = Arena::new();
 //!
 //! let root = parse_document(
 //!     &arena,
-//!     "This is my input.\n\n1. Also my input.\n2. Certainly my input.\n",
+//!     "This is my input.\n\n1. Also [my](#) input.\n2. Certainly *my* input.\n",
 //!     &Options::default());
 //!
-//! fn iter_nodes<'a, F>(node: &'a AstNode<'a>, f: &F)
-//!     where F : Fn(&'a AstNode<'a>) {
-//!     f(node);
-//!     for c in node.children() {
-//!         iter_nodes(c, f);
+//! for node in root.descendants() {
+//!     if let NodeValue::Text(ref mut text) = node.data.borrow_mut().value {
+//!         *text = text.replace("my", "your");
 //!     }
 //! }
-//!
-//! iter_nodes(root, &|node| {
-//!     match &mut node.data.borrow_mut().value {
-//!         &mut NodeValue::Text(ref mut text) => {
-//!             let orig = std::mem::replace(text, String::new());
-//!             *text = orig.replace("my", "your");
-//!         }
-//!         _ => (),
-//!     }
-//! });
 //!
 //! let mut html = vec![];
 //! format_html(root, &Options::default(), &mut html).unwrap();
@@ -53,8 +39,8 @@
 //!     String::from_utf8(html).unwrap(),
 //!     "<p>This is your input.</p>\n\
 //!      <ol>\n\
-//!      <li>Also your input.</li>\n\
-//!      <li>Certainly your input.</li>\n\
+//!      <li>Also <a href=\"#\">your</a> input.</li>\n\
+//!      <li>Certainly <em>your</em> input.</li>\n\
 //!      </ol>\n");
 //! # }
 //! ```
@@ -98,12 +84,15 @@ pub use cm::format_document as format_commonmark;
 pub use cm::format_document_with_plugins as format_commonmark_with_plugins;
 pub use html::format_document as format_html;
 pub use html::format_document_with_plugins as format_html_with_plugins;
+#[doc(inline)]
 pub use html::Anchorizer;
+#[allow(deprecated)]
+pub use parser::parse_document_with_broken_link_callback;
 pub use parser::{
-    parse_document, parse_document_with_broken_link_callback, BrokenLinkReference,
-    ExtensionOptions, ExtensionOptionsBuilder, ListStyleType, Options, ParseOptions,
-    ParseOptionsBuilder, Plugins, PluginsBuilder, RenderOptions, RenderOptionsBuilder,
-    RenderPlugins, RenderPluginsBuilder,
+    parse_document, BrokenLinkCallback, BrokenLinkReference, ExtensionOptions,
+    ExtensionOptionsBuilder, ListStyleType, Options, ParseOptions, ParseOptionsBuilder, Plugins,
+    PluginsBuilder, RenderOptions, RenderOptionsBuilder, RenderPlugins, RenderPluginsBuilder,
+    ResolvedReference,
 };
 pub use typed_arena::Arena;
 pub use xml::format_document as format_xml;
@@ -112,9 +101,9 @@ pub use xml::format_document_with_plugins as format_xml_with_plugins;
 /// Legacy naming of [`ExtensionOptions`]
 pub type ComrakExtensionOptions = ExtensionOptions;
 /// Legacy naming of [`Options`]
-pub type ComrakOptions = Options;
+pub type ComrakOptions<'c> = Options<'c>;
 /// Legacy naming of [`ParseOptions`]
-pub type ComrakParseOptions = ParseOptions;
+pub type ComrakParseOptions<'c> = ParseOptions<'c>;
 /// Legacy naming of [`Plugins`]
 pub type ComrakPlugins<'a> = Plugins<'a>;
 /// Legacy naming of [`RenderOptions`]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,9 +100,10 @@ pub use html::format_document as format_html;
 pub use html::format_document_with_plugins as format_html_with_plugins;
 pub use html::Anchorizer;
 pub use parser::{
-    parse_document, parse_document_with_broken_link_callback, ExtensionOptions,
-    ExtensionOptionsBuilder, ListStyleType, Options, ParseOptions, ParseOptionsBuilder, Plugins,
-    PluginsBuilder, RenderOptions, RenderOptionsBuilder, RenderPlugins, RenderPluginsBuilder,
+    parse_document, parse_document_with_broken_link_callback, BrokenLinkReference,
+    ExtensionOptions, ExtensionOptionsBuilder, ListStyleType, Options, ParseOptions,
+    ParseOptionsBuilder, Plugins, PluginsBuilder, RenderOptions, RenderOptionsBuilder,
+    RenderPlugins, RenderPluginsBuilder,
 };
 pub use typed_arena::Arena;
 pub use xml::format_document as format_xml;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -566,23 +566,31 @@ pub struct ParseOptions<'c> {
     /// used as the link destination and title if not [`None`].
     ///
     /// ```
-    /// # use std::str;
-    /// # use comrak::{Arena, Reference, parse_document_with_broken_link_callback, format_html, Options, BrokenLinkReference};
+    /// # use std::{str, sync::{Arc, Mutex}};
+    /// # use comrak::{Arena, ResolvedReference, parse_document, format_html, Options, BrokenLinkReference, ParseOptionsBuilder};
     /// # use comrak::nodes::{AstNode, NodeValue};
     /// #
     /// # fn main() -> std::io::Result<()> {
     /// let arena = Arena::new();
-    /// let root = parse_document_with_broken_link_callback(
+    /// let mut cb = |link_ref: BrokenLinkReference| match link_ref.normalized {
+    ///     "foo" => Some(ResolvedReference {
+    ///         url: "https://www.rust-lang.org/".to_string(),
+    ///         title: "The Rust Language".to_string(),
+    ///     }),
+    ///     _ => None,
+    /// };
+    /// let options = Options {
+    ///     parse: ParseOptionsBuilder::default()
+    ///         .broken_link_callback(Some(Arc::new(Mutex::new(&mut cb))))
+    ///         .build()
+    ///         .unwrap(),
+    ///     ..Default::default()
+    /// };
+    ///
+    /// let root = parse_document(
     ///     &arena,
     ///     "# Cool input!\nWow look at this cool [link][foo]. A [broken link] renders as text.",
-    ///     &Options::default(),
-    ///     Some(&mut |link_ref: BrokenLinkReference| match link_ref.normalized {
-    ///         "foo" => Some(Reference {
-    ///             url: "https://www.rust-lang.org/".to_string(),
-    ///             title: "The Rust Language".to_string(),
-    ///         }),
-    ///         _ => None,
-    ///     }),
+    ///     &options,
     /// );
     ///
     /// let mut output = Vec::new();

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -938,7 +938,7 @@ struct FootnoteDefinition<'a> {
     total_references: u32,
 }
 
-impl<'a, 'o, 'c> Parser<'a, 'o, 'c> {
+impl<'a, 'o, 'c: 'o> Parser<'a, 'o, 'c> {
     fn new(arena: &'a Arena<AstNode<'a>>, root: &'a AstNode<'a>, options: &'o Options<'c>) -> Self {
         Parser {
             arena,

--- a/src/tests/api.rs
+++ b/src/tests/api.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use parser::BrokenLinkReference;
 
 use crate::{
@@ -29,12 +31,21 @@ fn exercise_full_api() {
 
     let _: &AstNode = parse_document(&arena, "document", &default_options);
 
+    // Ensure the closure can modify its context.
+    let mut blr_ctx_0 = 0;
+    #[allow(deprecated)]
     let _: &AstNode = parse_document_with_broken_link_callback(
         &arena,
         "document",
-        &default_options,
+        &Options::default(),
         Some(&mut |blr: BrokenLinkReference| {
-            Some((blr.normalized.to_owned(), blr.original.to_owned()))
+            blr_ctx_0 += 1;
+            let _: &str = blr.normalized;
+            let _: &str = blr.original;
+            Some(ResolvedReference {
+                url: String::new(),
+                title: String::new(),
+            })
         }),
     );
 
@@ -64,6 +75,18 @@ fn exercise_full_api() {
     parse.default_info_string(Some("abc".to_string()));
     parse.relaxed_tasklist_matching(false);
     parse.relaxed_autolinks(false);
+    let mut blr_ctx_1 = 0;
+    parse.broken_link_callback(Some(Arc::new(Mutex::new(
+        &mut |blr: BrokenLinkReference| {
+            blr_ctx_1 += 1;
+            let _: &str = blr.normalized;
+            let _: &str = blr.original;
+            Some(ResolvedReference {
+                url: String::new(),
+                title: String::new(),
+            })
+        },
+    ))));
 
     let mut render = RenderOptionsBuilder::default();
     render.hardbreaks(false);

--- a/src/tests/api.rs
+++ b/src/tests/api.rs
@@ -1,3 +1,5 @@
+use parser::BrokenLinkReference;
+
 use crate::{
     adapters::{HeadingAdapter, HeadingMeta, SyntaxHighlighterAdapter},
     nodes::Sourcepos,
@@ -31,7 +33,9 @@ fn exercise_full_api() {
         &arena,
         "document",
         &default_options,
-        Some(&mut |_: &str| Some(("abc".to_string(), "xyz".to_string()))),
+        Some(&mut |blr: BrokenLinkReference| {
+            Some((blr.normalized.to_owned(), blr.original.to_owned()))
+        }),
     );
 
     let mut extension = ExtensionOptionsBuilder::default();

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -30,15 +30,15 @@ pub fn format_document_with_plugins<'a>(
     XmlFormatter::new(options, output, plugins).format(root, false)
 }
 
-struct XmlFormatter<'o> {
+struct XmlFormatter<'o, 'c> {
     output: &'o mut dyn Write,
-    options: &'o Options,
+    options: &'o Options<'c>,
     _plugins: &'o Plugins<'o>,
     indent: u32,
 }
 
-impl<'o> XmlFormatter<'o> {
-    fn new(options: &'o Options, output: &'o mut dyn Write, plugins: &'o Plugins) -> Self {
+impl<'o, 'c> XmlFormatter<'o, 'c> {
+    fn new(options: &'o Options<'c>, output: &'o mut dyn Write, plugins: &'o Plugins) -> Self {
         XmlFormatter {
             options,
             output,


### PR DESCRIPTION
Fixes #143.

This PR moves the callback into the `ParserOptions` struct (which now takes a lifetime), and deprecates `parse_document_with_broken_link_callback`. It also cleans up the docs and some types in general.