### PR TITLE
Unwrap Mutex from broken_link_callback

### DIFF
--- a/fuzz/fuzz_targets/all_options.rs
+++ b/fuzz/fuzz_targets/all_options.rs
@@ -35,13 +35,13 @@ fuzz_target!(|s: &str| {
     parse.default_info_string = Some("rust".to_string());
     parse.relaxed_tasklist_matching = true;
     parse.relaxed_autolinks = true;
-    let mut cb = |link_ref: BrokenLinkReference| {
+    let cb = |link_ref: BrokenLinkReference| {
         Some(ResolvedReference {
             url: link_ref.normalized.to_string(),
             title: link_ref.original.to_string(),
         })
     };
-    parse.broken_link_callback = Some(Arc::new(Mutex::new(&mut cb)));
+    parse.broken_link_callback = Some(Arc::new(cb));
 
     let mut render = RenderOptions::default();
     render.hardbreaks = true;

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -47,9 +47,9 @@ pub fn format_document_with_plugins<'a>(
     Ok(())
 }
 
-struct CommonMarkFormatter<'a, 'o, 'c> {
+struct CommonMarkFormatter<'a, 'o> {
     node: &'a AstNode<'a>,
-    options: &'o Options<'c>,
+    options: &'o Options,
     v: Vec<u8>,
     prefix: Vec<u8>,
     column: usize,
@@ -72,7 +72,7 @@ enum Escaping {
     Title,
 }
 
-impl<'a, 'o, 'c> Write for CommonMarkFormatter<'a, 'o, 'c> {
+impl<'a, 'o> Write for CommonMarkFormatter<'a, 'o> {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.output(buf, false, Escaping::Literal);
         Ok(buf.len())
@@ -83,8 +83,8 @@ impl<'a, 'o, 'c> Write for CommonMarkFormatter<'a, 'o, 'c> {
     }
 }
 
-impl<'a, 'o, 'c> CommonMarkFormatter<'a, 'o, 'c> {
-    fn new(node: &'a AstNode<'a>, options: &'o Options<'c>) -> Self {
+impl<'a, 'o> CommonMarkFormatter<'a, 'o> {
+    fn new(node: &'a AstNode<'a>, options: &'o Options) -> Self {
         CommonMarkFormatter {
             node,
             options,

--- a/src/html.rs
+++ b/src/html.rs
@@ -126,9 +126,9 @@ impl Anchorizer {
     }
 }
 
-struct HtmlFormatter<'o, 'c> {
+struct HtmlFormatter<'o> {
     output: &'o mut WriteWithLast<'o>,
-    options: &'o Options<'c>,
+    options: &'o Options,
     anchorizer: Anchorizer,
     footnote_ix: u32,
     written_footnote_ix: u32,
@@ -361,12 +361,8 @@ where
     Ok(())
 }
 
-impl<'o, 'c: 'o> HtmlFormatter<'o, 'c> {
-    fn new(
-        options: &'o Options<'c>,
-        output: &'o mut WriteWithLast<'o>,
-        plugins: &'o Plugins,
-    ) -> Self {
+impl<'o> HtmlFormatter<'o> {
+    fn new(options: &'o Options, output: &'o mut WriteWithLast<'o>, plugins: &'o Plugins) -> Self {
         HtmlFormatter {
             options,
             output,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,9 +101,9 @@ pub use xml::format_document_with_plugins as format_xml_with_plugins;
 /// Legacy naming of [`ExtensionOptions`]
 pub type ComrakExtensionOptions = ExtensionOptions;
 /// Legacy naming of [`Options`]
-pub type ComrakOptions<'c> = Options<'c>;
+pub type ComrakOptions = Options;
 /// Legacy naming of [`ParseOptions`]
-pub type ComrakParseOptions<'c> = ParseOptions<'c>;
+pub type ComrakParseOptions = ParseOptions;
 /// Legacy naming of [`Plugins`]
 pub type ComrakPlugins<'a> = Plugins<'a>;
 /// Legacy naming of [`RenderOptions`]

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -25,9 +25,9 @@ const MAXBACKTICKS: usize = 80;
 const MAX_LINK_LABEL_LENGTH: usize = 1000;
 const MAX_MATH_DOLLARS: usize = 2;
 
-pub struct Subject<'a: 'd, 'r, 'o, 'c, 'd, 'i> {
+pub struct Subject<'a: 'd, 'r, 'o, 'd, 'i> {
     pub arena: &'a Arena<AstNode<'a>>,
-    options: &'o Options<'c>,
+    options: &'o Options,
     pub input: &'i [u8],
     line: usize,
     pub pos: usize,
@@ -110,10 +110,10 @@ struct WikilinkComponents<'i> {
     link_label: Option<(&'i [u8], usize, usize)>,
 }
 
-impl<'a, 'r, 'o, 'c, 'd, 'i> Subject<'a, 'r, 'o, 'c, 'd, 'i> {
+impl<'a, 'r, 'o, 'd, 'i> Subject<'a, 'r, 'o, 'd, 'i> {
     pub fn new(
         arena: &'a Arena<AstNode<'a>>,
-        options: &'o Options<'c>,
+        options: &'o Options,
         input: &'i [u8],
         line: usize,
         refmap: &'r mut RefMap,
@@ -1548,7 +1548,7 @@ impl<'a, 'r, 'o, 'c, 'd, 'i> Subject<'a, 'r, 'o, 'c, 'd, 'i> {
         // Attempt to use the provided broken link callback if a reference cannot be resolved
         if reff.is_none() {
             if let Some(callback) = &self.options.parse.broken_link_callback {
-                reff = callback.lock().unwrap()(BrokenLinkReference {
+                reff = callback.resolve(BrokenLinkReference {
                     normalized: &lab,
                     original: &unfolded_lab,
                 });

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -644,11 +644,7 @@ pub struct ParseOptions<'c> {
     ///
     /// ```
     /// # use std::{str, sync::{Arc, Mutex}};
-    /// # use comrak::{Arena, ResolvedReference, parse_document, format_html, Options, BrokenLinkReference, ParseOptions};
-    /// # use comrak::nodes::{AstNode, NodeValue};
-    /// #
-    /// # fn main() -> std::io::Result<()> {
-    /// let arena = Arena::new();
+    /// # use comrak::{markdown_to_html, BrokenLinkReference, Options, ResolvedReference};
     /// let mut cb = |link_ref: BrokenLinkReference| match link_ref.normalized {
     ///     "foo" => Some(ResolvedReference {
     ///         url: "https://www.rust-lang.org/".to_string(),
@@ -656,27 +652,19 @@ pub struct ParseOptions<'c> {
     ///     }),
     ///     _ => None,
     /// };
-    /// let options = Options {
-    ///     parse: ParseOptions::builder()
-    ///         .broken_link_callback(Arc::new(Mutex::new(&mut cb)))
-    ///         .build(),
-    ///     ..Default::default()
-    /// };
+    /// 
+    /// let mut options = Options::default();
+    /// options.parse.broken_link_callback = Some(Arc::new(Mutex::new(&mut cb)));
     ///
-    /// let root = parse_document(
-    ///     &arena,
+    /// let output = markdown_to_html(
     ///     "# Cool input!\nWow look at this cool [link][foo]. A [broken link] renders as text.",
     ///     &options,
     /// );
     ///
-    /// let mut output = Vec::new();
-    /// format_html(root, &Options::default(), &mut output)?;
-    /// assert_eq!(str::from_utf8(&output).unwrap(),
+    /// assert_eq!(output,
     ///            "<h1>Cool input!</h1>\n<p>Wow look at this cool \
     ///            <a href=\"https://www.rust-lang.org/\" title=\"The Rust Language\">link</a>. \
     ///            A [broken link] renders as text.</p>\n");
-    /// # Ok(())
-    /// # }
     #[cfg_attr(feature = "arbitrary", arbitrary(default))]
     pub broken_link_callback: Option<Arc<Mutex<BrokenLinkCallback<'c>>>>,
 }

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -13,7 +13,7 @@ use super::inlines::count_newlines;
 const MAX_AUTOCOMPLETED_CELLS: usize = 500_000;
 
 pub fn try_opening_block<'a>(
-    parser: &mut Parser<'a, '_, '_>,
+    parser: &mut Parser<'a, '_>,
     container: &'a AstNode<'a>,
     line: &[u8],
 ) -> Option<(&'a AstNode<'a>, bool, bool)> {
@@ -30,7 +30,7 @@ pub fn try_opening_block<'a>(
 }
 
 fn try_opening_header<'a>(
-    parser: &mut Parser<'a, '_, '_>,
+    parser: &mut Parser<'a, '_>,
     container: &'a AstNode<'a>,
     line: &[u8],
 ) -> Option<(&'a AstNode<'a>, bool, bool)> {
@@ -133,7 +133,7 @@ fn try_opening_header<'a>(
 }
 
 fn try_opening_row<'a>(
-    parser: &mut Parser<'a, '_, '_>,
+    parser: &mut Parser<'a, '_>,
     container: &'a AstNode<'a>,
     alignments: &[TableAlignment],
     line: &[u8],
@@ -280,7 +280,7 @@ fn row(string: &[u8], spoiler: bool) -> Option<Row> {
 }
 
 fn try_inserting_table_header_paragraph<'a>(
-    parser: &mut Parser<'a, '_, '_>,
+    parser: &mut Parser<'a, '_>,
     container: &'a AstNode<'a>,
     paragraph_offset: usize,
 ) {

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -30,15 +30,15 @@ pub fn format_document_with_plugins<'a>(
     XmlFormatter::new(options, output, plugins).format(root, false)
 }
 
-struct XmlFormatter<'o, 'c> {
+struct XmlFormatter<'o> {
     output: &'o mut dyn Write,
-    options: &'o Options<'c>,
+    options: &'o Options,
     _plugins: &'o Plugins<'o>,
     indent: u32,
 }
 
-impl<'o, 'c> XmlFormatter<'o, 'c> {
-    fn new(options: &'o Options<'c>, output: &'o mut dyn Write, plugins: &'o Plugins) -> Self {
+impl<'o> XmlFormatter<'o> {
+    fn new(options: &'o Options, output: &'o mut dyn Write, plugins: &'o Plugins) -> Self {
         XmlFormatter {
             options,
             output,


### PR DESCRIPTION
While working on #481 I realized that the same principle of making a dyn trait instead of a FnMut could be applied to the broken link callback. This PR implements an API break for that, which does the following:
- removes the Mutex wrapper, allowing the link callback to be lock-free if the underlying function is also lock-free
- makes it easier write the callback if it is a plain Fn (you can still use interior mutability within like Arc<Mutex<T>> if you need it)
- replaces a more complicated explicit Debug impl with a single simpler explicit Debug impl
- simplifies a little bit of the lifetime soup from the Options struct