### PR TITLE
Add `task-list-item` class to task list items

### DIFF
--- a/fuzz/fuzz_targets/all_options.rs
+++ b/fuzz/fuzz_targets/all_options.rs
@@ -57,6 +57,7 @@ fuzz_target!(|s: &str| {
     render.ignore_empty_links = true;
     render.gfm_quirks = true;
     render.prefer_fenced = true;
+    render.tasklist_classes = true;
 
     markdown_to_html(
         s,

--- a/src/html.rs
+++ b/src/html.rs
@@ -478,11 +478,10 @@ impl<'o, 'c: 'o> HtmlFormatter<'o, 'c> {
             NodeValue::List(ref nl) => {
                 if entering {
                     self.cr()?;
-
                     match nl.list_type {
                         ListType::Bullet => {
                             self.output.write_all(b"<ul")?;
-                            if nl.is_task_list {
+                            if nl.is_task_list && self.options.render.tasklist_classes {
                                 self.output.write_all(b" class=\"contains-task-list\"")?;
                             }
                             self.render_sourcepos(node)?;
@@ -490,7 +489,7 @@ impl<'o, 'c: 'o> HtmlFormatter<'o, 'c> {
                         }
                         ListType::Ordered => {
                             self.output.write_all(b"<ol")?;
-                            if nl.is_task_list {
+                            if nl.is_task_list && self.options.render.tasklist_classes {
                                 self.output.write_all(b" class=\"contains-task-list\"")?;
                             }
                             self.render_sourcepos(node)?;
@@ -1052,18 +1051,21 @@ impl<'o, 'c: 'o> HtmlFormatter<'o, 'c> {
             NodeValue::TaskItem(symbol) => {
                 if entering {
                     self.cr()?;
-                    self.output.write_all(b"<li class=\"task-list-item\"")?;
+                    self.output.write_all(b"<li")?;
+                    if self.options.render.tasklist_classes {
+                        self.output.write_all(b" class=\"task-list-item\"")?;
+                    }
                     self.render_sourcepos(node)?;
                     self.output.write_all(b">")?;
-                    write!(
-                        self.output,
-                        "<input type=\"checkbox\" class=\"task-list-item-checkbox\" {}disabled=\"\" /> ",
-                        if symbol.is_some() {
-                            "checked=\"\" "
-                        } else {
-                            ""
-                        }
-                    )?;
+                    self.output.write_all(b"<input type=\"checkbox\"")?;
+                    if self.options.render.tasklist_classes {
+                        self.output
+                            .write_all(b" class=\"task-list-item-checkbox\"")?;
+                    }
+                    if symbol.is_some() {
+                        self.output.write_all(b" checked=\"\"")?;
+                    }
+                    self.output.write_all(b" disabled=\"\" /> ")?;
                 } else {
                     self.output.write_all(b"</li>\n")?;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,10 @@ struct Cli {
     #[arg(long)]
     relaxed_autolinks: bool,
 
+    /// Output classes on tasklist elements so that they can be styled with CSS
+    #[arg(long)]
+    tasklist_classes: bool,
+
     /// Default value for fenced code block's info strings if none is given
     #[arg(long, value_name = "INFO")]
     default_info_string: Option<String>,
@@ -296,6 +300,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .ignore_setext(cli.ignore_setext)
         .ignore_empty_links(cli.ignore_empty_links)
         .gfm_quirks(cli.gfm_quirks || cli.gfm)
+        .tasklist_classes(cli.tasklist_classes)
         .build()?;
 
     let options = Options {

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -297,6 +297,9 @@ pub struct NodeList {
     /// Whether the list is [tight](https://github.github.com/gfm/#tight), i.e. whether the
     /// paragraphs are wrapped in `<p>` tags when formatted as HTML.
     pub tight: bool,
+
+    /// Whether the list contains tasks (checkbox items)
+    pub is_task_list: bool,
 }
 
 /// The metadata of a description list

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -223,8 +223,8 @@ pub struct ExtensionOptions {
     /// options.extension.tasklist = true;
     /// options.render.unsafe_ = true;
     /// assert_eq!(markdown_to_html("* [x] Done\n* [ ] Not done\n", &options),
-    ///            "<ul class=\"contains-task-list\">\n<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\" disabled=\"\" /> Done</li>\n\
-    ///            <li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"\" /> Not done</li>\n</ul>\n");
+    ///            "<ul>\n<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Done</li>\n\
+    ///            <li><input type=\"checkbox\" disabled=\"\" /> Not done</li>\n</ul>\n");
     /// ```
     pub tasklist: bool,
 
@@ -892,6 +892,23 @@ pub struct RenderOptions {
     ///            "<p><figure><img src=\"https://example.com/image.png\" alt=\"image\" title=\"this is an image\" /><figcaption>this is an image</figcaption></figure></p>\n");
     /// ```
     pub figure_with_caption: bool,
+
+    /// Add classes to the output of the tasklist extension. This allows tasklists to be styled.
+    ///
+    /// ```rust
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
+    /// options.extension.tasklist = true;
+    /// let input = "- [ ] Foo";
+    ///
+    /// assert_eq!(markdown_to_html(input, &options),
+    ///            "<ul>\n<li><input type=\"checkbox\" disabled=\"\" /> Foo</li>\n</ul>\n");
+    ///
+    /// options.render.tasklist_classes = true;
+    /// assert_eq!(markdown_to_html(input, &options),
+    ///            "<ul class=\"contains-task-list\">\n<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"\" /> Foo</li>\n</ul>\n");
+    /// ```
+    pub tasklist_classes: bool,
 }
 
 #[non_exhaustive]

--- a/src/tests/fuzz.rs
+++ b/src/tests/fuzz.rs
@@ -10,7 +10,7 @@ fn tasklist() {
     html_opts!(
         [extension.tasklist, parse.relaxed_tasklist_matching],
         "* [*]",
-        "<ul>\n<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> </li>\n</ul>\n",
+        "<ul class=\"contains-task-list\">\n<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\" disabled=\"\" /> </li>\n</ul>\n",
     );
 }
 

--- a/src/tests/fuzz.rs
+++ b/src/tests/fuzz.rs
@@ -10,6 +10,15 @@ fn tasklist() {
     html_opts!(
         [extension.tasklist, parse.relaxed_tasklist_matching],
         "* [*]",
+        "<ul>\n<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> </li>\n</ul>\n",
+    );
+}
+
+#[test]
+fn tasklist_with_classes() {
+    html_opts!(
+        [extension.tasklist, render.tasklist_classes, parse.relaxed_tasklist_matching],
+        "* [*]",
         "<ul class=\"contains-task-list\">\n<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\" disabled=\"\" /> </li>\n</ul>\n",
     );
 }

--- a/src/tests/tasklist.rs
+++ b/src/tests/tasklist.rs
@@ -23,6 +23,58 @@ fn tasklist() {
             "    * [ ] Blue\n"
         ),
         concat!(
+            "<ul>\n",
+            "<li><input type=\"checkbox\" disabled=\"\" /> Red</li>\n",
+            "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Green</li>\n",
+            "<li><input type=\"checkbox\" disabled=\"\" /> Blue</li>\n",
+            "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Papayawhip</li>\n",
+            "</ul>\n",
+            "<!-- end list -->\n",
+            "<ol>\n",
+            "<li><input type=\"checkbox\" disabled=\"\" /> Bird</li>\n",
+            "<li><input type=\"checkbox\" disabled=\"\" /> McHale</li>\n",
+            "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Parish</li>\n",
+            "</ol>\n",
+            "<!-- end list -->\n",
+            "<ul>\n",
+            "<li><input type=\"checkbox\" disabled=\"\" /> Red\n",
+            "<ul>\n",
+            "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Green\n",
+            "<ul>\n",
+            "<li><input type=\"checkbox\" disabled=\"\" /> Blue</li>\n",
+            "</ul>\n",
+            "</li>\n",
+            "</ul>\n",
+            "</li>\n",
+            "</ul>\n"
+        ),
+    );
+}
+
+#[test]
+fn tasklist_with_classes() {
+    html_opts!(
+        [
+            render.unsafe_,
+            extension.tasklist,
+            render.tasklist_classes,
+            parse.relaxed_tasklist_matching
+        ],
+        concat!(
+            "* [ ] Red\n",
+            "* [x] Green\n",
+            "* [ ] Blue\n",
+            "* [!] Papayawhip\n",
+            "<!-- end list -->\n",
+            "1. [ ] Bird\n",
+            "2. [ ] McHale\n",
+            "3. [x] Parish\n",
+            "<!-- end list -->\n",
+            "* [ ] Red\n",
+            "  * [x] Green\n",
+            "    * [ ] Blue\n"
+        ),
+        concat!(
             "<ul class=\"contains-task-list\">\n",
             "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"\" /> Red</li>\n",
             "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\" disabled=\"\" /> Green</li>\n",
@@ -57,8 +109,8 @@ fn tasklist_relaxed_regression() {
         [extension.tasklist, parse.relaxed_tasklist_matching],
         "* [!] Red\n",
         concat!(
-            "<ul class=\"contains-task-list\">\n",
-            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\" disabled=\"\" /> Red</li>\n",
+            "<ul>\n",
+            "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Red</li>\n",
             "</ul>\n"
         ),
     );
@@ -73,6 +125,35 @@ fn tasklist_relaxed_regression() {
         [extension.tasklist, parse.relaxed_tasklist_matching],
         "* [!] Red\n",
         concat!(
+            "<ul>\n",
+            "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Red</li>\n",
+            "</ul>\n"
+        ),
+    );
+}
+
+#[test]
+fn tasklist_with_classes_relaxed_regression() {
+    html_opts!(
+        [extension.tasklist, render.tasklist_classes, parse.relaxed_tasklist_matching],
+        "* [!] Red\n",
+        concat!(
+            "<ul class=\"contains-task-list\">\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\" disabled=\"\" /> Red</li>\n",
+            "</ul>\n"
+        ),
+    );
+
+    html_opts!(
+        [extension.tasklist, render.tasklist_classes],
+        "* [!] Red\n",
+        concat!("<ul>\n", "<li>[!] Red</li>\n", "</ul>\n"),
+    );
+
+    html_opts!(
+        [extension.tasklist, render.tasklist_classes, parse.relaxed_tasklist_matching],
+        "* [!] Red\n",
+        concat!(
             "<ul class=\"contains-task-list\">\n",
             "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\" disabled=\"\" /> Red</li>\n",
             "</ul>\n"
@@ -84,6 +165,25 @@ fn tasklist_relaxed_regression() {
 fn tasklist_32() {
     html_opts!(
         [render.unsafe_, extension.tasklist],
+        concat!(
+            "- [ ] List item 1\n",
+            "- [ ] This list item is **bold**\n",
+            "- [x] There is some `code` here\n"
+        ),
+        concat!(
+            "<ul>\n",
+            "<li><input type=\"checkbox\" disabled=\"\" /> List item 1</li>\n",
+            "<li><input type=\"checkbox\" disabled=\"\" /> This list item is <strong>bold</strong></li>\n",
+            "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> There is some <code>code</code> here</li>\n",
+            "</ul>\n"
+        ),
+    );
+}
+
+#[test]
+fn tasklist_32_with_classes() {
+    html_opts!(
+        [render.unsafe_, extension.tasklist, render.tasklist_classes],
         concat!(
             "- [ ] List item 1\n",
             "- [ ] This list item is **bold**\n",

--- a/src/tests/tasklist.rs
+++ b/src/tests/tasklist.rs
@@ -23,25 +23,25 @@ fn tasklist() {
             "    * [ ] Blue\n"
         ),
         concat!(
-            "<ul>\n",
-            "<li><input type=\"checkbox\" disabled=\"\" /> Red</li>\n",
-            "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Green</li>\n",
-            "<li><input type=\"checkbox\" disabled=\"\" /> Blue</li>\n",
-            "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Papayawhip</li>\n",
+            "<ul class=\"contains-task-list\">\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"\" /> Red</li>\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\" disabled=\"\" /> Green</li>\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"\" /> Blue</li>\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\" disabled=\"\" /> Papayawhip</li>\n",
             "</ul>\n",
             "<!-- end list -->\n",
-            "<ol>\n",
-            "<li><input type=\"checkbox\" disabled=\"\" /> Bird</li>\n",
-            "<li><input type=\"checkbox\" disabled=\"\" /> McHale</li>\n",
-            "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Parish</li>\n",
+            "<ol class=\"contains-task-list\">\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"\" /> Bird</li>\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"\" /> McHale</li>\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\" disabled=\"\" /> Parish</li>\n",
             "</ol>\n",
             "<!-- end list -->\n",
-            "<ul>\n",
-            "<li><input type=\"checkbox\" disabled=\"\" /> Red\n",
-            "<ul>\n",
-            "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Green\n",
-            "<ul>\n",
-            "<li><input type=\"checkbox\" disabled=\"\" /> Blue</li>\n",
+            "<ul class=\"contains-task-list\">\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"\" /> Red\n",
+            "<ul class=\"contains-task-list\">\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\" disabled=\"\" /> Green\n",
+            "<ul class=\"contains-task-list\">\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"\" /> Blue</li>\n",
             "</ul>\n",
             "</li>\n",
             "</ul>\n",
@@ -57,8 +57,8 @@ fn tasklist_relaxed_regression() {
         [extension.tasklist, parse.relaxed_tasklist_matching],
         "* [!] Red\n",
         concat!(
-            "<ul>\n",
-            "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Red</li>\n",
+            "<ul class=\"contains-task-list\">\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\" disabled=\"\" /> Red</li>\n",
             "</ul>\n"
         ),
     );
@@ -73,8 +73,8 @@ fn tasklist_relaxed_regression() {
         [extension.tasklist, parse.relaxed_tasklist_matching],
         "* [!] Red\n",
         concat!(
-            "<ul>\n",
-            "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Red</li>\n",
+            "<ul class=\"contains-task-list\">\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\" disabled=\"\" /> Red</li>\n",
             "</ul>\n"
         ),
     );
@@ -90,10 +90,10 @@ fn tasklist_32() {
             "- [x] There is some `code` here\n"
         ),
         concat!(
-            "<ul>\n",
-            "<li><input type=\"checkbox\" disabled=\"\" /> List item 1</li>\n",
-            "<li><input type=\"checkbox\" disabled=\"\" /> This list item is <strong>bold</strong></li>\n",
-            "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> There is some <code>code</code> here</li>\n",
+            "<ul class=\"contains-task-list\">\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"\" /> List item 1</li>\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" disabled=\"\" /> This list item is <strong>bold</strong></li>\n",
+            "<li class=\"task-list-item\"><input type=\"checkbox\" class=\"task-list-item-checkbox\" checked=\"\" disabled=\"\" /> There is some <code>code</code> here</li>\n",
             "</ul>\n"
         ),
     );

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -161,15 +161,21 @@ impl<'o, 'c> XmlFormatter<'o, 'c> {
                     was_literal = true;
                 }
                 NodeValue::List(ref nl) => {
-                    if nl.list_type == ListType::Bullet {
-                        self.output.write_all(b" type=\"bullet\"")?;
-                    } else {
-                        write!(
-                            self.output,
-                            " type=\"ordered\" start=\"{}\" delim=\"{}\"",
-                            nl.start,
-                            nl.delimiter.xml_name()
-                        )?;
+                    match nl.list_type {
+                        ListType::Bullet => {
+                            self.output.write_all(b" type=\"bullet\"")?;
+                        }
+                        ListType::Ordered => {
+                            write!(
+                                self.output,
+                                " type=\"ordered\" start=\"{}\" delim=\"{}\"",
+                                nl.start,
+                                nl.delimiter.xml_name()
+                            )?;
+                        }
+                    }
+                    if nl.is_task_list {
+                        self.output.write_all(b" tasklist=\"true\"")?;
                     }
                     write!(self.output, " tight=\"{}\"", nl.tight)?;
                 }


### PR DESCRIPTION
I am trying to render tasklists similar to how Github renders them. Unfortunately it is currently very difficult to differentiate between a tasklist and a regular list generated by comrak using CSS, which is leading to my renderer rendering both the checkboxes and the regular list bullets for tasklists.

Github works around this issue by adding a special class to the `<ul>` and the `<li>` elements, which allows `list-style-type: none` to be specified for tasklist list items (causing the regular bullets to be hidden). I have implemented this for the `<li>` element of task lists in this PR. Doing it for the `<ul>` as well is more difficult as it doesn't have a special AST node. And it is also not required to set the `list-style-type` style for the list items.

Illustration of the problem:

<img width="868" alt="Screenshot 2024-09-12 at 13 21 06" src="https://github.com/user-attachments/assets/0c7ab11b-fc8b-4ca9-9a2c-b757e3b18db6">

Testing mixed lists:

- Hello
- World
- [ ] Item
- [x] Item 2

1. Numbered
- [x] Item

1. Numbered
1. [x] Item

1. Numbered
- Bullet

- Bullet
1. Numbered
