### PR TITLE
remove space before fenced codeblock info string.

### DIFF
--- a/src/cm.rs
+++ b/src/cm.rs
@@ -694,7 +694,6 @@ impl<'a, 'o, 'c, 'w> CommonMarkFormatter<'a, 'o, 'c, 'w> {
                 write!(self, "{}", fence_byte as char)?;
             }
             if !info.is_empty() {
-                write!(self, " ")?;
                 self.write_str(&ncb.info)?;
             }
             self.cr();

--- a/src/tests/commonmark.rs
+++ b/src/tests/commonmark.rs
@@ -58,7 +58,7 @@ fn commonmark_renders_single_list_item() {
 
 #[test_case("$$x^2$$ and $1 + 2$ and $`y^2`$", "$$x^2$$ and $1 + 2$ and $`y^2`$\n")]
 #[test_case("$$\nx^2\n$$", "$$\nx^2\n$$\n")]
-#[test_case("```math\nx^2\n```", "``` math\nx^2\n```\n")]
+#[test_case("```math\nx^2\n```", "```math\nx^2\n```\n")]
 fn commonmark_math(markdown: &str, cm: &str) {
     let mut options = Options::default();
     options.extension.math_dollars = true;


### PR DESCRIPTION
Fixes #685. There's no reason for us to do this; we had copied the reference implementation, but I think it's nicer not to include the space.