### PR TITLE
Make `wikilinks_title_after_pipe` override `wikilinks_title_before_pipe`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,3 +78,7 @@ clap = { version = "4.0", optional = true, features = [
     "string",
     "wrap_help",
 ] }
+
+[[example]]
+name = "syntect"
+required-features = [ "syntect" ]

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -6,7 +6,7 @@ use crate::nodes::{
 use crate::nodes::{NodeList, TableAlignment};
 #[cfg(feature = "shortcodes")]
 use crate::parser::shortcodes::NodeShortCode;
-use crate::parser::Options;
+use crate::parser::{Options, WikiLinksMode};
 use crate::scanners;
 use crate::strings::trim_start_match;
 use crate::{nodes, Plugins};
@@ -761,12 +761,12 @@ impl<'a, 'o, 'c> CommonMarkFormatter<'a, 'o, 'c> {
     fn format_wikilink(&mut self, nl: &NodeWikiLink, entering: bool) -> bool {
         if entering {
             write!(self, "[[").unwrap();
-            if self.options.extension.wikilinks_title_after_pipe {
+            if self.options.extension.wikilinks() == Some(WikiLinksMode::UrlFirst) {
                 self.output(nl.url.as_bytes(), false, Escaping::Url);
                 write!(self, "|").unwrap();
             }
         } else {
-            if self.options.extension.wikilinks_title_before_pipe {
+            if self.options.extension.wikilinks() == Some(WikiLinksMode::TitleFirst) {
                 write!(self, "|").unwrap();
                 self.output(nl.url.as_bytes(), false, Escaping::Url);
             }

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -181,6 +181,8 @@ pub enum NodeValue {
     MultilineBlockQuote(NodeMultilineBlockQuote),
 
     /// **Inline**.  A character that has been [escaped](https://github.github.com/gfm/#backslash-escapes)
+    ///
+    /// Enabled with [`escaped_char_spans`](crate::RenderOptionsBuilder::escaped_char_spans).
     Escaped,
 
     /// **Inline**.  A wikilink to some URL.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -193,6 +193,19 @@ where
 }
 
 #[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+/// Selects between wikilinks with the title first or the URL first.
+pub(crate) enum WikiLinksMode {
+    /// Indicates that the URL precedes the title. For example: `[[http://example.com|link
+    /// title]]`.
+    UrlFirst,
+
+    /// Indicates that the title precedes the URL. For example: `[[link title|http://example.com]]`.
+    TitleFirst,
+}
+
+#[non_exhaustive]
 #[derive(Default, Debug, Clone, Builder)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 /// Options to select extensions.
@@ -472,6 +485,11 @@ pub struct ExtensionOptions<'c> {
     /// [[url|link label]]
     /// ````
     ///
+    /// When both this option and [`wikilinks_title_before_pipe`][0] are enabled, this option takes
+    /// precedence.
+    ///
+    /// [0]: Self::wikilinks_title_before_pipe
+    ///
     /// ```
     /// # use comrak::{markdown_to_html, Options};
     /// let mut options = Options::default();
@@ -487,6 +505,10 @@ pub struct ExtensionOptions<'c> {
     /// ```` md
     /// [[link label|url]]
     /// ````
+    /// When both this option and [`wikilinks_title_after_pipe`][0] are enabled,
+    /// [`wikilinks_title_after_pipe`][0] takes precedence.
+    ///
+    /// [0]: Self::wikilinks_title_after_pipe
     ///
     /// ```
     /// # use comrak::{markdown_to_html, Options};
@@ -615,6 +637,19 @@ pub struct ExtensionOptions<'c> {
     /// ```
     #[cfg_attr(feature = "arbitrary", arbitrary(value = None))]
     pub link_url_rewriter: Option<Arc<dyn URLRewriter + 'c>>,
+}
+
+impl ExtensionOptions {
+    pub(crate) fn wikilinks(&self) -> Option<WikiLinksMode> {
+        match (
+            self.wikilinks_title_before_pipe,
+            self.wikilinks_title_after_pipe,
+        ) {
+            (false, false) => None,
+            (true, false) => Some(WikiLinksMode::TitleFirst),
+            (_, _) => Some(WikiLinksMode::UrlFirst),
+        }
+    }
 }
 
 #[non_exhaustive]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -865,6 +865,8 @@ pub struct RenderOptions {
     /// let xml = markdown_to_commonmark_xml(input, &options);
     /// assert!(xml.contains("<text sourcepos=\"1:4-1:15\" xml:space=\"preserve\">"));
     /// ```
+    ///
+    /// [`experimental_inline_sourcepos`]: crate::RenderOptionsBuilder::experimental_inline_sourcepos
     #[builder(default)]
     pub sourcepos: bool,
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -639,7 +639,7 @@ pub struct ExtensionOptions<'c> {
     pub link_url_rewriter: Option<Arc<dyn URLRewriter + 'c>>,
 }
 
-impl ExtensionOptions {
+impl<'c> ExtensionOptions<'c> {
     pub(crate) fn wikilinks(&self) -> Option<WikiLinksMode> {
         match (
             self.wikilinks_title_before_pipe,


### PR DESCRIPTION
Backwards compatible alternative to #497 