### PR TITLE
write out %25 in hrefs where not part of a percent-encode sequence.

### DIFF
--- a/src/tests/escape.rs
+++ b/src/tests/escape.rs
@@ -39,8 +39,9 @@ fn escape_inline_baseline() {
 /// [link destination]: https://spec.commonmark.org/0.31.2/#link-destination
 #[test]
 fn escape_link_target() {
-    let url = "rabbits) <cup\rcakes\n> [hyacinth](";
-    let escaped = r#"<rabbits) \<cup%0Dcakes%0A\> [hyacinth](>"#;
+    let url = "rabbits) <cup\rcakes\n> [%7Bhya%cinth%7d](";
+    let escaped = r#"<rabbits) \<cup%0Dcakes%0A\> [%7Bhya%cinth%7d](>"#;
+    let decoded = "rabbits) <cup\rcakes\n> [{hya%cinth}](";
 
     assert_eq!(escaped, escape_link_destination(url));
 
@@ -55,9 +56,12 @@ fn escape_link_target() {
         .expect("html should be one anchor in a paragraph")
         .to_string();
 
-    assert_eq!("rabbits)%20%3Ccup%0Dcakes%0A%3E%20%5Bhyacinth%5D(", html);
     assert_eq!(
-        url,
+        "rabbits)%20%3Ccup%0Dcakes%0A%3E%20%5B%7Bhya%25cinth%7d%5D(",
+        html
+    );
+    assert_eq!(
+        decoded,
         percent_encoding_rfc3986::percent_decode_str(&html)
             .unwrap()
             .decode_utf8()


### PR DESCRIPTION
This doesn't change how such URIs are interpreted by browsers: if a `%` isn't followed by two hexdigits, it's treated as the character `%`. If it is, it's treated as a percent-encoded sequence.

This PR makes Comrak's output a little more regular: we explicitly output `%25` where it isn't part of a percent-encode sequence. There is no effect on how any output is actually interpreted; before something like `%%20` would get written out as `%%20` and interpreted as the character `%` followed by a space; now it's written out as `%25%20`, which encodes the character `%` followed by a space.