### PR TITLE
Add byte_matches helper to simplify get/map_or chaining tests in parser

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -381,9 +381,7 @@ where
     fn parse_block_quote_prefix(&mut self, line: &str) -> bool {
         let bytes = line.as_bytes();
         let indent = self.indent;
-        if indent <= 3
-            && bytes.get(self.first_nonspace) == Some(&b'>')
-            && self.is_not_greentext(line)
+        if indent <= 3 && bytes.get(self.first_nonspace) == Some(&b'>') && !self.is_greentext(line)
         {
             self.advance_offset(line, indent + 1, true);
 
@@ -397,13 +395,16 @@ where
         false
     }
 
-    fn is_not_greentext(&self, line: &str) -> bool {
-        !self.options.extension.greentext
-            || byte_matches(
-                line.as_bytes(),
-                self.first_nonspace + 1,
-                strings::is_space_or_tab,
-            )
+    fn is_greentext(&self, line: &str) -> bool {
+        if !self.options.extension.greentext {
+            return false;
+        }
+
+        !byte_matches(
+            line.as_bytes(),
+            self.first_nonspace + 1,
+            strings::is_space_or_tab,
+        )
     }
 
     fn parse_node_item_prefix(&mut self, line: &str, container: Node<'a>, nl: &NodeList) -> bool {
@@ -767,7 +768,7 @@ where
     }
 
     fn detect_blockquote(&self, line: &str) -> bool {
-        line.as_bytes().get(self.first_nonspace) == Some(&b'>') && self.is_not_greentext(line)
+        line.as_bytes().get(self.first_nonspace) == Some(&b'>') && !self.is_greentext(line)
     }
 
     fn handle_atx_heading(&mut self, container: &mut Node<'a>, line: &str) -> bool {

--- a/src/tests/greentext.rs
+++ b/src/tests/greentext.rs
@@ -10,6 +10,11 @@ fn greentext_preserved() {
 }
 
 #[test]
+fn empty_line() {
+    html_opts!([extension.greentext], ">", "<p>&gt;</p>\n");
+}
+
+#[test]
 fn separate_quotes_on_line_end() {
     html_opts!(
         [extension.greentext],


### PR DESCRIPTION
This is a really common pattern, used in a bunch of places, so I centralized the definition to try to help with verbosity. Not sure about the impact there.

Also flipped the greentext checks for better readability since they use the pattern (the function name was negated).