### PR TITLE
rust-toolchain: remove

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly


### PR DESCRIPTION
Looks like this snuck in in a previous PR.