### PR TITLE
Add option for specifying a minimum width of ordered lists

### DIFF
--- a/src/cm.rs
+++ b/src/cm.rs
@@ -473,16 +473,22 @@ impl<'a, 'o, 'c> CommonMarkFormatter<'a, 'o, 'c> {
             let list_delim = parent.delimiter;
             write!(
                 listmarker,
-                "{}{}{}",
+                "{}{} ",
                 list_number,
                 if list_delim == ListDelimType::Paren {
                     ")"
                 } else {
                     "."
-                },
-                if list_number < 10 { "  " } else { " " }
+                }
             )
             .unwrap();
+            let mut current_len = listmarker.len();
+
+            while current_len < self.options.render.ol_width {
+                write!(listmarker, " ").unwrap();
+                current_len += 1;
+            }
+
             listmarker.len()
         };
 
@@ -498,7 +504,11 @@ impl<'a, 'o, 'c> CommonMarkFormatter<'a, 'o, 'c> {
                 write!(self.prefix, " ").unwrap();
             }
         } else {
-            let new_len = self.prefix.len() - marker_width;
+            let new_len = if self.prefix.len() > marker_width {
+                self.prefix.len() - marker_width
+            } else {
+                0
+            };
             self.prefix.truncate(new_len);
             self.cr();
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -909,6 +909,22 @@ pub struct RenderOptions {
     ///            "<ul class=\"contains-task-list\">\n<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"\" /> Foo</li>\n</ul>\n");
     /// ```
     pub tasklist_classes: bool,
+    /// Render ordered list with a minimum marker width.
+    /// Having a width lower than 3 doesn't do anything.
+    ///
+    /// ```rust
+    /// # use comrak::{markdown_to_commonmark, Options};
+    /// let mut options = Options::default();
+    /// let input = "1. Something";
+    ///
+    /// assert_eq!(markdown_to_commonmark(input, &options),
+    ///            "1. Something\n");
+    ///
+    /// options.render.ol_width = 5;
+    /// assert_eq!(markdown_to_commonmark(input, &options),
+    ///            "1.   Something\n");
+    /// ```
+    pub ol_width: usize,
 }
 
 #[non_exhaustive]

--- a/src/tests/commonmark.rs
+++ b/src/tests/commonmark.rs
@@ -64,10 +64,10 @@ fn wikilinks(markdown: &str, cm: &str) {
 fn commonmark_relist() {
     commonmark(
         concat!("3. one\n", "5. two\n",),
-        // Note that right now we always include enough room for up to two
-        // digits. TODO: Ideally we determine the maximum digit length before
-        // getting this far.
-        concat!("3.  one\n", "4.  two\n",),
+        // Note that right now we always include enough room for up to an user
+        // defined number of digits. TODO: Ideally we determine the maximum
+        // digit length before getting this far.
+        concat!("3. one\n", "4. two\n",),
         None,
     );
 
@@ -75,7 +75,7 @@ fn commonmark_relist() {
     options.extension.tasklist = true;
     commonmark(
         concat!("3. [ ] one\n", "5. [ ] two\n",),
-        concat!("3.  [ ] one\n", "4.  [ ] two\n",),
+        concat!("3. [ ] one\n", "4. [ ] two\n",),
         Some(&options),
     );
 }


### PR DESCRIPTION
See #464 .
I added ol_width in rendering options to specify the reserved width of ordered list markers.
For example, having `ol_width = 5` give you `1.   something` and `123. something` and `1234. something`.
A single whitespace is always added, so `ol_width <= 3` have no effect.
The previous behavior is equivalent to `ol_width = 4`.

Test `tests::commonmark::commonmark_relist` is adjusted with the changes.
During testing, `self.prefix.len() - marker_width` can sometimes cause a overflow.
I'm not too sure what do `self.prefix` mean, but 

```rust
let new_len = if self.prefix.len() > marker_width {
    self.prefix.len() - marker_width
} else {
    0
};
```

seemed to work fine.