### PR TITLE
Use `bon` for an infallible and compile-time-checked builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,18 +70,19 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bon"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dadc8d9c6898eaab366cb3702cfd885d3cb166825ac86aead171acd92a719065"
+checksum = "811d7882589e047896e5974d039dd8823a67973a63d559e6ad1e87ff5c42ed4f"
 dependencies = [
  "bon-macros",
+ "rustversion",
 ]
 
 [[package]]
 name = "bon-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ea161ce9835915784e809698d06c31632c47641ff0bca9fe94d7fdf653a7f86"
+checksum = "d8e745a763e579a5ce70130e66f9dd35abf77cfeb9f418f305aeab8d1ae54c43"
 dependencies = [
  "darling",
  "ident_case",
@@ -613,6 +614,12 @@ dependencies = [
  "linux-raw-sys 0.3.8",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bon"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "811d7882589e047896e5974d039dd8823a67973a63d559e6ad1e87ff5c42ed4f"
+checksum = "ee4f37d875011af3196e4828024742a84dcff6b0d027d272f2944f9a99f2c8af"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e745a763e579a5ce70130e66f9dd35abf77cfeb9f418f305aeab8d1ae54c43"
+checksum = "99b4b686e7ebf76cfa591052482d8c3c8242722518560798631974bf899d5565"
 dependencies = [
  "darling",
  "ident_case",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dadc8d9c6898eaab366cb3702cfd885d3cb166825ac86aead171acd92a719065"
+dependencies = [
+ "bon-macros",
+]
+
+[[package]]
+name = "bon-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ea161ce9835915784e809698d06c31632c47641ff0bca9fe94d7fdf653a7f86"
+dependencies = [
+ "darling",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
 name = "caseless"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,7 +123,7 @@ dependencies = [
  "clap_lex",
  "is-terminal",
  "once_cell",
- "strsim",
+ "strsim 0.10.0",
  "termcolor",
  "terminal_size",
 ]
@@ -133,9 +155,9 @@ name = "comrak"
 version = "0.29.0"
 dependencies = [
  "arbitrary",
+ "bon",
  "caseless",
  "clap",
- "derive_builder",
  "emojis",
  "entities",
  "memchr",
@@ -162,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -172,23 +194,23 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.60",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
@@ -203,37 +225,6 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.60",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
-dependencies = [
- "derive_builder_core",
  "syn 2.0.60",
 ]
 
@@ -707,6 +698,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ shell-words = { version = "1.0", optional = true }
 slug = "0.1.4"
 emojis = { version = "0.6.2", optional = true }
 arbitrary = { version = "1", optional = true, features = ["derive"] }
-bon = "2.1"
+bon = "2.2"
 caseless = "0.2.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ shell-words = { version = "1.0", optional = true }
 slug = "0.1.4"
 emojis = { version = "0.6.2", optional = true }
 arbitrary = { version = "1", optional = true, features = ["derive"] }
-bon = "2.2"
+bon = "2.2.1"
 caseless = "0.2.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ shell-words = { version = "1.0", optional = true }
 slug = "0.1.4"
 emojis = { version = "0.6.2", optional = true }
 arbitrary = { version = "1", optional = true, features = ["derive"] }
-derive_builder = "0.20.0"
+bon = "2.1"
 caseless = "0.2.1"
 
 [dev-dependencies]

--- a/examples/s-expr.rs
+++ b/examples/s-expr.rs
@@ -14,7 +14,7 @@ const INDENT: usize = 4;
 const CLOSE_NEWLINE: bool = false;
 
 use comrak::nodes::{AstNode, NodeValue};
-use comrak::{parse_document, Arena, ExtensionOptionsBuilder, Options};
+use comrak::{parse_document, Arena, ExtensionOptions, Options};
 use std::env;
 use std::error::Error;
 use std::fs::File;
@@ -74,7 +74,7 @@ fn iter_nodes<'a, W: Write>(
 fn dump(source: &str) -> io::Result<()> {
     let arena = Arena::new();
 
-    let extension = ExtensionOptionsBuilder::default()
+    let extension = ExtensionOptions::builder()
         .strikethrough(true)
         .tagfilter(true)
         .table(true)
@@ -88,8 +88,7 @@ fn dump(source: &str) -> io::Result<()> {
         .math_code(true)
         .wikilinks_title_after_pipe(true)
         .wikilinks_title_before_pipe(true)
-        .build()
-        .unwrap();
+        .build();
 
     let opts = Options {
         extension,

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
 //! The `comrak` binary.
 
 use comrak::{
-    adapters::SyntaxHighlighterAdapter, plugins::syntect::SyntectAdapter, Arena,
-    ExtensionOptionsBuilder, ListStyleType, Options, ParseOptionsBuilder, Plugins,
-    RenderOptionsBuilder,
+    adapters::SyntaxHighlighterAdapter, plugins::syntect::SyntectAdapter, Arena, ListStyleType,
+    Options, Plugins,
 };
 use std::boxed::Box;
 use std::env;
@@ -14,6 +13,7 @@ use std::path::PathBuf;
 use std::process;
 
 use clap::{Parser, ValueEnum};
+use comrak::{ExtensionOptions, ParseOptions, RenderOptions};
 
 const EXIT_SUCCESS: i32 = 0;
 const EXIT_PARSE_CONFIG: i32 = 2;
@@ -251,15 +251,14 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let exts = &cli.extensions;
 
-    let mut extension = ExtensionOptionsBuilder::default();
-    extension
+    let extension = ExtensionOptions::builder()
         .strikethrough(exts.contains(&Extension::Strikethrough) || cli.gfm)
         .tagfilter(exts.contains(&Extension::Tagfilter) || cli.gfm)
         .table(exts.contains(&Extension::Table) || cli.gfm)
         .autolink(exts.contains(&Extension::Autolink) || cli.gfm)
         .tasklist(exts.contains(&Extension::Tasklist) || cli.gfm)
         .superscript(exts.contains(&Extension::Superscript))
-        .header_ids(cli.header_ids)
+        .maybe_header_ids(cli.header_ids)
         .footnotes(exts.contains(&Extension::Footnotes))
         .description_lists(exts.contains(&Extension::DescriptionLists))
         .multiline_block_quotes(exts.contains(&Extension::MultilineBlockQuotes))
@@ -270,23 +269,21 @@ fn main() -> Result<(), Box<dyn Error>> {
         .underline(exts.contains(&Extension::Underline))
         .spoiler(exts.contains(&Extension::Spoiler))
         .greentext(exts.contains(&Extension::Greentext))
-        .front_matter_delimiter(cli.front_matter_delimiter);
+        .maybe_front_matter_delimiter(cli.front_matter_delimiter);
 
     #[cfg(feature = "shortcodes")]
-    {
-        extension.shortcodes(cli.gemojis);
-    }
+    let extension = extension.shortcodes(cli.gemojis);
 
-    let extension = extension.build()?;
+    let extension = extension.build();
 
-    let parse = ParseOptionsBuilder::default()
+    let parse = ParseOptions::builder()
         .smart(cli.smart)
-        .default_info_string(cli.default_info_string)
+        .maybe_default_info_string(cli.default_info_string)
         .relaxed_tasklist_matching(cli.relaxed_tasklist_character)
         .relaxed_autolinks(cli.relaxed_autolinks)
-        .build()?;
+        .build();
 
-    let render = RenderOptionsBuilder::default()
+    let render = RenderOptions::builder()
         .hardbreaks(cli.hardbreaks)
         .github_pre_lang(cli.github_pre_lang || cli.gfm)
         .full_info_string(cli.full_info_string)
@@ -301,7 +298,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .ignore_empty_links(cli.ignore_empty_links)
         .gfm_quirks(cli.gfm_quirks || cli.gfm)
         .tasklist_classes(cli.tasklist_classes)
-        .build()?;
+        .build();
 
     let options = Options {
         extension,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -587,7 +587,7 @@ pub struct ParseOptions<'c> {
     ///
     /// ```
     /// # use std::{str, sync::{Arc, Mutex}};
-    /// # use comrak::{Arena, ResolvedReference, parse_document, format_html, Options, BrokenLinkReference, ParseOptionsBuilder};
+    /// # use comrak::{Arena, ResolvedReference, parse_document, format_html, Options, BrokenLinkReference, ParseOptions};
     /// # use comrak::nodes::{AstNode, NodeValue};
     /// #
     /// # fn main() -> std::io::Result<()> {
@@ -600,10 +600,9 @@ pub struct ParseOptions<'c> {
     ///     _ => None,
     /// };
     /// let options = Options {
-    ///     parse: ParseOptionsBuilder::default()
-    ///         .broken_link_callback(Some(Arc::new(Mutex::new(&mut cb))))
-    ///         .build()
-    ///         .unwrap(),
+    ///     parse: ParseOptions::builder()
+    ///         .broken_link_callback(Arc::new(Mutex::new(&mut cb)))
+    ///         .build(),
     ///     ..Default::default()
     /// };
     ///

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -18,7 +18,6 @@ use crate::nodes::{
 };
 use crate::scanners::{self, SetextChar};
 use crate::strings::{self, split_off_front_matter, Case};
-use derive_builder::Builder;
 use std::cell::RefCell;
 use std::cmp::min;
 use std::collections::HashMap;
@@ -153,8 +152,8 @@ pub struct Options<'c> {
 }
 
 #[non_exhaustive]
-#[derive(Default, Debug, Clone, Builder)]
-#[builder(default)]
+#[bon::builder]
+#[derive(Default, Debug, Clone)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// Options to select extensions.
 pub struct ExtensionOptions {
@@ -169,6 +168,7 @@ pub struct ExtensionOptions {
     /// assert_eq!(markdown_to_html("Hello ~world~ there.\n", &options),
     ///            "<p>Hello <del>world</del> there.</p>\n");
     /// ```
+    #[builder(default)]
     pub strikethrough: bool,
 
     /// Enables the
@@ -183,6 +183,7 @@ pub struct ExtensionOptions {
     /// assert_eq!(markdown_to_html("Hello <xmp>.\n\n<xmp>", &options),
     ///            "<p>Hello &lt;xmp>.</p>\n&lt;xmp>\n");
     /// ```
+    #[builder(default)]
     pub tagfilter: bool,
 
     /// Enables the [table extension](https://github.github.com/gfm/#tables-extension-)
@@ -196,6 +197,7 @@ pub struct ExtensionOptions {
     ///            "<table>\n<thead>\n<tr>\n<th>a</th>\n<th>b</th>\n</tr>\n</thead>\n\
     ///             <tbody>\n<tr>\n<td>c</td>\n<td>d</td>\n</tr>\n</tbody>\n</table>\n");
     /// ```
+    #[builder(default)]
     pub table: bool,
 
     /// Enables the [autolink extension](https://github.github.com/gfm/#autolinks-extension-)
@@ -208,6 +210,7 @@ pub struct ExtensionOptions {
     /// assert_eq!(markdown_to_html("Hello www.github.com.\n", &options),
     ///            "<p>Hello <a href=\"http://www.github.com\">www.github.com</a>.</p>\n");
     /// ```
+    #[builder(default)]
     pub autolink: bool,
 
     /// Enables the
@@ -226,6 +229,7 @@ pub struct ExtensionOptions {
     ///            "<ul>\n<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Done</li>\n\
     ///            <li><input type=\"checkbox\" disabled=\"\" /> Not done</li>\n</ul>\n");
     /// ```
+    #[builder(default)]
     pub tasklist: bool,
 
     /// Enables the superscript Comrak extension.
@@ -237,6 +241,7 @@ pub struct ExtensionOptions {
     /// assert_eq!(markdown_to_html("e = mc^2^.\n", &options),
     ///            "<p>e = mc<sup>2</sup>.</p>\n");
     /// ```
+    #[builder(default)]
     pub superscript: bool,
 
     /// Enables the header IDs Comrak extension.
@@ -262,6 +267,7 @@ pub struct ExtensionOptions {
     /// assert_eq!(markdown_to_html("Hi[^x].\n\n[^x]: A greeting.\n", &options),
     ///            "<p>Hi<sup class=\"footnote-ref\"><a href=\"#fn-x\" id=\"fnref-x\" data-footnote-ref>1</a></sup>.</p>\n<section class=\"footnotes\" data-footnotes>\n<ol>\n<li id=\"fn-x\">\n<p>A greeting. <a href=\"#fnref-x\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"1\" aria-label=\"Back to reference 1\">↩</a></p>\n</li>\n</ol>\n</section>\n");
     /// ```
+    #[builder(default)]
     pub footnotes: bool,
 
     /// Enables the description lists extension.
@@ -290,6 +296,7 @@ pub struct ExtensionOptions {
     /// assert_eq!(markdown_to_html("Term\n\n: Definition", &options),
     ///            "<dl><dt>Term</dt>\n<dd>\n<p>Definition</p>\n</dd>\n</dl>\n");
     /// ```
+    #[builder(default)]
     pub description_lists: bool,
 
     /// Enables the front matter extension.
@@ -355,6 +362,7 @@ pub struct ExtensionOptions {
     /// assert_eq!(markdown_to_html(">>>\nparagraph\n>>>", &options),
     ///            "<blockquote>\n<p>paragraph</p>\n</blockquote>\n");
     /// ```
+    #[builder(default)]
     pub multiline_block_quotes: bool,
 
     /// Enables math using dollar syntax.
@@ -376,6 +384,7 @@ pub struct ExtensionOptions {
     /// assert_eq!(markdown_to_html("$$\nx^2\n$$\n", &options),
     ///            "<p><span data-math-style=\"display\">\nx^2\n</span></p>\n");
     /// ```
+    #[builder(default)]
     pub math_dollars: bool,
 
     /// Enables math using code syntax.
@@ -397,6 +406,7 @@ pub struct ExtensionOptions {
     /// assert_eq!(markdown_to_html("```math\nx^2\n```\n", &options),
     ///            "<pre><code class=\"language-math\" data-math-style=\"display\">x^2\n</code></pre>\n");
     /// ```
+    #[builder(default)]
     pub math_code: bool,
 
     #[cfg(feature = "shortcodes")]
@@ -413,6 +423,7 @@ pub struct ExtensionOptions {
     /// assert_eq!(markdown_to_html("Happy Friday! :smile:", &options),
     ///            "<p>Happy Friday! 😄</p>\n");
     /// ```
+    #[builder(default)]
     pub shortcodes: bool,
 
     /// Enables wikilinks using title after pipe syntax
@@ -428,6 +439,7 @@ pub struct ExtensionOptions {
     /// assert_eq!(markdown_to_html("[[url|link label]]", &options),
     ///            "<p><a href=\"url\" data-wikilink=\"true\">link label</a></p>\n");
     /// ```
+    #[builder(default)]
     pub wikilinks_title_after_pipe: bool,
 
     /// Enables wikilinks using title before pipe syntax
@@ -443,6 +455,7 @@ pub struct ExtensionOptions {
     /// assert_eq!(markdown_to_html("[[link label|url]]", &options),
     ///            "<p><a href=\"url\" data-wikilink=\"true\">link label</a></p>\n");
     /// ```
+    #[builder(default)]
     pub wikilinks_title_before_pipe: bool,
 
     /// Enables underlines using double underscores
@@ -459,6 +472,7 @@ pub struct ExtensionOptions {
     /// assert_eq!(markdown_to_html("__underlined text__", &options),
     ///            "<p><u>underlined text</u></p>\n");
     /// ```
+    #[builder(default)]
     pub underline: bool,
 
     /// Enables spoilers using double vertical bars
@@ -475,6 +489,7 @@ pub struct ExtensionOptions {
     /// assert_eq!(markdown_to_html("Darth Vader is ||Luke's father||", &options),
     ///            "<p>Darth Vader is <span class=\"spoiler\">Luke's father</span></p>\n");
     /// ```
+    #[builder(default)]
     pub spoiler: bool,
 
     /// Requires at least one space after a `>` character to generate a blockquote,
@@ -504,12 +519,13 @@ pub struct ExtensionOptions {
     ///             "<p>three</p>\n",
     ///             "</blockquote>\n"));
     /// ```
+    #[builder(default)]
     pub greentext: bool,
 }
 
 #[non_exhaustive]
-#[derive(Default, Clone, Builder)]
-#[builder(default)]
+#[bon::builder]
+#[derive(Default, Clone)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// Options for parser functions.
 pub struct ParseOptions<'c> {
@@ -525,6 +541,7 @@ pub struct ParseOptions<'c> {
     /// assert_eq!(markdown_to_html("'Hello,' \"world\" ...", &options),
     ///            "<p>‘Hello,’ “world” …</p>\n");
     /// ```
+    #[builder(default)]
     pub smart: bool,
 
     /// The default info string for fenced code blocks.
@@ -542,6 +559,7 @@ pub struct ParseOptions<'c> {
     pub default_info_string: Option<String>,
 
     /// Whether or not a simple `x` or `X` is used for tasklist or any other symbol is allowed.
+    #[builder(default)]
     pub relaxed_tasklist_matching: bool,
 
     /// Relax parsing of autolinks, allow links to be detected inside brackets
@@ -559,6 +577,7 @@ pub struct ParseOptions<'c> {
     /// assert_eq!(markdown_to_html("[https://foo.com]", &options),
     ///            "<p>[<a href=\"https://foo.com\">https://foo.com</a>]</p>\n");
     /// ```
+    #[builder(default)]
     pub relaxed_autolinks: bool,
 
     /// In case the parser encounters any potential links that have a broken
@@ -623,8 +642,8 @@ impl<'c> fmt::Debug for ParseOptions<'c> {
 }
 
 #[non_exhaustive]
-#[derive(Default, Debug, Clone, Copy, Builder)]
-#[builder(default)]
+#[bon::builder]
+#[derive(Default, Debug, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// Options for formatter functions.
 pub struct RenderOptions {
@@ -641,6 +660,7 @@ pub struct RenderOptions {
     /// assert_eq!(markdown_to_html("Hello.\nWorld.\n", &options),
     ///            "<p>Hello.<br />\nWorld.</p>\n");
     /// ```
+    #[builder(default)]
     pub hardbreaks: bool,
 
     /// GitHub-style `<pre lang="xyz">` is used for fenced code blocks with info tags.
@@ -655,6 +675,7 @@ pub struct RenderOptions {
     /// assert_eq!(markdown_to_html("``` rust\nfn hello();\n```\n", &options),
     ///            "<pre lang=\"rust\"><code>fn hello();\n</code></pre>\n");
     /// ```
+    #[builder(default)]
     pub github_pre_lang: bool,
 
     /// Enable full info strings for code blocks
@@ -670,6 +691,7 @@ pub struct RenderOptions {
     /// let re = regex::Regex::new(r#"data-meta="extra info""#).unwrap();
     /// assert!(re.is_match(&html));
     /// ```
+    #[builder(default)]
     pub full_info_string: bool,
 
     /// The wrap column when outputting CommonMark.
@@ -692,6 +714,7 @@ pub struct RenderOptions {
     ///            "hello hello hello\nhello hello hello\n");
     /// # }
     /// ```
+    #[builder(default)]
     pub width: usize,
 
     /// Allow rendering of raw HTML and potentially dangerous links.
@@ -717,6 +740,7 @@ pub struct RenderOptions {
     ///             <p><a href=\"javascript:alert(document.cookie)\">Dangerous</a>.</p>\n\
     ///             <p><a href=\"http://commonmark.org\">Safe</a>.</p>\n");
     /// ```
+    #[builder(default)]
     pub unsafe_: bool,
 
     /// Escape raw HTML instead of clobbering it.
@@ -732,6 +756,7 @@ pub struct RenderOptions {
     /// assert_eq!(markdown_to_html(input, &options),
     ///            "<p>&lt;i&gt;italic text&lt;/i&gt;</p>\n");
     /// ```
+    #[builder(default)]
     pub escape: bool,
 
     /// Set the type of [bullet list marker](https://spec.commonmark.org/0.30/#bullet-list-marker) to use. Options are:
@@ -755,6 +780,7 @@ pub struct RenderOptions {
     /// assert_eq!(markdown_to_commonmark(input, &options),
     ///            "* one\n* two\n* three\n");
     /// ```
+    #[builder(default)]
     pub list_style: ListStyleType,
 
     /// Include source position attributes in HTML and XML output.
@@ -775,6 +801,7 @@ pub struct RenderOptions {
     /// let xml = markdown_to_commonmark_xml(input, &options);
     /// assert!(xml.contains("<text sourcepos=\"1:4-1:15\" xml:space=\"preserve\">"));
     /// ```
+    #[builder(default)]
     pub sourcepos: bool,
 
     /// Include inline sourcepos in HTML output, which is known to have issues.
@@ -790,6 +817,7 @@ pub struct RenderOptions {
     /// assert_eq!(markdown_to_html(input, &options),
     ///            "<p data-sourcepos=\"1:1-1:14\">Hello <em data-sourcepos=\"1:7-1:13\">world</em>!</p>\n");
     /// ```
+    #[builder(default)]
     pub experimental_inline_sourcepos: bool,
 
     /// Wrap escaped characters in a `<span>` to allow any
@@ -807,6 +835,7 @@ pub struct RenderOptions {
     /// assert_eq!(markdown_to_html(input, &options),
     ///            "<p>Notify user <span data-escaped-char>@</span>example</p>\n");
     /// ```
+    #[builder(default)]
     pub escaped_char_spans: bool,
 
     /// Ignore setext headings in input.
@@ -823,6 +852,7 @@ pub struct RenderOptions {
     /// assert_eq!(markdown_to_html(input, &options),
     ///            "<p>setext heading</p>\n<hr />\n");
     /// ```
+    #[builder(default)]
     pub ignore_setext: bool,
 
     /// Ignore empty links in input.
@@ -838,6 +868,7 @@ pub struct RenderOptions {
     /// options.render.ignore_empty_links = true;
     /// assert_eq!(markdown_to_html(input, &options), "<p>[]()</p>\n");
     /// ```
+    #[builder(default)]
     pub ignore_empty_links: bool,
 
     /// Enables GFM quirks in HTML output which break CommonMark compatibility.
@@ -854,6 +885,7 @@ pub struct RenderOptions {
     /// assert_eq!(markdown_to_html(input, &options),
     ///            "<p><strong>abcd</strong> <em><em>foo</em></em></p>\n");
     /// ```
+    #[builder(default)]
     pub gfm_quirks: bool,
 
     /// Prefer fenced code blocks when outputting CommonMark.
@@ -875,6 +907,7 @@ pub struct RenderOptions {
     /// format_commonmark(&root, &options, &mut buf);
     /// assert_eq!(str::from_utf8(&buf).unwrap(), "```\nhello\n```\n");
     /// ```
+    #[builder(default)]
     pub prefer_fenced: bool,
 
     /// Render the image as a figure element with the title as its caption.
@@ -891,6 +924,7 @@ pub struct RenderOptions {
     /// assert_eq!(markdown_to_html(input, &options),
     ///            "<p><figure><img src=\"https://example.com/image.png\" alt=\"image\" title=\"this is an image\" /><figcaption>this is an image</figcaption></figure></p>\n");
     /// ```
+    #[builder(default)]
     pub figure_with_caption: bool,
 
     /// Add classes to the output of the tasklist extension. This allows tasklists to be styled.
@@ -908,7 +942,9 @@ pub struct RenderOptions {
     /// assert_eq!(markdown_to_html(input, &options),
     ///            "<ul class=\"contains-task-list\">\n<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"\" /> Foo</li>\n</ul>\n");
     /// ```
+    #[builder(default)]
     pub tasklist_classes: bool,
+
     /// Render ordered list with a minimum marker width.
     /// Having a width lower than 3 doesn't do anything.
     ///
@@ -924,21 +960,23 @@ pub struct RenderOptions {
     /// assert_eq!(markdown_to_commonmark(input, &options),
     ///            "1.   Something\n");
     /// ```
+    #[builder(default)]
     pub ol_width: usize,
 }
 
 #[non_exhaustive]
-#[derive(Default, Debug, Clone, Builder)]
-#[builder(default)]
+#[bon::builder]
+#[derive(Default, Debug, Clone)]
 /// Umbrella plugins struct.
 pub struct Plugins<'p> {
     /// Configure render-time plugins.
+    #[builder(default)]
     pub render: RenderPlugins<'p>,
 }
 
 #[non_exhaustive]
-#[derive(Default, Clone, Builder)]
-#[builder(default)]
+#[bon::builder]
+#[derive(Default, Clone)]
 /// Plugins for alternative rendering.
 pub struct RenderPlugins<'p> {
     /// Provide a syntax highlighter adapter implementation for syntax

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -18,6 +18,7 @@ use crate::nodes::{
 };
 use crate::scanners::{self, SetextChar};
 use crate::strings::{self, split_off_front_matter, Case};
+use bon::Builder;
 use std::cell::RefCell;
 use std::cmp::min;
 use std::collections::HashMap;
@@ -152,8 +153,7 @@ pub struct Options<'c> {
 }
 
 #[non_exhaustive]
-#[bon::builder]
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Builder)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// Options to select extensions.
 pub struct ExtensionOptions {
@@ -524,8 +524,7 @@ pub struct ExtensionOptions {
 }
 
 #[non_exhaustive]
-#[bon::builder]
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Builder)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// Options for parser functions.
 pub struct ParseOptions<'c> {
@@ -642,8 +641,7 @@ impl<'c> fmt::Debug for ParseOptions<'c> {
 }
 
 #[non_exhaustive]
-#[bon::builder]
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy, Builder)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// Options for formatter functions.
 pub struct RenderOptions {
@@ -965,8 +963,7 @@ pub struct RenderOptions {
 }
 
 #[non_exhaustive]
-#[bon::builder]
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Builder)]
 /// Umbrella plugins struct.
 pub struct Plugins<'p> {
     /// Configure render-time plugins.
@@ -975,8 +972,7 @@ pub struct Plugins<'p> {
 }
 
 #[non_exhaustive]
-#[bon::builder]
-#[derive(Default, Clone)]
+#[derive(Default, Clone, Builder)]
 /// Plugins for alternative rendering.
 pub struct RenderPlugins<'p> {
     /// Provide a syntax highlighter adapter implementation for syntax

--- a/src/tests/api.rs
+++ b/src/tests/api.rs
@@ -49,38 +49,40 @@ fn exercise_full_api() {
         }),
     );
 
-    let mut extension = ExtensionOptionsBuilder::default();
-    extension.strikethrough(false);
-    extension.tagfilter(false);
-    extension.table(false);
-    extension.autolink(false);
-    extension.tasklist(false);
-    extension.superscript(false);
-    extension.header_ids(Some("abc".to_string()));
-    extension.footnotes(false);
-    extension.description_lists(false);
-    extension.math_dollars(false);
-    extension.math_code(false);
-    extension.front_matter_delimiter(None);
-    extension.multiline_block_quotes(false);
-    extension.math_dollars(false);
-    extension.math_code(false);
-    #[cfg(feature = "shortcodes")]
-    extension.shortcodes(true);
-    extension.wikilinks_title_after_pipe(true);
-    extension.wikilinks_title_before_pipe(true);
-    extension.underline(true);
-    extension.spoiler(true);
-    extension.greentext(true);
+    let extension = ExtensionOptions::builder()
+        .strikethrough(false)
+        .tagfilter(false)
+        .table(false)
+        .autolink(false)
+        .tasklist(false)
+        .superscript(false)
+        .header_ids("abc".to_string())
+        .footnotes(false)
+        .description_lists(false)
+        .math_dollars(false)
+        .math_code(false)
+        .maybe_front_matter_delimiter(None)
+        .multiline_block_quotes(false);
 
-    let mut parse = ParseOptionsBuilder::default();
-    parse.smart(false);
-    parse.default_info_string(Some("abc".to_string()));
-    parse.relaxed_tasklist_matching(false);
-    parse.relaxed_autolinks(false);
+    #[cfg(feature = "shortcodes")]
+    let extension = extension.shortcodes(true);
+
+    let _extension = extension
+        .wikilinks_title_after_pipe(true)
+        .wikilinks_title_before_pipe(true)
+        .underline(true)
+        .spoiler(true)
+        .greentext(true);
+
+    let parse = ParseOptions::builder()
+        .smart(false)
+        .default_info_string("abc".to_string())
+        .relaxed_tasklist_matching(false)
+        .relaxed_autolinks(false);
+
     let mut blr_ctx_1 = 0;
-    parse.broken_link_callback(Some(Arc::new(Mutex::new(
-        &mut |blr: BrokenLinkReference| {
+    let _parse =
+        parse.broken_link_callback(Arc::new(Mutex::new(&mut |blr: BrokenLinkReference| {
             blr_ctx_1 += 1;
             let _: &str = blr.normalized;
             let _: &str = blr.original;
@@ -88,25 +90,24 @@ fn exercise_full_api() {
                 url: String::new(),
                 title: String::new(),
             })
-        },
-    ))));
+        })));
 
-    let mut render = RenderOptionsBuilder::default();
-    render.hardbreaks(false);
-    render.github_pre_lang(false);
-    render.full_info_string(false);
-    render.width(123456);
-    render.unsafe_(false);
-    render.escape(false);
-    render.list_style(ListStyleType::Dash);
-    render.sourcepos(false);
-    render.experimental_inline_sourcepos(false);
-    render.escaped_char_spans(false);
-    render.ignore_setext(true);
-    render.ignore_empty_links(true);
-    render.gfm_quirks(true);
-    render.prefer_fenced(true);
-    render.figure_with_caption(true);
+    let _render = RenderOptions::builder()
+        .hardbreaks(false)
+        .github_pre_lang(false)
+        .full_info_string(false)
+        .width(123456)
+        .unsafe_(false)
+        .escape(false)
+        .list_style(ListStyleType::Dash)
+        .sourcepos(false)
+        .experimental_inline_sourcepos(false)
+        .escaped_char_spans(false)
+        .ignore_setext(true)
+        .ignore_empty_links(true)
+        .gfm_quirks(true)
+        .prefer_fenced(true)
+        .figure_with_caption(true);
 
     pub struct MockAdapter {}
     impl SyntaxHighlighterAdapter for MockAdapter {
@@ -153,12 +154,11 @@ fn exercise_full_api() {
 
     let mock_adapter = MockAdapter {};
 
-    let mut render_plugins = RenderPluginsBuilder::default();
-    render_plugins.codefence_syntax_highlighter(Some(&mock_adapter));
-    render_plugins.heading_adapter(Some(&mock_adapter));
+    let render_plugins = RenderPlugins::builder()
+        .codefence_syntax_highlighter(&mock_adapter)
+        .heading_adapter(&mock_adapter);
 
-    let mut plugins = PluginsBuilder::default();
-    plugins.render(render_plugins.build().unwrap());
+    let _plugins = Plugins::builder().render(render_plugins.build());
 
     let _: String = markdown_to_html("# Yes", &default_options);
 

--- a/src/tests/options.rs
+++ b/src/tests/options.rs
@@ -77,10 +77,9 @@ fn broken_link_callback() {
         _ => None,
     };
     let options = Options {
-        parse: ParseOptionsBuilder::default()
-            .broken_link_callback(Some(Arc::new(Mutex::new(&mut cb))))
-            .build()
-            .unwrap(),
+        parse: ParseOptions::builder()
+            .broken_link_callback(Arc::new(Mutex::new(&mut cb)))
+            .build(),
         ..Default::default()
     };
 


### PR DESCRIPTION
Hi! This PR replaces the usage of `derive_builder` with [`bon`](https://github.com/elastio/bon). What does it give us?

- The `build()` method no longer returns a `Result<T>`, it returns `T` instead. So there are no potential panics and no need for error handling in runtime. For example:
    ![image](https://github.com/user-attachments/assets/d69e7770-7639-4d74-b0b9-adf2acf76279)
- The builder generated by `bon` validates that the same field isn't set twice. For example, with `bon` I detected this mistake in tests where `math_dollars` and `math_code` were set twice, because `bon` generated a [compile error](https://elastio.github.io/bon/blog/bon-builder-v2-1-release#better-error-messages) https://github.com/kivikakk/comrak/blob/1a33c63688dcfabc0bb5e61fc043765d20debf83/src/tests/api.rs#L62-L67
- `bon` generates a `T::builder()` method, which removes the need for importing the `TBuilder` type and using `TBuilder::default()` syntax to create the builder.
- If you ever need some more complex logic of building, or you want to avoid create a separate "parameters" struct, you can always generate a [builder from a function](https://elastio.github.io/bon/guide/overview#builder-for-a-function) or [from a method](https://elastio.github.io/bon/guide/overview#builder-for-an-associated-method) with `bon`. Builders generated this way use the same API conventions and it is even possible to switch between struct/function syntax and keep your crate API the same (see e.g. [switching from `#[derive(Builder)]` to a `#[builder]` on the method named "new"](https://elastio.github.io/bon/guide/compatibility#switching-between-derive-builder-and-builder-on-the-new-method))

I understand this is a breaking change for this crate, but I think improvements are worth it.