### PR TITLE
failing test case for commonmark output with Escaped nodes.

### DIFF
--- a/src/tests/core.rs
+++ b/src/tests/core.rs
@@ -514,6 +514,22 @@ fn entities() {
 }
 
 #[test]
+fn entities_ecs() {
+    html_opts!(
+        [parse.escaped_char_spans],
+        concat!(
+            "This is &amp;, &copy;, &trade;, \\&trade;, &xyz;, &NotEqualTilde;.\n",
+            "\n",
+            "&#8734; &#x221e;\n"
+        ),
+        concat!(
+            "<p>This is &amp;, ©, ™, &amp;trade;, &amp;xyz;, \u{2242}\u{338}.</p>\n",
+            "<p>∞ ∞</p>\n"
+        ),
+    );
+}
+
+#[test]
 fn links() {
     html(
         concat!(


### PR DESCRIPTION
In an input sequence like `\&trade;`, with `Escaped` nodes left in (where a user asks for them to be), the CommonMark formatter can't see that `&` is followed by alpha (since the `&` is in an isolated node), so it doesn't think it needs escaping.

I've given this a few tries, but obvious solutions are not as easy as one would think.