### PR TITLE
Cargo.toml: v0.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "arbitrary",
  "caseless",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comrak"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Asherah Connor <ashe@kivikakk.ee>"]
 rust-version = "1.62.1"
 description = "A 100% CommonMark-compatible GitHub Flavored Markdown parser and formatter"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -198,7 +198,7 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "comrak"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "arbitrary",
  "caseless",


### PR DESCRIPTION
Bump version in prep for releasing `0.29.0`