### PR TITLE
Clean up find_special_char logic for inlines

### DIFF
--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -1911,9 +1911,7 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
         let input = &self.input.as_bytes()[self.scanner.pos..];
         let index = input
             .iter()
-            .enumerate()
-            .find(|(_n, &value)| self.is_special_char(value))
-            .map(|(n, _value)| n)
+            .position(|&value| self.is_special_char(value))
             .unwrap_or(input.len());
 
         self.scanner.pos + index


### PR DESCRIPTION
The logic in this function was getting a bit unwieldy, so it's tidied up in this change by separating the logic for what counts as a special char from how to find it. It also unnests the conditionals and removes the need to constantly index into the input array.