### PR TITLE
Enable GitLab multiline alerts

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -52,6 +52,8 @@ python3 spec_tests.py --no-normalize --spec ../../../src/tests/fixtures/descript
   || failed=1
 python3 spec_tests.py --no-normalize --spec ../../../src/tests/fixtures/alerts.md "$PROGRAM_ARG -e alerts" \
   || failed=1
+python3 spec_tests.py --no-normalize --spec ../../../src/tests/fixtures/multiline_alerts.md "$PROGRAM_ARG -e alerts -e multiline-block-quotes" \
+  || failed=1
 
 python3 spec_tests.py --no-normalize --spec regression.txt "$PROGRAM_ARG" \
 	|| failed=1

--- a/src/parser/alert.rs
+++ b/src/parser/alert.rs
@@ -9,6 +9,12 @@ pub struct NodeAlert {
 
     /// Originated from a multiline blockquote.
     pub multiline: bool,
+
+    /// The length of the fence (multiline only).
+    pub fence_length: usize,
+
+    /// The indentation level of the fence marker (multiline only)
+    pub fence_offset: usize,
 }
 
 /// The type of alert.

--- a/src/scanners.re
+++ b/src/scanners.re
@@ -126,12 +126,13 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
     let mut cursor = 0;
     let mut marker = 0;
     let len = s.len();
+
 /*!re2c
-    '> [!note]' { return Some(AlertType::Note); }
-    '> [!tip]' { return Some(AlertType::Tip); }
-    '> [!important]' { return Some(AlertType::Important); }
-    '> [!warning]' { return Some(AlertType::Warning); }
-    '> [!caution]' { return Some(AlertType::Caution); }
+    [>]{1,} ' [!note]' { return Some(AlertType::Note); }
+    [>]{1,} ' [!tip]' { return Some(AlertType::Tip); }
+    [>]{1,} ' [!important]' { return Some(AlertType::Important); }
+    [>]{1,} ' [!warning]' { return Some(AlertType::Warning); }
+    [>]{1,} ' [!caution]' { return Some(AlertType::Caution); }
     * { return None; }
 */
 }

--- a/src/scanners.rs
+++ b/src/scanners.rs
@@ -4633,6 +4633,11 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                             yystate = 4;
                             continue 'yyl;
                         }
