### PR TITLE
Eliminate `regex` and `once_cell` dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,8 +165,6 @@ dependencies = [
  "entities",
  "memchr",
  "ntest",
- "once_cell",
- "regex",
  "shell-words",
  "slug",
  "syntect",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,6 @@ doc = false
 
 [dependencies]
 typed-arena = "2.0.2"
-regex = "1"
-once_cell = "1.19.0"
 entities = "1.0.1"
 unicode_categories = "0.1.1"
 memchr = "2"

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -787,8 +787,7 @@ pub struct RenderOptions {
     ///
     /// options.render.full_info_string = true;
     /// let html = markdown_to_html("``` rust extra info\nfn hello();\n```\n", &options);
-    /// let re = regex::Regex::new(r#"data-meta="extra info""#).unwrap();
-    /// assert!(re.is_match(&html));
+    /// assert!(html.contains(r#"data-meta="extra info""#));
     /// ```
     #[builder(default)]
     pub full_info_string: bool,


### PR DESCRIPTION
## Objective

Reduce compile time / binary size impact of Comrak for projects that are not otherwise using the `regex` crate.

## Changes made
- Replace use of regex in a doctest with a simple `String::contains`
- Replace the usage of regex in anchorization code with `unicode_categories` crate which comrak already depends on.
- Removes `once_cell` dependendency, as it was only being used to cache a Regex

Comrak also currently also pulls in `regex` as a build dependency of `caseless`. But I have also sent that crate a PR to remove it's usage.
