### PR TITLE
Recursively join text nodes inside links, images, and wikilinks

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2925,7 +2925,11 @@ where
         self.postprocess_text_nodes_with_context(node, false);
     }
 
-    fn postprocess_text_nodes_with_context(&mut self, node: &'a AstNode<'a>, in_bracket_context: bool) {
+    fn postprocess_text_nodes_with_context(
+        &mut self,
+        node: &'a AstNode<'a>,
+        in_bracket_context: bool,
+    ) {
         let mut stack = vec![(node, in_bracket_context)];
         let mut children = vec![];
 
@@ -2958,7 +2962,13 @@ where
                             }
                         }
 
-                        self.postprocess_text_node_with_context(n, root, &mut sourcepos, spxv, in_bracket_context);
+                        self.postprocess_text_node_with_context(
+                            n,
+                            root,
+                            &mut sourcepos,
+                            spxv,
+                            in_bracket_context,
+                        );
                         emptied = root.is_empty();
                     }
                     NodeValue::Link(..) | NodeValue::Image(..) | NodeValue::WikiLink(..) => {

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -446,3 +446,67 @@ fn autolink_consecutive_email_smart() {
         ])
     );
 }
+
+#[test]
+fn autolink_not_generated_inside_links() {
+    html_opts!(
+        [extension.autolink],
+        "[Contact user@example.com for help](http://support.example.com)",
+        "<p><a href=\"http://support.example.com\">Contact user@example.com for help</a></p>\n",
+    );
+
+    html_opts!(
+        [extension.autolink],
+        "[Visit https://www.example.com](http://example.com)",
+        "<p><a href=\"http://example.com\">Visit https://www.example.com</a></p>\n",
+    );
+
+    html_opts!(
+        [extension.autolink],
+        "[Check out www.example.com](http://example.com)",
+        "<p><a href=\"http://example.com\">Check out www.example.com</a></p>\n",
+    );
+}
+
+#[test]
+fn autolink_not_generated_inside_images() {
+    // Test that emails inside image alt text don't become autolinks
+    html_opts!(
+        [extension.autolink],
+        "![Contact user@example.com](image.png)",
+        "<p><img src=\"image.png\" alt=\"Contact user@example.com\" /></p>\n",
+    );
+
+    html_opts!(
+        [extension.autolink],
+        "![Visit https://www.example.com](image.png)",
+        "<p><img src=\"image.png\" alt=\"Visit https://www.example.com\" /></p>\n",
+    );
+
+    html_opts!(
+        [extension.autolink],
+        "![Check www.example.com](image.png)",
+        "<p><img src=\"image.png\" alt=\"Check www.example.com\" /></p>\n",
+    );
+}
+
+#[test]
+fn autolink_not_generated_inside_wikilinks() {
+    html_opts!(
+        [extension.autolink, extension.wikilinks_title_after_pipe],
+        "[[http://example.com|Contact user@example.com]]",
+        "<p><a href=\"http://example.com\" data-wikilink=\"true\">Contact user@example.com</a></p>\n",
+    );
+
+    html_opts!(
+        [extension.autolink, extension.wikilinks_title_after_pipe],
+        "[[http://example.com|Visit https://www.example.com]]",
+        "<p><a href=\"http://example.com\" data-wikilink=\"true\">Visit https://www.example.com</a></p>\n",
+    );
+
+    html_opts!(
+        [extension.autolink, extension.wikilinks_title_before_pipe],
+        "[[Check www.example.com|http://example.com]]",
+        "<p><a href=\"http://example.com\" data-wikilink=\"true\">Check www.example.com</a></p>\n",
+    );
+}

--- a/src/tests/wikilinks.rs
+++ b/src/tests/wikilinks.rs
@@ -246,9 +246,7 @@ fn sourcepos() {
             (paragraph (1:1-1:44) [
                 (text (1:1-1:5) "This ")
                 (wikilink (1:6-1:39) [
-                    (text (1:8-1:11) "link")
-                    (text (1:12-1:13) "[")
-                    (text (1:14-1:18) "label")
+                    (text (1:8-1:18) "link[label")
                 ])
                 (text (1:40-1:44) " that")
             ])


### PR DESCRIPTION
Previously link, image, and wikilink nodes were not recursively parsed to join text nodes. This change adds `in_bracket_context` to recursively join text nodes but avoids generating nested autolinks.

Related: https://github.com/gjtorikian/commonmarker/issues/376