### PR TITLE
Only delete parent if the node has no siblings

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -3080,7 +3080,7 @@ where
 
         // See tests::fuzz::echaw9. The paragraph doesn't exist in the source,
         // so we remove it.
-        if sourcepos.end.column < adjust {
+        if sourcepos.end.column < adjust && node.next_sibling().is_none() {
             parent.detach();
         } else {
             sourcepos.start.column = adjust;

--- a/src/tests/tasklist.rs
+++ b/src/tests/tasklist.rs
@@ -11,7 +11,7 @@ fn tasklist() {
         concat!(
             "* [ ] Red\n",
             "* [x] Green\n",
-            "* [ ] Blue\n",
+            "* [ ] `Blue`\n",
             "* [!] Papayawhip\n",
             "<!-- end list -->\n",
             "1. [ ] Bird\n",
@@ -26,7 +26,7 @@ fn tasklist() {
             "<ul>\n",
             "<li><input type=\"checkbox\" disabled=\"\" /> Red</li>\n",
             "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Green</li>\n",
-            "<li><input type=\"checkbox\" disabled=\"\" /> Blue</li>\n",
+            "<li><input type=\"checkbox\" disabled=\"\" /> <code>Blue</code></li>\n",
             "<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> Papayawhip</li>\n",
             "</ul>\n",
             "<!-- end list -->\n",


### PR DESCRIPTION
This addresses https://github.com/kivikakk/comrak/issues/558. Fixes a problem where task list items that starts with an inline node other than text that does not render.

Example:

```
- [ ] `code`
```