### PR TITLE
Add CJK friendly emphasis to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Comrak additionally supports its own extensions, which are yet to be specced out
 - Underline
 - Spoiler text
 - "Greentext"
+- [CJK friendly emphasis](https://github.com/tats-u/markdown-cjk-friendly)
 
 By default none are enabled; they are individually enabled with each parse by setting the appropriate values in the
 [`ExtensionOptions` struct](https://docs.rs/comrak/latest/comrak/struct.ExtensionOptions.html).


### PR DESCRIPTION
Follow up of #582

Forgot to mention CJK friendly emphasis in README

You can merge this just before a next minor release