### PR TITLE
Track line offsets for better accuracy of inline sourcepos

### DIFF
--- a/src/cm.rs
+++ b/src/cm.rs
@@ -544,13 +544,13 @@ impl<'a, 'o, 'c> CommonMarkFormatter<'a, 'o, 'c> {
             let info = ncb.info.as_bytes();
             let literal = ncb.literal.as_bytes();
 
-            if info.is_empty()
-                && (literal.len() > 2
-                    && !isspace(literal[0])
-                    && !(isspace(literal[literal.len() - 1])
-                        && isspace(literal[literal.len() - 2])))
-                && !first_in_list_item
-                && !self.options.render.prefer_fenced
+            #[allow(clippy::len_zero)]
+            if !(info.len() > 0
+                || literal.len() <= 2
+                || isspace(literal[0])
+                || first_in_list_item
+                || self.options.render.prefer_fenced
+                || isspace(literal[literal.len() - 1]) && isspace(literal[literal.len() - 2]))
             {
                 write!(self, "    ").unwrap();
                 write!(self.prefix, "    ").unwrap();

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -534,6 +534,7 @@ pub struct Ast {
     pub(crate) open: bool,
     pub(crate) last_line_blank: bool,
     pub(crate) table_visited: bool,
+    pub(crate) line_offsets: Vec<usize>,
 }
 
 /// Represents the position in the source Markdown this node was rendered from.
@@ -609,6 +610,7 @@ impl Ast {
             open: true,
             last_line_blank: false,
             table_visited: false,
+            line_offsets: Vec::with_capacity(0),
         }
     }
 }

--- a/src/parser/autolink.rs
+++ b/src/parser/autolink.rs
@@ -41,14 +41,11 @@ pub(crate) fn process_autolinks<'a>(
                 }
             }
 
