### PR TITLE
fix: Incorrect `sourcepos` for escaped character spans

### DIFF
--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -392,7 +392,7 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
 
             let inline_text = self.make_inline(
                 NodeValue::Text(self.input[self.pos - 1..self.pos].to_string().into()),
-                self.pos - 2,
+                self.pos - 1,
                 self.pos - 1,
             );
 

--- a/src/tests/escaped_char_spans.rs
+++ b/src/tests/escaped_char_spans.rs
@@ -12,3 +12,24 @@ fn escaped_char_spans(markdown: &str, html: &str) {
 fn disabled_escaped_char_spans(markdown: &str, expected: &str) {
     html(markdown, expected);
 }
+
+#[test]
+fn escaped_char_span_sourcepos() {
+    assert_ast_match!(
+        [render.escaped_char_spans],
+        "Test \\`hello world\\` here.",
+        (document (1:1-1:26) [
+            (paragraph (1:1-1:26) [
+                (text (1:1-1:5) "Test ")
+                (escaped (1:6-1:7) [
+                    (text (1:7-1:7) "`")
+                ])
+                (text (1:8-1:18) "hello world")
+                (escaped (1:19-1:20) [
+                    (text (1:20-1:20) "`")
+                ])
+                (text (1:21-1:26) " here.")
+            ])
+        ])
+    );
+}

--- a/src/tests/sourcepos.rs
+++ b/src/tests/sourcepos.rs
@@ -246,7 +246,12 @@ const TEXT: TestCase = (
         sourcepos!((11:3-11:8)),
         sourcepos!((12:3-12:9)),
         sourcepos!((12:12-12:15)),
-        sourcepos!((14:7-14:14)),
+        sourcepos!((14:1-14:5)),
+        sourcepos!((14:7-14:7)),
+        sourcepos!((14:8-14:18)),
+        sourcepos!((14:20-14:20)),
+        sourcepos!((14:21-14:26)),
+        sourcepos!((16:7-16:14)),
     ],
     r#"stuff before
 
@@ -260,6 +265,8 @@ hello world
 
 - item 1[^1]
 - item 2 **bold**
+
+Test \`hello world\` here.
 
 [^1]: The end.
 "#,


### PR DESCRIPTION
This PR fixes the incorrect source position tracking for escaped characters and updates related tests to reflect these changes.

Fixes #562 