### PR TITLE
Add CJK Friendly Emphasis to CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Options:
           [possible values: strikethrough, tagfilter, table, autolink, tasklist, superscript,
           footnotes, description-lists, multiline-block-quotes, math-dollars, math-code,
           wikilinks-title-after-pipe, wikilinks-title-before-pipe, underline, subscript, spoiler,
-          greentext, alerts]
+          greentext, alerts, cjk-friendly-emphasis]
 
   -t, --to <FORMAT>
           Specify output format

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,6 +188,7 @@ enum Extension {
     Spoiler,
     Greentext,
     Alerts,
+    CjkFriendlyEmphasis,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -273,7 +274,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .spoiler(exts.contains(&Extension::Spoiler))
         .greentext(exts.contains(&Extension::Greentext))
         .alerts(exts.contains(&Extension::Alerts))
-        .maybe_front_matter_delimiter(cli.front_matter_delimiter);
+        .maybe_front_matter_delimiter(cli.front_matter_delimiter)
+        .cjk_friendly_emphasis(exts.contains(&Extension::CjkFriendlyEmphasis));
 
     #[cfg(feature = "shortcodes")]
     let extension = extension.shortcodes(cli.gemojis);


### PR DESCRIPTION
I have forgot to add this as a CLI option.