-            match contents[i] {
-                b'@' => {
-                    post_org = email_match(arena, contents, i, relaxed_autolinks);
-                    if post_org.is_some() {
-                        break;
-                    }
+            if contents[i] == b'@' {
+                post_org = email_match(arena, contents, i, relaxed_autolinks);
+                if post_org.is_some() {
+                    break;
                 }
-                _ => (),
             }
             i += 1;
         }
@@ -161,7 +158,7 @@ fn check_domain(data: &[u8], allow_short: bool) -> Option<usize> {
 }
 
 fn is_valid_hostchar(ch: char) -> bool {
-    !ch.is_whitespace() && !(ch.is_punctuation() || ch.is_symbol())
+    !(ch.is_whitespace() || ch.is_punctuation() || ch.is_symbol())
 }
 
 fn autolink_delim(data: &[u8], mut link_end: usize, relaxed_autolinks: bool) -> usize {

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1123,11 +1123,18 @@ impl<'a, 'r, 'o, 'c, 'd, 'i> Subject<'a, 'r, 'o, 'c, 'd, 'i> {
             self.pos,
         );
         {
+            // if we have `___` or `***` then we need to adjust the sourcepos colums by 1
+            let triple_adjustment = if opener_num_chars > 0 && use_delims == 2 {
+                1
+            } else {
+                0
+            };
+
             emph.data.borrow_mut().sourcepos = (
                 opener.inl.data.borrow().sourcepos.start.line,
-                opener.inl.data.borrow().sourcepos.start.column,
+                opener.inl.data.borrow().sourcepos.start.column + triple_adjustment,
                 closer.inl.data.borrow().sourcepos.end.line,
-                closer.inl.data.borrow().sourcepos.end.column,
+                closer.inl.data.borrow().sourcepos.end.column - triple_adjustment,
             )
                 .into();
         }

--- a/src/tests/core.rs
+++ b/src/tests/core.rs
@@ -599,7 +599,7 @@ fn link_sourcepos_truffle_bergamot() {
 }
 
 #[test]
-fn link_sourcepos_inline_paragraph_multiline() {
+fn paragraph_sourcepos_multiline() {
     assert_ast_match!(
         [],
         "  A\n"
@@ -615,7 +615,7 @@ fn link_sourcepos_inline_paragraph_multiline() {
 }
 
 #[test]
-fn link_sourcepos_inline_listitem_multiline() {
+fn listitem_sourcepos_multiline() {
     assert_ast_match!(
         [],
         "- A\n"
@@ -635,7 +635,7 @@ fn link_sourcepos_inline_listitem_multiline() {
 }
 
 #[test]
-fn link_sourcepos_inline_listitem_multiline_2() {
+fn listitem_sourcepos_multiline_2() {
     assert_ast_match!(
         [],
         "- A\n"
@@ -664,7 +664,7 @@ fn link_sourcepos_inline_listitem_multiline_2() {
 }
 
 #[test]
-fn link_sourcepos_inline_double_emphasis_1() {
+fn emphasis_sourcepos_double_1() {
     assert_ast_match!(
         [],
         "_**this**_\n",
@@ -680,12 +680,45 @@ fn link_sourcepos_inline_double_emphasis_1() {
     );
 }
 
-#[ignore]
 #[test]
-fn link_sourcepos_inline_double_emphasis_2() {
+fn emphasis_sourcepos_double_2() {
+    assert_ast_match!(
+        [],
+        "**_this_**\n",
+        (document (1:1-1:10) [
+            (paragraph (1:1-1:10) [
+                (strong (1:1-1:10) [
+                    (emph (1:3-1:8) [
+                        (text (1:4-1:7) "this")
+                    ])
+                ])
+            ])
+        ])
+    );
+}
+
+#[test]
+fn emphasis_sourcepos_double_3() {
     assert_ast_match!(
         [],
         "___this___\n",
+        (document (1:1-1:10) [
+            (paragraph (1:1-1:10) [
+                (emph (1:1-1:10) [
+                    (strong (1:2-1:9) [
+                        (text (1:4-1:7) "this")
+                    ])
+                ])
+            ])
+        ])
+    );
+}
+
+#[test]
+fn emphasis_sourcepos_double_4() {
+    assert_ast_match!(
+        [],
+        "***this***\n",
         (document (1:1-1:10) [
             (paragraph (1:1-1:10) [
                 (emph (1:1-1:10) [

--- a/src/tests/core.rs
+++ b/src/tests/core.rs
@@ -529,8 +529,6 @@ fn link_sourcepos_newline() {
     );
 }
 
-// Ignored per https://github.com/kivikakk/comrak/pull/439#issuecomment-2225129960.
-#[ignore]
 #[test]
 fn link_sourcepos_truffle() {
     assert_ast_match!(
@@ -577,8 +575,6 @@ fn link_sourcepos_truffle_twist() {
     );
 }
 
-// Ignored per https://github.com/kivikakk/comrak/pull/439#issuecomment-2225129960.
-#[ignore]
 #[test]
 fn link_sourcepos_truffle_bergamot() {
     assert_ast_match!(
@@ -595,6 +591,106 @@ fn link_sourcepos_truffle_bergamot() {
                                 (text (2:7-2:7) "B")
                             ])
                         ])
+                    ])
+                ])
+            ])
+        ])
+    );
+}
+
+#[test]
+fn link_sourcepos_inline_paragraph_multiline() {
+    assert_ast_match!(
+        [],
+        "  A\n"
+        "   B\n",
+        (document (1:1-2:4) [
+            (paragraph (1:3-2:4) [
+                (text (1:3-1:3) "A")
+                (softbreak (1:4-1:4))
+                (text (2:4-2:4) "B")
+            ])
+        ])
+    );
+}
+
+#[test]
+fn link_sourcepos_inline_listitem_multiline() {
+    assert_ast_match!(
+        [],
+        "- A\n"
+        "B\n",
+        (document (1:1-2:1) [
+            (list (1:1-2:1) [
+                (item (1:1-2:1) [
+                    (paragraph (1:3-2:1) [
+                        (text (1:3-1:3) "A")
+                        (softbreak (1:4-1:4))
+                        (text (2:1-2:1) "B")
+                    ])
+                ])
+            ])
+        ])
+    );
+}
+
+#[test]
+fn link_sourcepos_inline_listitem_multiline_2() {
+    assert_ast_match!(
+        [],
+        "- A\n"
+        "   B\n"
+        "-  C\n"
+        " D",
+        (document (1:1-4:2) [
+            (list (1:1-4:2) [
+                (item (1:1-2:4) [
+                    (paragraph (1:3-2:4) [
+                        (text (1:3-1:3) "A")
+                        (softbreak (1:4-1:4))
+                        (text (2:4-2:4) "B")
+                    ])
+                ])
+                (item (3:1-4:2) [
+                    (paragraph (3:4-4:2) [
+                        (text (3:4-3:4) "C")
+                        (softbreak (3:5-3:5))
+                        (text (4:2-4:2) "D")
+                    ])
+                ])
+            ])
+        ])
+    );
+}
+
+#[test]
+fn link_sourcepos_inline_double_emphasis_1() {
+    assert_ast_match!(
+        [],
+        "_**this**_\n",
+        (document (1:1-1:10) [
+            (paragraph (1:1-1:10) [
+                (emph (1:1-1:10) [
+                    (strong (1:2-1:9) [
+                        (text (1:4-1:7) "this")
+                    ])
+                ])
+            ])
+        ])
+    );
+}
+
+#[ignore]
+#[test]
+fn link_sourcepos_inline_double_emphasis_2() {
+    assert_ast_match!(
+        [],
+        "___this___\n",
+        (document (1:1-1:10) [
+            (paragraph (1:1-1:10) [
+                (emph (1:1-1:10) [
+                    (strong (1:2-1:9) [
+                        (text (1:4-1:7) "this")
                     ])
                 ])
             ])

--- a/src/tests/table.rs
+++ b/src/tests/table.rs
@@ -192,14 +192,10 @@ fn sourcepos_with_preceding_para_offset() {
         " | c | d |\n"
         ,
         (document (1:1-5:10) [
-
-            // XXX This should be 1:2-2:5; see
-            // crate::parser::table::try_inserting_table_header_paragraph.
-            (paragraph (1:2-2:4) [
-
+            (paragraph (1:2-2:5) [
                 (text (1:2-1:4) "123")
                 (softbreak (1:5-1:5))
-                (text (2:2-2:4) "456")
+                (text (2:3-2:5) "456")
             ])
             (table (3:2-5:10) [
                 (table_row (3:2-3:10) [

--- a/src/tests/underline.rs
+++ b/src/tests/underline.rs
@@ -8,3 +8,34 @@ fn underline() {
         concat!("<p><u>underlined text</u></p>\n"),
     );
 }
+
+#[test]
+fn underline_sourcepos() {
+    assert_ast_match!(
+        [extension.underline],
+        "__this__\n",
+        (document (1:1-1:8) [
+            (paragraph (1:1-1:8) [
+                (underline (1:1-1:8) [
+                    (text (1:3-1:6) "this")
+                ])
+            ])
+        ])
+    );
+}
+#[test]
+fn underline_sourcepos_emphasis() {
+    assert_ast_match!(
+        [extension.underline],
+        "___this___\n",
+        (document (1:1-1:10) [
+            (paragraph (1:1-1:10) [
+                (emph (1:1-1:10) [
+                    (underline (1:2-1:9) [
+                        (text (1:4-1:7) "this")
+                    ])
+                ])
+            ])
+        ])
+    );
+}


### PR DESCRIPTION
Adds a `line_offsets` vector used to record the number of spaces stripped from each line of content added. This allows us to more accurately calculate `sourcepos` for inline elements.