+                        0x3E => {
+                            cursor += 1;
+                            yystate = 6;
+                            continue 'yyl;
+                        }
                         _ => {
                             yystate = 2;
                             continue 'yyl;
@@ -4650,7 +4655,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                     match yych {
                         0x5B => {
                             cursor += 1;
-                            yystate = 6;
+                            yystate = 7;
                             continue 'yyl;
                         }
                         _ => {
@@ -4673,9 +4678,14 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x21 => {
+                        0x20 => {
                             cursor += 1;
-                            yystate = 7;
+                            yystate = 4;
+                            continue 'yyl;
+                        }
+                        0x3E => {
+                            cursor += 1;
+                            yystate = 6;
                             continue 'yyl;
                         }
                         _ => {
@@ -4693,29 +4703,9 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x43 | 0x63 => {
+                        0x21 => {
                             cursor += 1;
                             yystate = 8;
-                            continue 'yyl;
-                        }
-                        0x49 | 0x69 => {
-                            cursor += 1;
-                            yystate = 9;
-                            continue 'yyl;
-                        }
-                        0x4E | 0x6E => {
-                            cursor += 1;
-                            yystate = 10;
-                            continue 'yyl;
-                        }
-                        0x54 | 0x74 => {
-                            cursor += 1;
-                            yystate = 11;
-                            continue 'yyl;
-                        }
-                        0x57 | 0x77 => {
-                            cursor += 1;
-                            yystate = 12;
                             continue 'yyl;
                         }
                         _ => {
@@ -4733,7 +4723,27 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x41 | 0x61 => {
+                        0x43 | 0x63 => {
+                            cursor += 1;
+                            yystate = 9;
+                            continue 'yyl;
+                        }
+                        0x49 | 0x69 => {
+                            cursor += 1;
+                            yystate = 10;
+                            continue 'yyl;
+                        }
+                        0x4E | 0x6E => {
+                            cursor += 1;
+                            yystate = 11;
+                            continue 'yyl;
+                        }
+                        0x54 | 0x74 => {
+                            cursor += 1;
+                            yystate = 12;
+                            continue 'yyl;
+                        }
+                        0x57 | 0x77 => {
                             cursor += 1;
                             yystate = 13;
                             continue 'yyl;
@@ -4753,7 +4763,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x4D | 0x6D => {
+                        0x41 | 0x61 => {
                             cursor += 1;
                             yystate = 14;
                             continue 'yyl;
@@ -4773,7 +4783,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x4F | 0x6F => {
+                        0x4D | 0x6D => {
                             cursor += 1;
                             yystate = 15;
                             continue 'yyl;
@@ -4793,7 +4803,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x49 | 0x69 => {
+                        0x4F | 0x6F => {
                             cursor += 1;
                             yystate = 16;
                             continue 'yyl;
@@ -4813,7 +4823,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x41 | 0x61 => {
+                        0x49 | 0x69 => {
                             cursor += 1;
                             yystate = 17;
                             continue 'yyl;
@@ -4833,7 +4843,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x55 | 0x75 => {
+                        0x41 | 0x61 => {
                             cursor += 1;
                             yystate = 18;
                             continue 'yyl;
@@ -4853,7 +4863,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x50 | 0x70 => {
+                        0x55 | 0x75 => {
                             cursor += 1;
                             yystate = 19;
                             continue 'yyl;
@@ -4873,7 +4883,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x54 | 0x74 => {
+                        0x50 | 0x70 => {
                             cursor += 1;
                             yystate = 20;
                             continue 'yyl;
@@ -4893,7 +4903,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x50 | 0x70 => {
+                        0x54 | 0x74 => {
                             cursor += 1;
                             yystate = 21;
                             continue 'yyl;
@@ -4913,7 +4923,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x52 | 0x72 => {
+                        0x50 | 0x70 => {
                             cursor += 1;
                             yystate = 22;
                             continue 'yyl;
@@ -4933,7 +4943,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x54 | 0x74 => {
+                        0x52 | 0x72 => {
                             cursor += 1;
                             yystate = 23;
                             continue 'yyl;
@@ -4953,7 +4963,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x4F | 0x6F => {
+                        0x54 | 0x74 => {
                             cursor += 1;
                             yystate = 24;
                             continue 'yyl;
@@ -4973,7 +4983,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x45 | 0x65 => {
+                        0x4F | 0x6F => {
                             cursor += 1;
                             yystate = 25;
                             continue 'yyl;
@@ -4993,7 +5003,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x5D => {
+                        0x45 | 0x65 => {
                             cursor += 1;
                             yystate = 26;
                             continue 'yyl;
@@ -5013,7 +5023,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x4E | 0x6E => {
+                        0x5D => {
                             cursor += 1;
                             yystate = 27;
                             continue 'yyl;
@@ -5033,7 +5043,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x49 | 0x69 => {
+                        0x4E | 0x6E => {
                             cursor += 1;
                             yystate = 28;
                             continue 'yyl;
@@ -5053,7 +5063,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x52 | 0x72 => {
+                        0x49 | 0x69 => {
                             cursor += 1;
                             yystate = 29;
                             continue 'yyl;
@@ -5073,7 +5083,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x5D => {
+                        0x52 | 0x72 => {
                             cursor += 1;
                             yystate = 30;
                             continue 'yyl;
@@ -5085,9 +5095,6 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                     }
                 }
                 26 => {
-                    return Some(AlertType::Tip);
-                }
-                27 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -5096,7 +5103,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x49 | 0x69 => {
+                        0x5D => {
                             cursor += 1;
                             yystate = 31;
                             continue 'yyl;
@@ -5107,6 +5114,9 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     }
                 }
+                27 => {
+                    return Some(AlertType::Tip);
+                }
                 28 => {
                     yych = unsafe {
                         if cursor < len {
@@ -5116,7 +5126,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x4F | 0x6F => {
+                        0x49 | 0x69 => {
                             cursor += 1;
                             yystate = 32;
                             continue 'yyl;
@@ -5136,7 +5146,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x54 | 0x74 => {
+                        0x4F | 0x6F => {
                             cursor += 1;
                             yystate = 33;
                             continue 'yyl;
@@ -5148,9 +5158,6 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                     }
                 }
                 30 => {
-                    return Some(AlertType::Note);
-                }
-                31 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -5159,7 +5166,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x4E | 0x6E => {
+                        0x54 | 0x74 => {
                             cursor += 1;
                             yystate = 34;
                             continue 'yyl;
@@ -5169,6 +5176,9 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                             continue 'yyl;
                         }
                     }
+                }
+                31 => {
+                    return Some(AlertType::Note);
                 }
                 32 => {
                     yych = unsafe {
@@ -5199,7 +5209,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x41 | 0x61 => {
+                        0x4E | 0x6E => {
                             cursor += 1;
                             yystate = 36;
                             continue 'yyl;
@@ -5219,7 +5229,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x47 | 0x67 => {
+                        0x41 | 0x61 => {
                             cursor += 1;
                             yystate = 37;
                             continue 'yyl;
@@ -5239,7 +5249,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x5D => {
+                        0x47 | 0x67 => {
                             cursor += 1;
                             yystate = 38;
                             continue 'yyl;
@@ -5259,7 +5269,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x4E | 0x6E => {
+                        0x5D => {
                             cursor += 1;
                             yystate = 39;
                             continue 'yyl;
@@ -5279,7 +5289,7 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     };
                     match yych {
-                        0x5D => {
+                        0x4E | 0x6E => {
                             cursor += 1;
                             yystate = 40;
                             continue 'yyl;
@@ -5291,32 +5301,6 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                     }
                 }
                 38 => {
-                    return Some(AlertType::Caution);
-                }
-                39 => {
-                    yych = unsafe {
-                        if cursor < len {
-                            *s.get_unchecked(cursor)
-                        } else {
-                            0
-                        }
-                    };
-                    match yych {
-                        0x54 | 0x74 => {
-                            cursor += 1;
-                            yystate = 41;
-                            continue 'yyl;
-                        }
-                        _ => {
-                            yystate = 5;
-                            continue 'yyl;
-                        }
-                    }
-                }
-                40 => {
-                    return Some(AlertType::Warning);
-                }
-                41 => {
                     yych = unsafe {
                         if cursor < len {
                             *s.get_unchecked(cursor)
@@ -5327,6 +5311,29 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                     match yych {
                         0x5D => {
                             cursor += 1;
+                            yystate = 41;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                39 => {
+                    return Some(AlertType::Caution);
+                }
+                40 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x54 | 0x74 => {
+                            cursor += 1;
                             yystate = 42;
                             continue 'yyl;
                         }
@@ -5336,7 +5343,30 @@ pub fn alert_start(s: &[u8]) -> Option<AlertType> {
                         }
                     }
                 }
+                41 => {
+                    return Some(AlertType::Warning);
+                }
                 42 => {
+                    yych = unsafe {
+                        if cursor < len {
+                            *s.get_unchecked(cursor)
+                        } else {
+                            0
+                        }
+                    };
+                    match yych {
+                        0x5D => {
+                            cursor += 1;
+                            yystate = 43;
+                            continue 'yyl;
+                        }
+                        _ => {
+                            yystate = 5;
+                            continue 'yyl;
+                        }
+                    }
+                }
+                43 => {
                     return Some(AlertType::Important);
                 }
                 _ => panic!("internal lexer error"),

--- a/src/tests/alerts.rs
+++ b/src/tests/alerts.rs
@@ -15,6 +15,20 @@ fn alerts() {
 }
 
 #[test]
+fn multiline_alerts() {
+    html_opts!(
+        [extension.alerts, extension.multiline_block_quotes],
+        concat!(">>> [!note]\n", "Pay attention\n", ">>>",),
+        concat!(
+            "<div class=\"alert alert-note\">\n",
+            "<p class=\"alert-title\">Note</p>\n",
+            "<p>Pay attention</p>\n",
+            "</div>\n",
+        ),
+    );
+}
+
+#[test]
 fn sourcepos() {
     assert_ast_match!(
         [extension.alerts],
@@ -49,6 +63,23 @@ fn sourcepos_in_list() {
                             (text (4:5-4:17) "Pay attention")
                         ])
                     ])
+                ])
+            ])
+        ])
+    );
+}
+
+#[test]
+fn sourcepos_multiline() {
+    assert_ast_match!(
+        [extension.alerts, extension.multiline_block_quotes],
+        ">>> [!note]\n"
+        "Pay attention\n"
+        ">>>\n",
+        (document (1:1-3:3) [
+            (alert (1:1-2:13) [
+                (paragraph (2:1-2:13) [
+                    (text (2:1-2:13) "Pay attention")
                 ])
             ])
         ])

--- a/src/tests/fixtures/multiline_alerts.md
+++ b/src/tests/fixtures/multiline_alerts.md
@@ -1,0 +1,388 @@
+---
+title: GitLab Flavored Markdown Spec
+version: 0.1
+date: '2023-12-18'
+license: '[CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/)'
+---
+
+## Multi-line Alerts
+
+Simple container
+
+```````````````````````````````` example
+>>> [!NOTE]
+*content*
+>>>
+.
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<p><em>content</em></p>
+</div>
+````````````````````````````````
+
+Other kinds of alerts:
+
+```````````````````````````````` example
+>>> [!TIP]
+Optional information to help a user be more successful.
+>>>
+.
+<div class="alert alert-tip">
+<p class="alert-title">Tip</p>
+<p>Optional information to help a user be more successful.</p>
+</div>
+````````````````````````````````
+
+```````````````````````````````` example
+>>> [!IMPORTANT]
+Crucial information necessary for users to succeed.
+>>>
+.
+<div class="alert alert-important">
+<p class="alert-title">Important</p>
+<p>Crucial information necessary for users to succeed.</p>
+</div>
+````````````````````````````````
+
+```````````````````````````````` example
+>>> [!WARNING]
+Critical content demanding immediate user attention due to potential risks.
+>>>
+.
+<div class="alert alert-warning">
+<p class="alert-title">Warning</p>
+<p>Critical content demanding immediate user attention due to potential risks.</p>
+</div>
+````````````````````````````````
+
+```````````````````````````````` example
+>>> [!CAUTION]
+Negative potential consequences of an action.
+>>>
+.
+<div class="alert alert-caution">
+<p class="alert-title">Caution</p>
+<p>Negative potential consequences of an action.</p>
+</div>
+````````````````````````````````
+
+A title can be specified to override the default title:
+
+```````````````````````````````` example
+>>> [!NOTE] Pay attention
+Highlights information that users should take into account, even when skimming.
+>>>
+.
+<div class="alert alert-note">
+<p class="alert-title">Pay attention</p>
+<p>Highlights information that users should take into account, even when skimming.</p>
+</div>
+````````````````````````````````
+
+Can contain block elements
+
+```````````````````````````````` example
+>>> [!NOTE]
+### heading
+
+-----------
+>>>
+.
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<h3>heading</h3>
+<hr />
+</div>
+````````````````````````````````
+
+
+Ending marker can be longer
+
+```````````````````````````````` example
+>>>>>> [!NOTE]
+  hello world
+>>>>>>>>>>>
+normal
+.
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<p>hello world</p>
+</div>
+<p>normal</p>
+````````````````````````````````
+
+
+Nested alerts
+
+```````````````````````````````` example
+>>>>> [!NOTE]
+>>>> [!CAUTION]
+foo
+>>>>
+>>>>>
+.
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<div class="alert alert-caution">
+<p class="alert-title">Caution</p>
+<p>foo</p>
+</div>
+</div>
+````````````````````````````````
+
+Incorrectly nested alerts
+
+```````````````````````````````` example
+>>>> [!NOTE]
+this block is closed with 5 markers below
+
+>>>>>
+
+auto-closed blocks
+>>>>>
+>>>>
+.
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<p>this block is closed with 5 markers below</p>
+</div>
+<p>auto-closed blocks</p>
+<blockquote>
+<blockquote>
+</blockquote>
+</blockquote>
+````````````````````````````````
+
+
+Marker can be indented up to 3 spaces
+
+```````````````````````````````` example
+   >>>> [!NOTE]
+   first-level blockquote
+    >>> [!CAUTION]
+    second-level blockquote
+    >>>
+   >>>>
+   regular paragraph
+.
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<p>first-level blockquote</p>
+<div class="alert alert-caution">
+<p class="alert-title">Caution</p>
+<p>second-level blockquote</p>
+</div>
+</div>
+<p>regular paragraph</p>
+````````````````````````````````
+
+
+Fours spaces makes it a code block
+
+```````````````````````````````` example
+    >>>
+    content
+    >>>
+.
+<pre><code>&gt;&gt;&gt;
+content
+&gt;&gt;&gt;
+</code></pre>
+````````````````````````````````
+
+
+Detection of embedded 4 spaces code block starts in the
+column the alert starts, not from the beginning of
+the line.
+
+```````````````````````````````` example
+  >>> [!NOTE]
+      code block
+  >>>
+.
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<pre><code>code block
+</code></pre>
+</div>
+````````````````````````````````
+
+```````````````````````````````` example
+   >>>> [!NOTE]
+   content
+    >>> [!CAUTION]
+        code block
+    >>>
+   >>>>
+.
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<p>content</p>
+<div class="alert alert-caution">
+<p class="alert-title">Caution</p>
+<pre><code>code block
+</code></pre>
+</div>
+</div>
+````````````````````````````````
+
+Closing marker can't have text on the same line
+
+```````````````````````````````` example
+>>> [!NOTE]
+foo
+>>> arg=123
+.
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<p>foo</p>
+<blockquote>
+<blockquote>
+<blockquote>
+<p>arg=123</p>
+</blockquote>
+</blockquote>
+</blockquote>
+</div>
+````````````````````````````````
+
+
+Alerts self-close at the end of the document
+
+```````````````````````````````` example
+>>> [!NOTE]
+foo
+.
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<p>foo</p>
+</div>
+````````````````````````````````
+
+
+They should terminate paragraphs
+
+```````````````````````````````` example
+blah blah
+>>> [!NOTE]
+content
+>>>
+.
+<p>blah blah</p>
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<p>content</p>
+</div>
+````````````````````````````````
+
+
+They can be nested in lists
+
+```````````````````````````````` example
+ -  >>> [!NOTE]
+    - foo
+    >>>
+.
+<ul>
+<li>
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<ul>
+<li>foo</li>
+</ul>
+</div>
+</li>
+</ul>
+````````````````````````````````
+
+
+Or in blockquotes
+
+```````````````````````````````` example
+> >>> [!NOTE]
+> foo
+>> bar
+> baz
+> >>>
+.
+<blockquote>
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<p>foo</p>
+<blockquote>
+<p>bar
+baz</p>
+</blockquote>
+</div>
+</blockquote>
+````````````````````````````````
+
+
+List indentation
+
+```````````````````````````````` example
+ -  >>> [!NOTE]
+    foo
+    bar
+    >>>
+
+ -  >>> [!NOTE]
+    foo
+    bar
+    >>>
+.
+<ul>
+<li>
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<p>foo
+bar</p>
+</div>
+</li>
+<li>
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<p>foo
+bar</p>
+</div>
+</li>
+</ul>
+````````````````````````````````
+
+
+Ignored inside code blocks:
+
+```````````````````````````````` example
+```txt
+# Code
+>>> [!NOTE]
+# Code
+>>>
+# Code
+```
+.
+<pre><code class="language-txt"># Code
+&gt;&gt;&gt; [!NOTE]
+# Code
+&gt;&gt;&gt;
+# Code
+</code></pre>
+````````````````````````````````
+
+
+Does not require a leading or trailing blank line
+
+```````````````````````````````` example
+Some text
+>>> [!NOTE]
+A quote
+>>>
+Some other text
+.
+<p>Some text</p>
+<div class="alert alert-note">
+<p class="alert-title">Note</p>
+<p>A quote</p>
+</div>
+<p>Some other text</p>
+````````````````````````````````


### PR DESCRIPTION
When the extensions `alerts` and `multiline-block-quotes` are enabled, then we now recognize GitLab style multiline alerts.  For example

```
>>> [!note]
Something of interest.

And another thing...
>>>
```

will behave the same as

```
> [!note]
> Something of interest.
>
> And another thing...
```

This makes it easier to make an alert out of multiple paragraphs and blocks, in the same fashion as [GitLab multiline block quotes](https://docs.gitlab.com/ee/user/markdown.html#multiline-blockquote)