### PR TITLE
Fix the range of non-emoji general purpose variation selector

### DIFF
--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -114,7 +114,7 @@ impl FlankingCheckHelper for char {
 
     #[inline]
     fn is_non_emoji_general_purpose_vs(&self) -> bool {
-        matches!(u32::from(*self), 0xFE00..=0xFE0F)
+        matches!(u32::from(*self), 0xFE00..=0xFE0E)
     }
 
     #[inline]


### PR DESCRIPTION
I found a porting error in CJK friendly emphasis.

https://github.com/tats-u/markdown-cjk-friendly/blob/main/ranges.md#non-emoji-general-use-variation-selectors

> Non-emoji General-use Variation Selectors
>
> - U+FE00..U+FE0E

vs 

```rs
    fn is_non_emoji_general_purpose_vs(&self) -> bool {
        matches!(u32::from(*self), 0xFE00..=0xFE0F)
    }
```

U+FE0F is treated as a _non-emoji_ one even though it is an _emoji_ one.