### PR TITLE
tests: don't let sourcepos stand in the way of roundtrip tests.

### DIFF
--- a/src/tests/fuzz.rs
+++ b/src/tests/fuzz.rs
@@ -84,6 +84,9 @@ fn trailing_hyphen_matches() {
     html_opts!(
         [extension.autolink, parse.smart, render.sourcepos],
         "3@.l--",
-        "<p data-sourcepos=\"1:1-1:6\"><a href=\"mailto:3@.l\">3@.l</a>–</p>\n"
+        "<p data-sourcepos=\"1:1-1:6\"><a href=\"mailto:3@.l\">3@.l</a>–</p>\n",
+        no_roundtrip // We serialise the link back to <3@.l>, which doesn't
+                     // parse as a classic autolink, but the email inside the
+                     // <...> does, meaning the </> get rendered!
     );
 }

--- a/src/tests/math.rs
+++ b/src/tests/math.rs
@@ -119,9 +119,6 @@ fn math_unrecognized_syntax(markdown: &str, html: &str) {
     );
 }
 
-// html_opts! does a roundtrip check unless sourcepos is set.
-// These cases don't work roundtrip, because converting to commonmark
-// automatically escapes certain characters.
 #[test_case("$`$", "<p data-sourcepos=\"1:1-1:3\">$`$</p>\n")]
 fn math_unrecognized_syntax_non_roundtrip(markdown: &str, html: &str) {
     html_opts!(
@@ -131,7 +128,8 @@ fn math_unrecognized_syntax_non_roundtrip(markdown: &str, html: &str) {
             render.sourcepos
         ],
         markdown,
-        html
+        html,
+        no_roundtrip
     );
 }
 


### PR DESCRIPTION
Just remove the sourcepos when making the roundtrip comparison. Use the actual "no_roundtrip" flag where needed --- we want to aim for as few of these as possible.