### PR TITLE
Stop at first suitable $ at inline math

### DIFF
--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -647,6 +647,16 @@ impl<'a, 'r, 'o, 'd, 'i, 'c> Subject<'a, 'r, 'o, 'd, 'i, 'c> {
         self.pos - start_pos
     }
 
+    pub fn take_while_with_limit(&mut self, c: u8, limit: usize) -> usize {
+        let start_pos = self.pos;
+        let mut count = 0;
+        while count < limit && self.peek_char() == Some(&c) {
+            self.pos += 1;
+            count += 1;
+        }
+        self.pos - start_pos
+    }
+
     pub fn scan_to_closing_backtick(&mut self, openticklength: usize) -> Option<usize> {
         if openticklength > MAXBACKTICKS {
             return None;
@@ -733,7 +743,7 @@ impl<'a, 'r, 'o, 'd, 'i, 'c> Subject<'a, 'r, 'o, 'd, 'i, 'c> {
                 continue;
             }
 
-            let numdollars = self.take_while(b'$');
+            let numdollars = self.take_while_with_limit(b'$', opendollarlength);
 
             // ending $ can't be followed by a digit
             if opendollarlength == 1 && self.peek_char().map_or(false, |&c| isdigit(c)) {

--- a/src/tests/math.rs
+++ b/src/tests/math.rs
@@ -2,6 +2,11 @@ use super::*;
 use ntest::test_case;
 
 #[test_case("$2+2$", "<p><math>2+2</math></p>\n")]
+#[test_case(
+    "$\\alpha$$\\beta$",
+    "<p><math>\\alpha</math><math>\\beta</math></p>\n"
+)]
+#[test_case("$2+2$$2+2$", "<p><math>2+2</math><math>2+2</math></p>\n")]
 #[test_case("$22 and $2+2$", "<p>$22 and <math>2+2</math></p>\n")]
 #[test_case("$a!$", "<p><math>a!</math></p>\n")]
 #[test_case("$x$", "<p><math>x</math></p>\n")]


### PR DESCRIPTION
I added two failing test cases which this change attempts to fix. 

The issue originally relates to: https://gitlab.com/gitlab-org/gitlab/-/issues/431890