### PR TITLE
Strip trailing newlines in unhighlighted code blocks

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -582,7 +582,10 @@ where
                         let mut code_attributes: HashMap<String, String> = HashMap::new();
                         let code_attr: String;
 
-                        let literal = &ncb.literal.as_bytes();
+                        let literal = &ncb
+                            .literal
+                            .trim_end_matches(|c| c == '\r' || c == '\n')
+                            .as_bytes();
                         let info = &ncb.info.as_bytes();
 
                         if !info.is_empty() {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -699,11 +699,11 @@ pub struct ParseOptions<'c> {
     /// # use comrak::{markdown_to_html, Options};
     /// let mut options = Options::default();
     /// assert_eq!(markdown_to_html("```\nfn hello();\n```\n", &options),
-    ///            "<pre><code>fn hello();\n</code></pre>\n");
+    ///            "<pre><code>fn hello();</code></pre>\n");
     ///
     /// options.parse.default_info_string = Some("rust".into());
     /// assert_eq!(markdown_to_html("```\nfn hello();\n```\n", &options),
-    ///            "<pre><code class=\"language-rust\">fn hello();\n</code></pre>\n");
+    ///            "<pre><code class=\"language-rust\">fn hello();</code></pre>\n");
     /// ```
     pub default_info_string: Option<String>,
 
@@ -789,11 +789,11 @@ pub struct RenderOptions {
     /// # use comrak::{markdown_to_html, Options};
     /// let mut options = Options::default();
     /// assert_eq!(markdown_to_html("``` rust\nfn hello();\n```\n", &options),
-    ///            "<pre><code class=\"language-rust\">fn hello();\n</code></pre>\n");
+    ///            "<pre><code class=\"language-rust\">fn hello();</code></pre>\n");
     ///
     /// options.render.github_pre_lang = true;
     /// assert_eq!(markdown_to_html("``` rust\nfn hello();\n```\n", &options),
-    ///            "<pre lang=\"rust\"><code>fn hello();\n</code></pre>\n");
+    ///            "<pre lang=\"rust\"><code>fn hello();</code></pre>\n");
     /// ```
     #[cfg_attr(feature = "bon", builder(default))]
     pub github_pre_lang: bool,
@@ -804,7 +804,7 @@ pub struct RenderOptions {
     /// # use comrak::{markdown_to_html, Options};
     /// let mut options = Options::default();
     /// assert_eq!(markdown_to_html("``` rust extra info\nfn hello();\n```\n", &options),
-    ///            "<pre><code class=\"language-rust\">fn hello();\n</code></pre>\n");
+    ///            "<pre><code class=\"language-rust\">fn hello();</code></pre>\n");
     ///
     /// options.render.full_info_string = true;
     /// let html = markdown_to_html("``` rust extra info\nfn hello();\n```\n", &options);
@@ -1110,7 +1110,7 @@ pub struct RenderPlugins<'p> {
     /// let input = "```rust\nfn main<'a>();\n```";
     ///
     /// assert_eq!(markdown_to_html_with_plugins(input, &options, &plugins),
-    ///            "<pre><code class=\"language-rust\">fn main&lt;'a&gt;();\n</code></pre>\n");
+    ///            "<pre><code class=\"language-rust\">fn main&lt;'a&gt;();</code></pre>\n");
     ///
     /// pub struct MockAdapter {}
     /// impl SyntaxHighlighterAdapter for MockAdapter {

--- a/src/tests/core.rs
+++ b/src/tests/core.rs
@@ -32,10 +32,7 @@ fn basic() {
 fn codefence() {
     html(
         concat!("``` rust yum\n", "fn main<'a>();\n", "```\n"),
-        concat!(
-            "<pre><code class=\"language-rust\">fn main&lt;'a&gt;();\n",
-            "</code></pre>\n"
-        ),
+        concat!("<pre><code class=\"language-rust\">fn main&lt;'a&gt;();</code></pre>\n"),
     );
 }
 

--- a/src/tests/footnotes.rs
+++ b/src/tests/footnotes.rs
@@ -40,8 +40,7 @@ fn footnotes() {
             "<li id=\"fn-longnote\">\n",
             "<p>Here's one with multiple blocks.</p>\n",
             "<p>Subsequent paragraphs are indented.</p>\n",
-            "<pre><code>code\n",
-            "</code></pre>\n",
+            "<pre><code>code</code></pre>\n",
             "<a href=\"#fnref-longnote\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2\" aria-label=\"Back to reference 2\">↩</a> \
              <a href=\"#fnref-longnote-2\" class=\"footnote-backref\" data-footnote-backref data-footnote-backref-idx=\"2-2\" aria-label=\"Back to reference 2-2\">↩<sup class=\"footnote-ref\">2</sup></a>\n",
             "</li>\n",


### PR DESCRIPTION
Fixes #527.

It is possible to apply a similar fix to math code blocks, but I was unsure whether that was a correct change as I'm not using math code blocks so I have not included that change here.