### PR TITLE
cm::escape_link_destination: add function to escape URL for use as link destination.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,7 @@ dependencies = [
  "entities",
  "memchr",
  "ntest",
+ "percent-encoding-rfc3986",
  "shell-words",
  "slug",
  "strum",
@@ -485,6 +486,12 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "percent-encoding-rfc3986"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3637c05577168127568a64e9dc5a6887da720efef07b3d9472d45f63ab191166"
 
 [[package]]
 name = "phf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ caseless = "0.2.1"
 
 [dev-dependencies]
 ntest = "0.9"
+percent-encoding-rfc3986 = "0.1.3"
 strum = { version = "0.26.3", features = ["derive"] }
 toml = "0.7.3"
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,9 @@ New APIs:
 * `cm::escape_inline` (aliased at crate level as `escape_commonmark_inline`)
   is added; escapes input text suitable for inclusion in a CommonMark document
   where regular inline processing takes place.
+* `cm::escape_link_destination` (aliased at crate level as
+  `escape_commonmark_link_destination`) is added; escapes input URL suitable for
+  use as a link destination in a CommonMark document.
 
 Changed APIs:
 

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -1083,3 +1083,27 @@ pub fn escape_inline(text: &str) -> String {
 
     result
 }
+
+/// Escapes the input URL, rendering it suitable for inclusion as a [link
+/// destination] per the CommonMark spec.
+///
+/// [link destination]: https://spec.commonmark.org/0.31.2/#link-destination
+pub fn escape_link_destination(url: &str) -> String {
+    let mut result = String::with_capacity(url.len() * 3 / 2);
+
+    result.push('<');
+    for c in url.chars() {
+        match c {
+            '<' | '>' => {
+                result.push('\\');
+                result.push(c);
+            }
+            '\n' => result.push_str("%0A"),
+            '\r' => result.push_str("%0D"),
+            _ => result.push(c),
+        }
+    }
+    result.push('>');
+
+    result
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ mod tests;
 mod xml;
 
 pub use cm::escape_inline as escape_commonmark_inline;
+pub use cm::escape_link_destination as escape_commonmark_link_destination;
 pub use cm::format_document as format_commonmark;
 pub use cm::format_document_with_plugins as format_commonmark_with_plugins;
 pub use html::format_document as format_html;

--- a/src/tests/escape.rs
+++ b/src/tests/escape.rs
@@ -1,7 +1,8 @@
-use crate::{cm::escape_inline, entity, markdown_to_html, Options};
+use crate::cm::{escape_inline, escape_link_destination};
+use crate::{entity, markdown_to_html, Options};
 
-/// Assert that the input escapes to the expected result, and that the expected
-/// result renders to HTML which displays the input text.
+/// Assert that the input text escapes to the expected result in inline context,
+/// and that the expected result renders to HTML which displays the input text.
 #[track_caller]
 fn assert_escape_inline(input: &str, expected: &str) {
     let actual = escape_inline(input);
@@ -35,25 +36,34 @@ fn escape_inline_baseline() {
     );
 }
 
-/// Assert a suitable method to escape [link destination]s.
+/// Assert that the URL is escaped as expected, and that the result is rendered
+/// into HTML in such a way that preserves the meaning of the input.
 ///
 /// [link destination]: https://spec.commonmark.org/0.31.2/#link-destination
 #[test]
 fn escape_link_target() {
     let url = "rabbits) <cup\rcakes\n> [hyacinth](";
-    let escaped = format!(
-        "<{}>",
-        url.replace("<", "\\<")
-            .replace(">", "\\>")
-            .replace("\n", "%0A")
-            .replace("\r", "%0D")
-    );
+    let escaped = r#"<rabbits) \<cup%0Dcakes%0A\> [hyacinth](>"#;
 
-    let md = format!("A [link]({escaped}).");
-    let html = markdown_to_html(&md, &Options::default());
+    assert_eq!(escaped, escape_link_destination(url));
 
+    let md = format!("[link]({escaped})");
+    let mut html = markdown_to_html(&md, &Options::default());
+    html = html
+        .strip_prefix("<p><a href=\"")
+        .expect("html should be one anchor in a paragraph")
+        .to_string();
+    html = html
+        .strip_suffix("\">link</a></p>\n")
+        .expect("html should be one anchor in a paragraph")
+        .to_string();
+
+    assert_eq!("rabbits)%20%3Ccup%0Dcakes%0A%3E%20%5Bhyacinth%5D(", html);
     assert_eq!(
-        "<p>A <a href=\"rabbits)%20%3Ccup%0Dcakes%0A%3E%20%5Bhyacinth%5D(\">link</a>.</p>\n",
-        html
+        url,
+        percent_encoding_rfc3986::percent_decode_str(&html)
+            .unwrap()
+            .decode_utf8()
+            .unwrap()
     );
 }

--- a/src/tests/escape.rs
+++ b/src/tests/escape.rs
@@ -34,3 +34,26 @@ fn escape_inline_baseline() {
         r#"some \<\"complicated\"\> \& '/problematic\\' input"#,
     );
 }
+
+/// Assert a suitable method to escape [link destination]s.
+///
+/// [link destination]: https://spec.commonmark.org/0.31.2/#link-destination
+#[test]
+fn escape_link_target() {
+    let url = "rabbits) <cup\rcakes\n> [hyacinth](";
+    let escaped = format!(
+        "<{}>",
+        url.replace("<", "\\<")
+            .replace(">", "\\>")
+            .replace("\n", "%0A")
+            .replace("\r", "%0D")
+    );
+
+    let md = format!("A [link]({escaped}).");
+    let html = markdown_to_html(&md, &Options::default());
+
+    assert_eq!(
+        "<p>A <a href=\"rabbits)%20%3Ccup%0Dcakes%0A%3E%20%5Bhyacinth%5D(\">link</a>.</p>\n",
+        html
+    );
+}


### PR DESCRIPTION
Add a method that takes a URL and returns something suitable for use directly as the [link destination] in a CommonMark document.

[link destination]: https://spec.commonmark.org/0.31.2/#link-destination