### PR TITLE
Support language-specific codefence renderers

### DIFF
--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -7,6 +7,17 @@ use std::io::{self, Write};
 
 use crate::nodes::Sourcepos;
 
+/// Implement this adapter for custom rendering of codefence blocks.
+pub trait CodefenceRendererAdapter: Send + Sync {
+    /// Render the codefence block.
+    fn write(
+        &self,
+        output: &mut dyn Write,
+        literal: &String,
+        sourcepos: Option<Sourcepos>,
+    ) -> io::Result<()>;
+}
+
 /// Implement this adapter for creating a plugin for custom syntax highlighting of codefence blocks.
 pub trait SyntaxHighlighterAdapter: Send + Sync {
     /// Generates a syntax highlighted HTML output.

--- a/src/html.rs
+++ b/src/html.rs
@@ -574,6 +574,23 @@ where
                 if entering {
                     if ncb.info.eq("math") {
                         self.render_math_code_block(node, &ncb.literal)?;
+                    } else if let Some(adapter) = self
+                        .plugins
+                        .render
+                        .codefence_renderers
+                        .get(&ncb.info)
+                    {
+                        self.cr()?;
+
+                        adapter.write(
+                            self.output,
+                            &ncb.literal,
+                            if self.options.render.sourcepos {
+                                Some(node.data.borrow().sourcepos)
+                            } else {
+                                None
+                            },
+                        )?;
                     } else {
                         self.cr()?;
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8,7 +8,7 @@ pub mod alert;
 pub mod math;
 pub mod multiline_block_quote;
 
-use crate::adapters::SyntaxHighlighterAdapter;
+use crate::adapters::{CodefenceRendererAdapter, SyntaxHighlighterAdapter};
 use crate::arena_tree::Node;
 use crate::ctype::{isdigit, isspace};
 use crate::entity;
@@ -1098,6 +1098,10 @@ pub struct Plugins<'p> {
 #[cfg_attr(feature = "bon", derive(Builder))]
 /// Plugins for alternative rendering.
 pub struct RenderPlugins<'p> {
+    /// Provide language-specific renderers for codefence blocks.
+    #[builder(default)]
+    pub codefence_renderers: HashMap<String, &'p dyn CodefenceRendererAdapter>,
+
     /// Provide a syntax highlighter adapter implementation for syntax
     /// highlighting of codefence blocks.
     /// ```


### PR DESCRIPTION
I was looking for a way to render [Pikchr](https://pikchr.org/) diagrams. I'm porting some code from Go where I used [goldmark](https://github.com/yuin/goldmark) and the [goldmark-pikchr](https://github.com/jchenry/goldmark-pikchr) extension which support this through fenced code blocks.

I thought of different ways to support this:

1. **Pikchr could be officially supported either generally or through a named feature.** This would solve my particular need but isn't particularly extensible.

2. **Implement [`SyntaxHighlighterAdapter`](https://docs.rs/comrak/0.35.0/comrak/adapters/trait.SyntaxHighlighterAdapter.html) and short-circuit the rendering of a particular language.** The problem with this is that you can't opt out of the closing `</code>` and `</pre>` tags:
  https://github.com/kivikakk/comrak/blob/8d30848b65354d67f5d1a945ddd24fdc1c0b15cb/src/html.rs#L644

3. **Pre-render certain [`CodeBlock`](https://docs.rs/comrak/0.35.0/comrak/nodes/enum.NodeValue.html#variant.CodeBlock) nodes to [`HtmlBlock`](https://docs.rs/comrak/0.35.0/comrak/nodes/enum.NodeValue.html#variant.HtmlBlock).** My one problem with this approach is that it ended up being more code than ideal and it didn't feel right.

4. **Allow a way to register language-specific renderers.** I liked this the best and there's even some prior art in #366:
  https://github.com/kivikakk/comrak/blob/8d30848b65354d67f5d1a945ddd24fdc1c0b15cb/src/html.rs#L575-L576

I would not be opposed to contributing Pikchr as a gated feature if it would be useful to others but I like adding the general capability to allow experimenting with it and other language-specific renderers.

Anyway, I opened this draft pull request so there's something concrete to discuss. If we agree that this is the preferred approach, I'll add tests, improve the documentation and address eventual feedback.