### PR TITLE
feat: Add `closed` property to NodeHeading

### DIFF
--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -418,6 +418,10 @@ pub struct NodeHeading {
 
     /// Whether the heading is setext (if not, ATX).
     pub setext: bool,
+
+    /// Whether this ATX heading had a closing sequence of trailing hashes.
+    /// Only meaningful for ATX headings (i.e. when `setext` is false).
+    pub closed: bool,
 }
 
 /// The metadata of an included HTML block.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -820,6 +820,7 @@ where
         container_ast.value = NodeValue::Heading(NodeHeading {
             level,
             setext: false,
+            closed: false,
         });
 
         true
@@ -928,6 +929,7 @@ where
                     scanners::SetextChar::Hyphen => 2,
                 },
                 setext: true,
+                closed: false,
             });
             let adv = line.len() - 1 - self.offset;
             self.advance_offset(line, adv, false);
@@ -1452,9 +1454,11 @@ where
                         // do nothing
                     } else if container.data().value.accepts_lines() {
                         let mut line = line;
-                        if let NodeValue::Heading(ref nh) = container.data().value {
+                        if let NodeValue::Heading(ref mut nh) = container.data_mut().value {
                             if !nh.setext {
-                                line = strings::chop_trailing_hashes(line);
+                                let (new_line, closed) = strings::chop_trailing_hashes(line);
+                                line = new_line;
+                                nh.closed = closed;
                             }
                         };
                         let count = self.first_nonspace - self.offset;

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -160,7 +160,11 @@ pub fn is_space_or_tab(ch: u8) -> bool {
     matches!(ch, 9 | 32)
 }
 
-pub fn chop_trailing_hashes(mut line: &str) -> &str {
+/// Chop any trailing sequence of `#` characters from an ATX heading line.
+///
+/// Returns the possibly-chopped line and a boolean indicating whether
+/// trailing hashes were removed (i.e. the heading had a closing sequence).
+pub fn chop_trailing_hashes(mut line: &str) -> (&str, bool) {
     line = rtrim_slice(line);
 
     let orig_n = line.len() - 1;
@@ -169,15 +173,15 @@ pub fn chop_trailing_hashes(mut line: &str) -> &str {
     let bytes = line.as_bytes();
     while bytes[n] == b'#' {
         if n == 0 {
-            return line;
+            return (line, false);
         }
         n -= 1;
     }
 
     if n != orig_n && is_space_or_tab(bytes[n]) {
-        rtrim_slice(&line[..n])
+        (rtrim_slice(&line[..n]), true)
     } else {
-        line
+        (line, false)
     }
 }
 

--- a/src/tests/sourcepos.rs
+++ b/src/tests/sourcepos.rs
@@ -150,12 +150,14 @@ hello world
 );
 
 const HEADING: TestCase = (
-    &[sourcepos!((5:1-5:13))],
+    &[sourcepos!((5:1-5:13)), sourcepos!((7:1-7:16))],
     r#"---
 a: b
 ---
 
 # Hello World
+
+# Test heading #
 
 hello world
 "#,


### PR DESCRIPTION
This PR adds tracking of whether an ATX heading is "closed" with a trailing sequence of hashes, as specified in the CommonMark spec.

Closes #422 