### PR TITLE
fix: Incorrect `sourcepos` for lists and its children

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -604,10 +604,15 @@ where
     // and, where a node's end column is zero, attempt to adopt a
     // non-zero end column from its deepest-last descendant; otherwise
     // fall back to the node's start position.
-    fn fix_zero_end_columns(&mut self, container: Node<'a>) {
+    // Returns a candidate end position for `container` if found.
+    fn fix_zero_end_columns(&mut self, container: Node<'a>) -> Option<nodes::LineColumn> {
         // explicit stack for post-order traversal: (node, visited)
         let mut stack: Vec<(Node<'a>, bool)> = Vec::new();
-        for ch in container.children() {
+
+        // Collect children first to avoid holding an iterator borrow on
+        // the container while we later may need to mutably borrow it.
+        let children: Vec<_> = container.children().collect();
+        for ch in children {
             stack.push((ch, false));
 
             while let Some((node, visited)) = stack.pop() {
@@ -636,6 +641,21 @@ where
                 }
             }
         }
+
+        // Compute a candidate end position for the container by looking
+        // at its deepest-last descendant. Return it only if it has a
+        // non-zero column; the caller can fall back to the container's
+        // start position if desired.
+        if let Some(mut last_desc) = container.last_child() {
+            while let Some(ld) = last_desc.last_child() {
+                last_desc = ld;
+            }
+            let last_end = last_desc.data().sourcepos.end;
+            if last_end.column != 0 {
+                return Some(last_end);
+            }
+        }
+        None
     }
 
     /////////////////////
@@ -1664,6 +1684,9 @@ where
                 mem::swap(&mut nhb.literal, content);
             }
             NodeValue::List(ref mut nl) => {
+                if let Some(candidate_end) = self.fix_zero_end_columns(node) {
+                    ast.sourcepos.end = candidate_end;
+                }
                 nl.tight = self.determine_list_tight(node);
             }
             _ => (),

--- a/src/tests/sourcepos.rs
+++ b/src/tests/sourcepos.rs
@@ -439,11 +439,7 @@ fn node_values() -> HashMap<NodeValueDiscriminants, TestCase> {
         .filter(|v| {
             !matches!(
                 v,
-                // Remove buggy variants.
-                List // end is 3:0
-                    | Item // end is 3:0
-                    | TaskItem // end is 4:0
-                    | Raw // unparseable
+                Raw // unparseable
             )
         })
         .filter_map(|v| {

--- a/src/tests/tasklist.rs
+++ b/src/tests/tasklist.rs
@@ -338,6 +338,133 @@ fn sourcepos() {
         ])
     );
 
+    // https://github.github.com/gfm/#example-279
+    assert_ast_match!(
+        [extension.tasklist],
+        "- [ ] item\n",
+        (document (1:1-1:10) [
+            (list (1:1-1:10) [
+                (taskitem (1:1-1:10) [
+                    (paragraph (1:7-1:10) [
+                        (text (1:7-1:10) "item")
+                    ])
+                ])
+            ])
+        ])
+    );
+
+    assert_ast_match!(
+        [extension.tasklist],
+        "- [ ] item\n"
+        "- [x] item2\n",
+        (document (1:1-2:11) [
+            (list (1:1-2:11) [
+                (taskitem (1:1-1:10) [
+                    (paragraph (1:7-1:10) [
+                        (text (1:7-1:10) "item")
+                    ])
+                ])
+                (taskitem (2:1-2:11) [
+                    (paragraph (2:7-2:11) [
+                        (text (2:7-2:11) "item2")
+                    ])
+                ])
+            ])
+        ])
+    );
+
+    // https://github.github.com/gfm/#example-280
+    assert_ast_match!(
+        [extension.tasklist],
+        "- [x] item\n"
+        "  - [ ] item2\n"
+        "  - [x] item3\n"
+        "- [ ] item4\n",
+        (document (1:1-4:11) [
+            (list (1:1-4:11) [
+                (taskitem (1:1-3:13) [
+                    (paragraph (1:7-1:10) [
+                        (text (1:7-1:10) "item")
+                    ])
+                    (list (2:3-3:13) [
+                        (taskitem (2:3-2:13) [
+                            (paragraph (2:9-2:13) [
+                                (text (2:9-2:13) "item2")
+                            ])
+                        ])
+                        (taskitem (3:3-3:13) [
+                            (paragraph (3:9-3:13) [
+                                (text (3:9-3:13) "item3")
+                            ])
+                        ])
+                    ])
+                ])
+                (taskitem (4:1-4:11) [
+                    (paragraph (4:7-4:11) [
+                        (text (4:7-4:11) "item4")
+                    ])
+                ])
+            ])
+        ])
+    );
+
+    assert_ast_match!(
+        [extension.tasklist],
+        "- [ ] bullet point one\n"
+        "- bullet point two and some extra text\n"
+        "- [x] bullet point three\n",
+        (document (1:1-3:24) [
+            (list (1:1-3:24) [
+                (taskitem (1:1-1:22) [
+                    (paragraph (1:7-1:22) [
+                        (text (1:7-1:22) "bullet point one")
+                    ])
+                ])
+                (item (2:1-2:38) [
+                    (paragraph (2:3-2:38) [
+                        (text (2:3-2:38) "bullet point two and some extra text")
+                    ])
+                ])
+                (taskitem (3:1-3:24) [
+                    (paragraph (3:7-3:24) [
+                        (text (3:7-3:24) "bullet point three")
+                    ])
+                ])
+            ])
+        ])
+    );
+
+    assert_ast_match!(
+        [extension.tasklist],
+        "- [ ] bullet point one\n"
+        "- bullet point two and some extra text\n"
+        "- [x] bullet point three\n"
+        "\n"
+        "hello world\n",
+        (document (1:1-5:11) [
+            (list (1:1-3:24) [
+                (taskitem (1:1-1:22) [
+                    (paragraph (1:7-1:22) [
+                        (text (1:7-1:22) "bullet point one")
+                    ])
+                ])
+                (item (2:1-2:38) [
+                    (paragraph (2:3-2:38) [
+                        (text (2:3-2:38) "bullet point two and some extra text")
+                    ])
+                ])
+                (taskitem (3:1-3:24) [
+                    (paragraph (3:7-3:24) [
+                        (text (3:7-3:24) "bullet point three")
+                    ])
+                ])
+            ])
+            (paragraph (5:1-5:11) [
+                (text (5:1-5:11) "hello world")
+            ])
+        ])
+    );
+
     assert_ast_match!(
         [extension.tasklist],
         "h\n"


### PR DESCRIPTION
This PR fixes incorrect `sourcepos` for lists, items and taskitems.

Fixes #541 (all other incorrect `sourcepos` values were fixed by previous PRs) 🚀