### PR TITLE
commonmark: experimental minimize

### DIFF
--- a/examples/iterator_replace.rs
+++ b/examples/iterator_replace.rs
@@ -27,7 +27,7 @@ fn main() {
     let doc = "This is my input.\n\n1. Also [my](#) input.\n2. Certainly *my* input.\n";
     let orig = "my";
     let repl = "your";
-    let html = replace_text(&doc, &orig, &repl);
+    let html = replace_text(doc, orig, repl);
 
     println!("{}", html);
 }

--- a/examples/sample.rs
+++ b/examples/sample.rs
@@ -38,7 +38,7 @@ fn large() {
         let doc = "This is my input.\n\n1. Also [my](#) input.\n2. Certainly *my* input.\n";
         let orig = "my";
         let repl = "your";
-        let html = replace_text(&doc, &orig, &repl);
+        let html = replace_text(doc, orig, repl);
 
         println!("{}", html);
         // Output:

--- a/examples/update-readme.rs
+++ b/examples/update-readme.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
                 if next_block_is_help_body {
                     next_block_is_help_body = false;
-                    assert!(ncb.info == "" && ncb.literal.starts_with(HELP_START));
+                    assert!(ncb.info.is_empty() && ncb.literal.starts_with(HELP_START));
                     let mut content = String::new();
                     let mut cmd = std::process::Command::new("cargo");
                     content.push_str(

--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,7 @@
             "cargo"
             "rustc"
             "rust-analyzer"
+            "clippy"
           ])
           pkgs.cargo-fuzz
           pkgs.python3

--- a/src/main.rs
+++ b/src/main.rs
@@ -369,7 +369,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         formatter(root, &options, &mut bw, &plugins)?;
         bw.flush()?;
     } else if cli.inplace {
-        let output_filename = cli.files.unwrap().get(0).unwrap().clone();
+        let output_filename = cli.files.unwrap().first().unwrap().clone();
         let mut bw = BufWriter::new(fs::File::create(output_filename)?);
         formatter(root, &options, &mut bw, &plugins)?;
         bw.flush()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,10 @@ struct Cli {
     /// Ignore empty links
     #[arg(long)]
     ignore_empty_links: bool,
+
+    // Minimize escapes in CommonMark output using a trial-and-error algorithm.
+    #[arg(long)]
+    experimental_minimize_commonmark: bool,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -297,6 +301,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .list_style(cli.list_style.into())
         .sourcepos(cli.sourcepos)
         .experimental_inline_sourcepos(cli.experimental_inline_sourcepos)
+        .experimental_minimize_commonmark(cli.experimental_minimize_commonmark)
         .escaped_char_spans(cli.escaped_char_spans)
         .ignore_setext(cli.ignore_setext)
         .ignore_empty_links(cli.ignore_empty_links)

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1083,6 +1083,26 @@ pub struct RenderOptions {
     /// ```
     #[cfg_attr(feature = "bon", builder(default))]
     pub ol_width: usize,
+
+    /// Minimise escapes used in CommonMark output (`-t commonmark`) by removing
+    /// each individually and seeing if the resulting document roundtrips.
+    /// Brute-force and expensive, but produces nicer output.  Note that the
+    /// result may not in fact be minimal.
+    ///
+    /// ```rust
+    /// # use comrak::{markdown_to_commonmark, Options};
+    /// let mut options = Options::default();
+    /// let input = "__hi";
+    ///
+    /// assert_eq!(markdown_to_commonmark(input, &options),
+    ///            "\\_\\_hi\n");
+    ///
+    /// options.render.experimental_minimize_commonmark = true;
+    /// assert_eq!(markdown_to_commonmark(input, &options),
+    ///            "__hi\n");
+    /// ```
+    #[cfg_attr(feature = "bon", builder(default))]
+    pub experimental_minimize_commonmark: bool,
 }
 
 #[derive(Default, Debug, Clone)]

--- a/src/tests/front_matter.rs
+++ b/src/tests/front_matter.rs
@@ -105,7 +105,8 @@ fn trailing_space_open() {
     let root = parse_document(&arena, input, &options);
 
     let found = root
-        .descendants().find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
+        .descendants()
+        .find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
 
     assert!(found.is_none(), "no FrontMatter expected");
 }
@@ -120,7 +121,8 @@ fn leading_space_open() {
     let root = parse_document(&arena, input, &options);
 
     let found = root
-        .descendants().find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
+        .descendants()
+        .find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
 
     assert!(found.is_none(), "no FrontMatter expected");
 }
@@ -135,7 +137,8 @@ fn leading_space_close() {
     let root = parse_document(&arena, input, &options);
 
     let found = root
-        .descendants().find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
+        .descendants()
+        .find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
 
     assert!(found.is_none(), "no FrontMatter expected");
 }
@@ -150,7 +153,8 @@ fn trailing_space_close() {
     let root = parse_document(&arena, input, &options);
 
     let found = root
-        .descendants().find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
+        .descendants()
+        .find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
 
     assert!(found.is_none(), "no FrontMatter expected");
 }
@@ -165,7 +169,8 @@ fn second_line() {
     let root = parse_document(&arena, input, &options);
 
     let found = root
-        .descendants().find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
+        .descendants()
+        .find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
 
     assert!(found.is_none(), "no FrontMatter expected");
 }
@@ -180,7 +185,8 @@ fn fm_only_with_trailing_newline() {
     let root = parse_document(&arena, input, &options);
 
     let found = root
-        .descendants().find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
+        .descendants()
+        .find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
 
     assert!(found.is_some(), "front matter expected");
 }
@@ -195,7 +201,8 @@ fn fm_only_without_trailing_newline() {
     let root = parse_document(&arena, input, &options);
 
     let found = root
-        .descendants().find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
+        .descendants()
+        .find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
 
     assert!(found.is_some(), "front matter expected");
 }

--- a/src/tests/front_matter.rs
+++ b/src/tests/front_matter.rs
@@ -10,7 +10,7 @@ fn round_trip_one_field() {
     let input = "---\nlayout: post\n---\nText\n";
     let root = parse_document(&arena, input, &options);
     let mut buf = Vec::new();
-    format_commonmark(&root, &options, &mut buf).unwrap();
+    format_commonmark(root, &options, &mut buf).unwrap();
     assert_eq!(&String::from_utf8(buf).unwrap(), input);
 }
 
@@ -22,7 +22,7 @@ fn round_trip_wide_delimiter() {
     let input = "\u{04fc}\nlayout: post\n\u{04fc}\nText\n";
     let root = parse_document(&arena, input, &options);
     let mut buf = Vec::new();
-    format_commonmark(&root, &options, &mut buf).unwrap();
+    format_commonmark(root, &options, &mut buf).unwrap();
     assert_eq!(&String::from_utf8(buf).unwrap(), input);
 }
 
@@ -105,9 +105,7 @@ fn trailing_space_open() {
     let root = parse_document(&arena, input, &options);
 
     let found = root
-        .descendants()
-        .filter(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)))
-        .next();
+        .descendants().find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
 
     assert!(found.is_none(), "no FrontMatter expected");
 }
