### PR TITLE
Add support for image and link URL rewriting

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -864,7 +864,11 @@ impl<'o, 'c: 'o> HtmlFormatter<'o, 'c> {
                         self.output.write_all(b" href=\"")?;
                         let url = nl.url.as_bytes();
                         if self.options.render.unsafe_ || !dangerous_url(url) {
-                            self.escape_href(url)?;
+                            if let Some(rewriter) = &self.options.extension.link_url_rewriter {
+                                self.escape_href(rewriter.to_html(&nl.url).as_bytes())?;
+                            } else {
+                                self.escape_href(url)?;
+                            }
                         }
                         if !nl.title.is_empty() {
                             self.output.write_all(b"\" title=\"")?;
@@ -889,7 +893,11 @@ impl<'o, 'c: 'o> HtmlFormatter<'o, 'c> {
                     self.output.write_all(b" src=\"")?;
                     let url = nl.url.as_bytes();
                     if self.options.render.unsafe_ || !dangerous_url(url) {
-                        self.escape_href(url)?;
+                        if let Some(rewriter) = &self.options.extension.image_url_rewriter {
+                            self.escape_href(rewriter.to_html(&nl.url).as_bytes())?;
+                        } else {
+                            self.escape_href(url)?;
+                        }
                     }
                     self.output.write_all(b"\" alt=\"")?;
                     return Ok(true);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ pub use parser::{
     parse_document, BrokenLinkCallback, BrokenLinkReference, ExtensionOptions,
     ExtensionOptionsBuilder, ListStyleType, Options, ParseOptions, ParseOptionsBuilder, Plugins,
     PluginsBuilder, RenderOptions, RenderOptionsBuilder, RenderPlugins, RenderPluginsBuilder,
-    ResolvedReference,
+    ResolvedReference, URLRewriter,
 };
 pub use typed_arena::Arena;
 pub use xml::format_document as format_xml;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -21,6 +21,7 @@ mod options;
 mod pathological;
 mod plugins;
 mod regressions;
+mod rewriter;
 mod shortcodes;
 mod spoiler;
 mod strikethrough;

--- a/src/tests/rewriter.rs
+++ b/src/tests/rewriter.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use super::*;
+
+#[test]
+fn image_url_rewriter() {
+    html_opts_i(
+        "![](http://unsafe.example.com/bad.png)",
+        "<p><img src=\"https://safe.example.com?url=http://unsafe.example.com/bad.png\" alt=\"\" /></p>\n",
+        true,
+        |opts| opts.extension.image_url_rewriter = Some(Arc::new(
+            |url: &str| format!("{}{}", "https://safe.example.com?url=", url)
+        ))
+    );
+}
+
+#[test]
+fn link_url_rewriter() {
+    html_opts_i(
+        "[my link](http://unsafe.example.com/bad)",
+        "<p><a href=\"https://safe.example.com/norefer?url=http://unsafe.example.com/bad\">my link</a></p>\n",
+        true,
+        |opts| opts.extension.link_url_rewriter = Some(Arc::new(
+            |url: &str| format!("{}{}", "https://safe.example.com/norefer?url=", url)
+        ))
+    );
+}


### PR DESCRIPTION
This adds support for stateful URL rewriting during HTML generation. I attempted to follow the `broken_link_callback` in ParseOptions as an example, but needed to wrap the type because there isn't a blanket implementation for Debug on dyn Fn.