### PR TITLE
Add support fo backslash escape in wikilinks

### DIFF
--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1730,7 +1730,7 @@ impl<'a, 'r, 'o, 'c, 'd, 'i> Subject<'a, 'r, 'o, 'c, 'd, 'i> {
         let startpos = self.pos;
         let component = self.wikilink_url_link_label()?;
         let url_clean = strings::clean_url(component.url);
-        let (link_label, link_label_start_column, link_label_end_column) =
+        let (link_label, link_label_start_column, _link_label_end_column) =
             match component.link_label {
                 Some((label, sc, ec)) => (entity::unescape_html(label), sc, ec),
                 None => (
@@ -1744,11 +1744,8 @@ impl<'a, 'r, 'o, 'c, 'd, 'i> Subject<'a, 'r, 'o, 'c, 'd, 'i> {
             url: String::from_utf8(url_clean).unwrap(),
         };
         let inl = self.make_inline(NodeValue::WikiLink(nl), startpos - 1, self.pos - 1);
-        inl.append(self.make_inline(
-            NodeValue::Text(String::from_utf8(link_label).unwrap()),
-            link_label_start_column,
-            link_label_end_column,
-        ));
+
+        self.label_backslash_escapes(inl, link_label, link_label_start_column);
 
         Some(inl)
     }
@@ -1842,6 +1839,68 @@ impl<'a, 'r, 'o, 'c, 'd, 'i> Subject<'a, 'r, 'o, 'c, 'd, 'i> {
         }
 
         true
+    }
+
+    // Given a label, handles backslash escaped characters. Appends the resulting
+    // nodes to the container
+    fn label_backslash_escapes(
+        &mut self,
+        container: &'a AstNode<'a>,
+        label: Vec<u8>,
+        start_column: usize,
+    ) {
+        let mut startpos = 0;
+        let mut offset = 0;
+
+        while offset < label.len() {
+            let c = label[offset];
+
+            if c == b'\\' {
+                if ispunct(label[offset + 1]) {
+                    let preceding_text = self.make_inline(
+                        NodeValue::Text(
+                            String::from_utf8(label[startpos..offset].to_owned()).unwrap(),
+                        ),
+                        start_column + startpos,
+                        start_column + offset - 1,
+                    );
+
+                    container.append(preceding_text);
+
+                    let inline_text = self.make_inline(
+                        NodeValue::Text(String::from_utf8(vec![label[offset + 1]]).unwrap()),
+                        start_column + offset,
+                        start_column + offset + 1,
+                    );
+
+                    if self.options.render.escaped_char_spans {
+                        let span = self.make_inline(
+                            NodeValue::Escaped,
+                            start_column + offset,
+                            start_column + offset + 1,
+                        );
+
+                        span.append(inline_text);
+                        container.append(span);
+                    } else {
+                        container.append(inline_text);
+                    }
+
+                    offset += 2;
+                    startpos = offset;
+                } else {
+                    offset += 1;
+                }
+            } else {
+                offset += 1;
+            }
+        }
+
+        container.append(self.make_inline(
+            NodeValue::Text(String::from_utf8(label[startpos..offset].to_owned()).unwrap()),
+            start_column + startpos,
+            start_column + offset - 1,
+        ));
     }
 
     pub fn spnl(&mut self) {

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1891,11 +1891,13 @@ impl<'a, 'r, 'o, 'c, 'd, 'i> Subject<'a, 'r, 'o, 'c, 'd, 'i> {
             }
         }
 
-        container.append(self.make_inline(
-            NodeValue::Text(String::from_utf8(label[startpos..offset].to_owned()).unwrap()),
-            start_column + startpos,
-            start_column + offset - 1,
-        ));
+        if startpos != offset {
+            container.append(self.make_inline(
+                NodeValue::Text(String::from_utf8(label[startpos..offset].to_owned()).unwrap()),
+                start_column + startpos,
+                start_column + offset - 1,
+            ));
+        }
     }
 
     pub fn spnl(&mut self) {

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1851,46 +1851,41 @@ impl<'a, 'r, 'o, 'c, 'd, 'i> Subject<'a, 'r, 'o, 'c, 'd, 'i> {
     ) {
         let mut startpos = 0;
         let mut offset = 0;
+        let len = label.len();
 
-        while offset < label.len() {
+        while offset < len {
             let c = label[offset];
 
-            if c == b'\\' {
-                if ispunct(label[offset + 1]) {
-                    let preceding_text = self.make_inline(
-                        NodeValue::Text(
-                            String::from_utf8(label[startpos..offset].to_owned()).unwrap(),
-                        ),
-                        start_column + startpos,
-                        start_column + offset - 1,
-                    );
+            if c == b'\\' && (offset + 1) < len && ispunct(label[offset + 1]) {
+                let preceding_text = self.make_inline(
+                    NodeValue::Text(String::from_utf8(label[startpos..offset].to_owned()).unwrap()),
+                    start_column + startpos,
+                    start_column + offset - 1,
+                );
 
-                    container.append(preceding_text);
+                container.append(preceding_text);
 
-                    let inline_text = self.make_inline(
-                        NodeValue::Text(String::from_utf8(vec![label[offset + 1]]).unwrap()),
+                let inline_text = self.make_inline(
+                    NodeValue::Text(String::from_utf8(vec![label[offset + 1]]).unwrap()),
+                    start_column + offset,
+                    start_column + offset + 1,
+                );
+
+                if self.options.render.escaped_char_spans {
+                    let span = self.make_inline(
+                        NodeValue::Escaped,
                         start_column + offset,
                         start_column + offset + 1,
                     );
 
-                    if self.options.render.escaped_char_spans {
-                        let span = self.make_inline(
-                            NodeValue::Escaped,
-                            start_column + offset,
-                            start_column + offset + 1,
-                        );
-
-                        span.append(inline_text);
-                        container.append(span);
-                    } else {
-                        container.append(inline_text);
-                    }
-
-                    offset += 2;
-                    startpos = offset;
+                    span.append(inline_text);
+                    container.append(span);
                 } else {
-                    offset += 1;
+                    container.append(inline_text);
                 }
+
+                offset += 2;
+                startpos = offset;
             } else {
                 offset += 1;
             }

--- a/src/tests/fixtures/wikilinks_title_after_pipe.md
+++ b/src/tests/fixtures/wikilinks_title_after_pipe.md
@@ -45,3 +45,25 @@ HTML entities are recognized both in the name of page and in the link title.
 .
 <p><a href="Gesch%C3%BCtztes%20Leerzeichen" data-wikilink="true">Über &amp;nbsp;</a></p>
 ````````````````````````````````
+
+Escaping characters is supported
+
+```````````````````````````````` example
+[[https://example.org|foo\[\]bar]]
+.
+<p><a href="https://example.org" data-wikilink="true">foo[]bar</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+[[Name \[of\] page]]
+.
+<p><a href="Name%20%5Bof%5D%20page" data-wikilink="true">Name [of] page</a></p>
+````````````````````````````````
+
+Emphasis or other inline markdown is not supported
+
+```````````````````````````````` example
+[[Name _of_ page]]
+.
+<p><a href="Name%20_of_%20page" data-wikilink="true">Name _of_ page</a></p>
+````````````````````````````````

--- a/src/tests/fixtures/wikilinks_title_before_pipe.md
+++ b/src/tests/fixtures/wikilinks_title_before_pipe.md
@@ -53,3 +53,25 @@ HTML entities are recognized both in the name of page and in the link title.
 .
 <p><a href="Gesch%C3%BCtztes%20Leerzeichen" data-wikilink="true">Über &amp;nbsp;</a></p>
 ````````````````````````````````
+
+Escaping characters is supported
+
+```````````````````````````````` example
+[[foo\[\]bar|https://example.org]]
+.
+<p><a href="https://example.org" data-wikilink="true">foo[]bar</a></p>
+````````````````````````````````
+
+```````````````````````````````` example
+[[Name \[of\] page]]
+.
+<p><a href="Name%20%5Bof%5D%20page" data-wikilink="true">Name [of] page</a></p>
+````````````````````````````````
+
+Emphasis or other inline markdown is not supported
+
+```````````````````````````````` example
+[[Name _of_ page]]
+.
+<p><a href="Name%20_of_%20page" data-wikilink="true">Name _of_ page</a></p>
+````````````````````````````````

--- a/src/tests/wikilinks.rs
+++ b/src/tests/wikilinks.rs
@@ -48,6 +48,16 @@ fn wikilinks_sanitizes_the_href_attribute_case_2() {
 }
 
 #[test]
+fn wikilinks_title_escape_chars() {
+    html_opts!(
+        [extension.wikilinks_title_before_pipe, render.escaped_char_spans],
+        concat!("[[Name \\[of\\] page|http://example.com]]",),
+        concat!("<p><a href=\"http://example.com\" data-wikilink=\"true\">Name <span data-escaped-char>[</span>of<span data-escaped-char>]</span> page</a></p>\n"),
+        no_roundtrip,
+    );
+}
+
+#[test]
 fn wikilinks_supercedes_relaxed_autolinks() {
     html_opts!(
         [
@@ -225,6 +235,22 @@ fn sourcepos() {
                     (text (1:8-1:25) "http://example.com")
                 ])
                 (text (1:28-1:32) " that")
+            ])
+        ])
+    );
+
+    assert_ast_match!(
+        [extension.wikilinks_title_before_pipe],
+        "This [[link\\[label|http://example.com]] that\n",
+        (document (1:1-1:44) [
+            (paragraph (1:1-1:44) [
+                (text (1:1-1:5) "This ")
+                (wikilink (1:6-1:39) [
+                    (text (1:8-1:11) "link")
+                    (text (1:12-1:13) "[")
+                    (text (1:14-1:18) "label")
+                ])
+                (text (1:40-1:44) " that")
             ])
         ])
     );


### PR DESCRIPTION
Adds support for using markdown backslash escapes in wikilink titles. So you can now use `[` and `]` in the title. For example `[[Name \[of\] page]]` or `[[Name \[of\] page|https://example.org]]`

Closes https://github.com/kivikakk/comrak/issues/470