@@ -122,9 +120,7 @@ fn leading_space_open() {
     let root = parse_document(&arena, input, &options);
 
     let found = root
-        .descendants()
-        .filter(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)))
-        .next();
+        .descendants().find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
 
     assert!(found.is_none(), "no FrontMatter expected");
 }
@@ -139,9 +135,7 @@ fn leading_space_close() {
     let root = parse_document(&arena, input, &options);
 
     let found = root
-        .descendants()
-        .filter(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)))
-        .next();
+        .descendants().find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
 
     assert!(found.is_none(), "no FrontMatter expected");
 }
@@ -156,9 +150,7 @@ fn trailing_space_close() {
     let root = parse_document(&arena, input, &options);
 
     let found = root
-        .descendants()
-        .filter(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)))
-        .next();
+        .descendants().find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
 
     assert!(found.is_none(), "no FrontMatter expected");
 }
@@ -173,9 +165,7 @@ fn second_line() {
     let root = parse_document(&arena, input, &options);
 
     let found = root
-        .descendants()
-        .filter(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)))
-        .next();
+        .descendants().find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
 
     assert!(found.is_none(), "no FrontMatter expected");
 }
@@ -190,9 +180,7 @@ fn fm_only_with_trailing_newline() {
     let root = parse_document(&arena, input, &options);
 
     let found = root
-        .descendants()
-        .filter(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)))
-        .next();
+        .descendants().find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
 
     assert!(found.is_some(), "front matter expected");
 }
@@ -207,9 +195,7 @@ fn fm_only_without_trailing_newline() {
     let root = parse_document(&arena, input, &options);
 
     let found = root
-        .descendants()
-        .filter(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)))
-        .next();
+        .descendants().find(|n| matches!(n.data.borrow().value, NodeValue::FrontMatter(..)));
 
     assert!(found.is_some(), "front matter expected");
 }


### PR DESCRIPTION
Fixes #509, kinda. Supersedes #510.
Experimental-quality CommonMark output minimizer.

Doesn't encode any intelligence about the underlying format; tries removing every backslash (`\`) escape in order and sees if the document parses the same, accumulating those deletions that do.

It's wasteful but better than nothing!