### PR TITLE
Fix edge cases for relaxed-autolink option

### DIFF
--- a/src/parser/autolink.rs
+++ b/src/parser/autolink.rs
@@ -273,7 +273,10 @@ pub fn url_match<'a>(
 
     while link_end < size - i && !isspace(contents[i + link_end]) {
         // basic test to detect whether we're in a normal markdown link - not exhaustive
-        if relaxed_autolinks && link_end > 0 && contents[i + link_end - 1] == b']' && contents[i + link_end] == b'('
+        if relaxed_autolinks
+            && link_end > 0
+            && contents[i + link_end - 1] == b']'
+            && contents[i + link_end] == b'('
         {
             return None;
         }

--- a/src/parser/autolink.rs
+++ b/src/parser/autolink.rs
@@ -96,6 +96,11 @@ pub fn www_match<'a>(
     };
 
     while i + link_end < contents.len() && !isspace(contents[i + link_end]) {
+        // basic test to detect whether we're in a normal markdown link - not exhaustive
+        if relaxed_autolinks && contents[i + link_end - 1] == b']' && contents[i + link_end] == b'('
+        {
+            return None;
+        }
         link_end += 1;
     }
 
@@ -267,6 +272,11 @@ pub fn url_match<'a>(
     };
 
     while link_end < size - i && !isspace(contents[i + link_end]) {
+        // basic test to detect whether we're in a normal markdown link - not exhaustive
+        if relaxed_autolinks && link_end > 0 && contents[i + link_end - 1] == b']' && contents[i + link_end] == b'('
+        {
+            return None;
+        }
         link_end += 1;
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -545,7 +545,8 @@ pub struct ParseOptions<'c> {
     pub relaxed_tasklist_matching: bool,
 
     /// Relax parsing of autolinks, allow links to be detected inside brackets
-    /// and allow all url schemes
+    /// and allow all url schemes. It is intended to allow a very specific type of autolink
+    /// detection, such as `[this http://and.com that]` or `{http://foo.com}`, on a best can basis.
     ///
     /// ```
     /// # use comrak::{markdown_to_html, Options};

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -136,6 +136,35 @@ fn autolink_relaxed_links_in_brackets() {
             "[<https://foo.com>]",
             "<p>[<a href=\"https://foo.com\">https://foo.com</a>]</p>\n",
         ],
+        [
+            "[http://foo.com/](url)",
+            "<p><a href=\"url\">http://foo.com/</a></p>\n",
+        ],
+        ["[http://foo.com/](url", "<p>[http://foo.com/](url</p>\n"],
+        [
+            "[www.foo.com/](url)",
+            "<p><a href=\"url\">www.foo.com/</a></p>\n",
+        ],
+        [
+            "{https://foo.com}",
+            "<p>{<a href=\"https://foo.com\">https://foo.com</a>}</p>\n",
+        ],
+        [
+            "[this http://and.com that](url)",
+            "<p><a href=\"url\">this http://and.com that</a></p>\n",
+        ],
+        [
+            "[this <http://and.com> that](url)",
+            "<p><a href=\"url\">this http://and.com that</a></p>\n",
+        ],
+        [
+            "{this http://and.com that}(url)",
+            "<p>{this <a href=\"http://and.com\">http://and.com</a> that}(url)</p>\n",
+        ],
+        [
+            "[http://foo.com](url)\n[http://bar.com]\n\n[http://bar.com]: http://bar.com/extra",
+            "<p><a href=\"url\">http://foo.com</a>\n<a href=\"http://bar.com/extra\">http://bar.com</a></p>\n",
+        ],
     ];
 
     for example in examples {
@@ -166,6 +195,15 @@ fn autolink_relaxed_links_curly_braces_balanced() {
         concat!(
             "<p><a href=\"http://example.com/%7Babc%7D\">http://example.com/{abc}</a>}...</p>\n"
         ),
+    );
+}
+
+#[test]
+fn autolink_relaxed_links_curly_parentheses_balanced() {
+    html_opts!(
+        [extension.autolink, parse.relaxed_autolinks],
+        concat!("http://example.com/(abc))...\n"),
+        concat!("<p><a href=\"http://example.com/(abc)\">http://example.com/(abc)</a>)...</p>\n"),
     );
 }
 


### PR DESCRIPTION
Handle several edge cases with the `relaxed-autolinks` option when autolinking inside a markdown link. We now detect if it's a single url in a markdown link (`[url](url)`). We also handle if an autolink does get added to a link by removing the duplicate link when converting to HTML. 

Related issue: #459 

