### PR TITLE
Fixes header-ids accessibility

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -642,7 +642,7 @@ fn render_heading<'a, T>(
                     id = context.anchorizer.anchorize(id);
                     write!(
                         context,
-                        "<a href=\"#{}\" aria-hidden=\"true\" class=\"anchor\" id=\"{}{}\"></a>",
+                        "<a inert href=\"#{}\" aria-hidden=\"true\" class=\"anchor\" id=\"{}{}\"></a>",
                         id, prefix, id
                     )?;
                 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -308,7 +308,7 @@ pub struct ExtensionOptions<'c> {
     /// let mut options = Options::default();
     /// options.extension.header_ids = Some("user-content-".to_string());
     /// assert_eq!(markdown_to_html("# README\n", &options),
-    ///            "<h1><a href=\"#readme\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-readme\"></a>README</h1>\n");
+    ///            "<h1><a inert href=\"#readme\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-readme\"></a>README</h1>\n");
     /// ```
     pub header_ids: Option<String>,
 

--- a/src/tests/header_ids.rs
+++ b/src/tests/header_ids.rs
@@ -13,13 +13,13 @@ fn header_ids() {
             "# Isn't it grand?"
         ),
         concat!(
-            "<h1><a href=\"#hi\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi\"></a>Hi.</h1>\n",
-            "<h2><a href=\"#hi-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-1\"></a>Hi 1.</h2>\n",
-            "<h3><a href=\"#hi-2\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-2\"></a>Hi.</h3>\n",
-            "<h4><a href=\"#hello\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello\"></a>Hello.</h4>\n",
-            "<h5><a href=\"#hi-3\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-3\"></a>Hi.</h5>\n",
-            "<h6><a href=\"#hello-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello-1\"></a>Hello.</h6>\n",
-            "<h1><a href=\"#isnt-it-grand\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-isnt-it-grand\"></a>Isn't it grand?</h1>\n"
+            "<h1><a inert href=\"#hi\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi\"></a>Hi.</h1>\n",
+            "<h2><a inert href=\"#hi-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-1\"></a>Hi 1.</h2>\n",
+            "<h3><a inert href=\"#hi-2\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-2\"></a>Hi.</h3>\n",
+            "<h4><a inert href=\"#hello\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello\"></a>Hello.</h4>\n",
+            "<h5><a inert href=\"#hi-3\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-3\"></a>Hi.</h5>\n",
+            "<h6><a inert href=\"#hello-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello-1\"></a>Hello.</h6>\n",
+            "<h1><a inert href=\"#isnt-it-grand\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-isnt-it-grand\"></a>Isn't it grand?</h1>\n"
         ),
         true,
         |opts| opts.extension.header_ids = Some("user-content-".to_owned()),


### PR DESCRIPTION
Accessibiity tools can't handle the anchors generated as they retain focus, adding the [inert](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inert) prevents focus on this element and fixes this accessibility issue. Closes #573