### PR TITLE
fix: Incorrect table `sourcepos` affected by spaces in preceding paragraph

### DIFF
--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -317,6 +317,7 @@ fn try_inserting_table_header_paragraph<'a>(
             .count();
 
     container_ast.sourcepos.start.line += newlines;
+    container_ast.sourcepos.start.column = container_ast.line_offsets[newlines] + 1;
 
     paragraph.content = paragraph_content;
     let node = parser.arena.alloc(paragraph.into());

--- a/src/tests/table.rs
+++ b/src/tests/table.rs
@@ -144,7 +144,7 @@ fn nested_tables_3() {
 }
 
 #[test]
-fn sourcepos_with_preceding_para() {
+fn sourcepos_with_preceding_para_no_spaces() {
     assert_ast_match!(
         [extension.table],
         "123\n"
@@ -182,7 +182,83 @@ fn sourcepos_with_preceding_para() {
 }
 
 #[test]
-fn sourcepos_with_preceding_para_offset() {
+fn sourcepos_with_preceding_para_spaces_before_table() {
+    assert_ast_match!(
+        [extension.table],
+        "123\n"
+        "456\n"
+        " | a | b |\n"
+        " | - | - |\n"
+        " | c | d |\n"
+        ,
+        (document (1:1-5:10) [
+            (paragraph (1:1-2:3) [
+                (text (1:1-1:3) "123")
+                (softbreak (1:4-1:4))
+                (text (2:1-2:3) "456")
+            ])
+            (table (3:2-5:10) [
+                (table_row (3:2-3:10) [
+                    (table_cell (3:3-3:5) [
+                        (text (3:4-3:4) "a")
+                    ])
+                    (table_cell (3:7-3:9) [
+                        (text (3:8-3:8) "b")
+                    ])
+                ])
+                (table_row (5:2-5:10) [
+                    (table_cell (5:3-5:5) [
+                        (text (5:4-5:4) "c")
+                    ])
+                    (table_cell (5:7-5:9) [
+                        (text (5:8-5:8) "d")
+                    ])
+                ])
+            ])
+        ])
+    );
+}
+
+#[test]
+fn sourcepos_with_preceding_para_spaces_before_para() {
+    assert_ast_match!(
+        [extension.table],
+        " 123\n"
+        "  456\n"
+        "| a | b |\n"
+        "| - | - |\n"
+        "| c | d |\n"
+        ,
+        (document (1:1-5:9) [
+            (paragraph (1:2-2:5) [
+                (text (1:2-1:4) "123")
+                (softbreak (1:5-1:5))
+                (text (2:3-2:5) "456")
+            ])
+            (table (3:1-5:9) [
+                (table_row (3:1-3:9) [
+                    (table_cell (3:2-3:4) [
+                        (text (3:3-3:3) "a")
+                    ])
+                    (table_cell (3:6-3:8) [
+                        (text (3:7-3:7) "b")
+                    ])
+                ])
+                (table_row (5:1-5:9) [
+                    (table_cell (5:2-5:4) [
+                        (text (5:3-5:3) "c")
+                    ])
+                    (table_cell (5:6-5:8) [
+                        (text (5:7-5:7) "d")
+                    ])
+                ])
+            ])
+        ])
+    );
+}
+
+#[test]
+fn sourcepos_with_preceding_para_spaces_before_both() {
     assert_ast_match!(
         [extension.table],
         " 123\n"


### PR DESCRIPTION
This PR fixes incorrect table, tr, th and td `sourcepos` when the paragraph just above the table started with spaces.

Originally, when a paragraph preceding a table contained leading spaces/newlines, the parser updated the paragraph node but didn't update the container's start column. The table node later used that stale column, producing incorrect source positions.

Fixes #591 