### PR TITLE
Use CSS class `markdown-alert` instead of `alert`

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -1155,13 +1155,14 @@ where
             NodeValue::Alert(ref alert) => {
                 if entering {
                     self.cr()?;
-                    self.output.write_all(b"<div class=\"alert ")?;
+                    self.output.write_all(b"<div class=\"markdown-alert ")?;
                     self.output
                         .write_all(alert.alert_type.css_class().as_bytes())?;
                     self.output.write_all(b"\"")?;
                     self.render_sourcepos(node)?;
                     self.output.write_all(b">\n")?;
-                    self.output.write_all(b"<p class=\"alert-title\">")?;
+                    self.output
+                        .write_all(b"<p class=\"markdown-alert-title\">")?;
                     match alert.title {
                         Some(ref title) => self.escape(title.as_bytes())?,
                         None => {

--- a/src/parser/alert.rs
+++ b/src/parser/alert.rs
@@ -52,11 +52,11 @@ impl AlertType {
     /// Returns the CSS class to use for an alert type
     pub(crate) fn css_class(&self) -> String {
         match *self {
-            AlertType::Note => String::from("alert-note"),
-            AlertType::Tip => String::from("alert-tip"),
-            AlertType::Important => String::from("alert-important"),
-            AlertType::Warning => String::from("alert-warning"),
-            AlertType::Caution => String::from("alert-caution"),
+            AlertType::Note => String::from("markdown-alert-note"),
+            AlertType::Tip => String::from("markdown-alert-tip"),
+            AlertType::Important => String::from("markdown-alert-important"),
+            AlertType::Warning => String::from("markdown-alert-warning"),
+            AlertType::Caution => String::from("markdown-alert-caution"),
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -434,7 +434,7 @@ pub struct ExtensionOptions<'c> {
     /// let mut options = Options::default();
     /// options.extension.alerts = true;
     /// assert_eq!(markdown_to_html("> [!note]\n> Something of note", &options),
-    ///            "<div class=\"alert alert-note\">\n<p class=\"alert-title\">Note</p>\n<p>Something of note</p>\n</div>\n");
+    ///            "<div class=\"markdown-alert markdown-alert-note\">\n<p class=\"markdown-alert-title\">Note</p>\n<p>Something of note</p>\n</div>\n");
     /// ```
     #[cfg_attr(feature = "bon", builder(default))]
     pub alerts: bool,

--- a/src/tests/alerts.rs
+++ b/src/tests/alerts.rs
@@ -6,8 +6,8 @@ fn alerts() {
         [extension.alerts],
         concat!("> [!note]\n", "> Pay attention\n",),
         concat!(
-            "<div class=\"alert alert-note\">\n",
-            "<p class=\"alert-title\">Note</p>\n",
+            "<div class=\"markdown-alert markdown-alert-note\">\n",
+            "<p class=\"markdown-alert-title\">Note</p>\n",
             "<p>Pay attention</p>\n",
             "</div>\n",
         ),
@@ -20,8 +20,8 @@ fn multiline_alerts() {
         [extension.alerts, extension.multiline_block_quotes],
         concat!(">>> [!note]\n", "Pay attention\n", ">>>",),
         concat!(
-            "<div class=\"alert alert-note\">\n",
-            "<p class=\"alert-title\">Note</p>\n",
+            "<div class=\"markdown-alert markdown-alert-note\">\n",
+            "<p class=\"markdown-alert-title\">Note</p>\n",
             "<p>Pay attention</p>\n",
             "</div>\n",
         ),

--- a/src/tests/fixtures/alerts.md
+++ b/src/tests/fixtures/alerts.md
@@ -11,8 +11,8 @@ GitHub style alerts look like this:
 > [!NOTE]
 > Highlights information that users should take into account, even when skimming.
 .
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>Highlights information that users should take into account, even when skimming.</p>
 </div>
 ````````````````````````````````
@@ -24,8 +24,8 @@ the `[!NOTE]`:
 > [!NOTE]  
 > Highlights information that users should take into account, even when skimming.
 .
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>Highlights information that users should take into account, even when skimming.</p>
 </div>
 ````````````````````````````````
@@ -36,8 +36,8 @@ Uppercase isn't required:
 > [!note]
 > Highlights information that users should take into account, even when skimming.
 .
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>Highlights information that users should take into account, even when skimming.</p>
 </div>
 ````````````````````````````````
@@ -51,8 +51,8 @@ Alerts can contain multiple blocks:
 >
 > Paragraph two.
 .
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>Highlights information that users should take into account, even when skimming.</p>
 <p>Paragraph two.</p>
 </div>
@@ -64,8 +64,8 @@ Other kinds of alerts:
 > [!TIP]
 > Optional information to help a user be more successful.
 .
-<div class="alert alert-tip">
-<p class="alert-title">Tip</p>
+<div class="markdown-alert markdown-alert-tip">
+<p class="markdown-alert-title">Tip</p>
 <p>Optional information to help a user be more successful.</p>
 </div>
 ````````````````````````````````
@@ -74,8 +74,8 @@ Other kinds of alerts:
 > [!IMPORTANT]
 > Crucial information necessary for users to succeed.
 .
-<div class="alert alert-important">
-<p class="alert-title">Important</p>
+<div class="markdown-alert markdown-alert-important">
+<p class="markdown-alert-title">Important</p>
 <p>Crucial information necessary for users to succeed.</p>
 </div>
 ````````````````````````````````
@@ -84,8 +84,8 @@ Other kinds of alerts:
 > [!WARNING]
 > Critical content demanding immediate user attention due to potential risks.
 .
-<div class="alert alert-warning">
-<p class="alert-title">Warning</p>
+<div class="markdown-alert markdown-alert-warning">
+<p class="markdown-alert-title">Warning</p>
 <p>Critical content demanding immediate user attention due to potential risks.</p>
 </div>
 ````````````````````````````````
@@ -94,8 +94,8 @@ Other kinds of alerts:
 > [!CAUTION]
 > Negative potential consequences of an action.
 .
-<div class="alert alert-caution">
-<p class="alert-title">Caution</p>
+<div class="markdown-alert markdown-alert-caution">
+<p class="markdown-alert-title">Caution</p>
 <p>Negative potential consequences of an action.</p>
 </div>
 ````````````````````````````````
@@ -106,8 +106,8 @@ A title can be specified to override the default title:
 > [!NOTE] Pay attention
 > Highlights information that users should take into account, even when skimming.
 .
-<div class="alert alert-note">
-<p class="alert-title">Pay attention</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Pay attention</p>
 <p>Highlights information that users should take into account, even when skimming.</p>
 </div>
 ````````````````````````````````
@@ -118,8 +118,8 @@ The title does not process markdown and is escaped:
 > [!NOTE] **Pay** attention <script>
 > Highlights information that users should take into account, even when skimming.
 .
-<div class="alert alert-note">
-<p class="alert-title">**Pay** attention &lt;script&gt;</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">**Pay** attention &lt;script&gt;</p>
 <p>Highlights information that users should take into account, even when skimming.</p>
 </div>
 ````````````````````````````````
@@ -135,8 +135,8 @@ They work in the same places as a normal blockquote would, such as in a list ite
 <ul>
 <li>
 <p>Item one</p>
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>Highlights information that users should take into account, even when skimming.</p>
 </div>
 </li>

--- a/src/tests/fixtures/multiline_alerts.md
+++ b/src/tests/fixtures/multiline_alerts.md
@@ -14,8 +14,8 @@ Simple container
 *content*
 >>>
 .
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p><em>content</em></p>
 </div>
 ````````````````````````````````
@@ -27,8 +27,8 @@ Other kinds of alerts:
 Optional information to help a user be more successful.
 >>>
 .
-<div class="alert alert-tip">
-<p class="alert-title">Tip</p>
+<div class="markdown-alert markdown-alert-tip">
+<p class="markdown-alert-title">Tip</p>
 <p>Optional information to help a user be more successful.</p>
 </div>
 ````````````````````````````````
@@ -38,8 +38,8 @@ Optional information to help a user be more successful.
 Crucial information necessary for users to succeed.
 >>>
 .
-<div class="alert alert-important">
-<p class="alert-title">Important</p>
+<div class="markdown-alert markdown-alert-important">
+<p class="markdown-alert-title">Important</p>
 <p>Crucial information necessary for users to succeed.</p>
 </div>
 ````````````````````````````````
@@ -49,8 +49,8 @@ Crucial information necessary for users to succeed.
 Critical content demanding immediate user attention due to potential risks.
 >>>
 .
-<div class="alert alert-warning">
-<p class="alert-title">Warning</p>
+<div class="markdown-alert markdown-alert-warning">
+<p class="markdown-alert-title">Warning</p>
 <p>Critical content demanding immediate user attention due to potential risks.</p>
 </div>
 ````````````````````````````````
@@ -60,8 +60,8 @@ Critical content demanding immediate user attention due to potential risks.
 Negative potential consequences of an action.
 >>>
 .
-<div class="alert alert-caution">
-<p class="alert-title">Caution</p>
+<div class="markdown-alert markdown-alert-caution">
+<p class="markdown-alert-title">Caution</p>
 <p>Negative potential consequences of an action.</p>
 </div>
 ````````````````````````````````
@@ -73,8 +73,8 @@ A title can be specified to override the default title:
 Highlights information that users should take into account, even when skimming.
 >>>
 .
-<div class="alert alert-note">
-<p class="alert-title">Pay attention</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Pay attention</p>
 <p>Highlights information that users should take into account, even when skimming.</p>
 </div>
 ````````````````````````````````
@@ -88,8 +88,8 @@ Can contain block elements
 -----------
 >>>
 .
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <h3>heading</h3>
 <hr />
 </div>
@@ -104,8 +104,8 @@ Ending marker can be longer
 >>>>>>>>>>>
 normal
 .
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>hello world</p>
 </div>
 <p>normal</p>
@@ -121,10 +121,10 @@ foo
 >>>>
 >>>>>
 .
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
-<div class="alert alert-caution">
-<p class="alert-title">Caution</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
+<div class="markdown-alert markdown-alert-caution">
+<p class="markdown-alert-title">Caution</p>
 <p>foo</p>
 </div>
 </div>
@@ -142,8 +142,8 @@ auto-closed blocks
 >>>>>
 >>>>
 .
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>this block is closed with 5 markers below</p>
 </div>
 <p>auto-closed blocks</p>
@@ -165,11 +165,11 @@ Marker can be indented up to 3 spaces
    >>>>
    regular paragraph
 .
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>first-level blockquote</p>
-<div class="alert alert-caution">
-<p class="alert-title">Caution</p>
+<div class="markdown-alert markdown-alert-caution">
+<p class="markdown-alert-title">Caution</p>
 <p>second-level blockquote</p>
 </div>
 </div>
@@ -200,8 +200,8 @@ the line.
       code block
   >>>
 .
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <pre><code>code block
 </code></pre>
 </div>
@@ -215,11 +215,11 @@ the line.
     >>>
    >>>>
 .
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>content</p>
-<div class="alert alert-caution">
-<p class="alert-title">Caution</p>
+<div class="markdown-alert markdown-alert-caution">
+<p class="markdown-alert-title">Caution</p>
 <pre><code>code block
 </code></pre>
 </div>
@@ -233,8 +233,8 @@ Closing marker can't have text on the same line
 foo
 >>> arg=123
 .
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>foo</p>
 <blockquote>
 <blockquote>
@@ -253,8 +253,8 @@ Alerts self-close at the end of the document
 >>> [!NOTE]
 foo
 .
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>foo</p>
 </div>
 ````````````````````````````````
@@ -269,8 +269,8 @@ content
 >>>
 .
 <p>blah blah</p>
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>content</p>
 </div>
 ````````````````````````````````
@@ -285,8 +285,8 @@ They can be nested in lists
 .
 <ul>
 <li>
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <ul>
 <li>foo</li>
 </ul>
@@ -306,8 +306,8 @@ Or in blockquotes
 > >>>
 .
 <blockquote>
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>foo</p>
 <blockquote>
 <p>bar
@@ -333,15 +333,15 @@ List indentation
 .
 <ul>
 <li>
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>foo
 bar</p>
 </div>
 </li>
 <li>
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>foo
 bar</p>
 </div>
@@ -380,8 +380,8 @@ A quote
 Some other text
 .
 <p>Some text</p>
-<div class="alert alert-note">
-<p class="alert-title">Note</p>
+<div class="markdown-alert markdown-alert-note">
+<p class="markdown-alert-title">Note</p>
 <p>A quote</p>
 </div>
 <p>Some other text</p>


### PR DESCRIPTION
Using the CSS classes `alert` and `alert-warning` can clash with other CSS frameworks, such as [Bootstrap](https://getbootstrap.com/docs/5.3/components/alerts/#examples)

GitHub uses `markdown-alert` in their output - let's align with that in order to avoid needless class collisions.