### PR TITLE
chore: apply clippy suggestions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -16,7 +16,7 @@ fn main() {
     // Sort it for binary search.
     let mut translated_entities = ENTITIES
         .iter()
-        .filter(|e| e.entity.starts_with("&") && e.entity.ends_with(";"))
+        .filter(|e| e.entity.starts_with('&') && e.entity.ends_with(';'))
         .map(|e| (&e.entity[1..e.entity.len() - 1], e.characters))
         .collect::<Vec<_>>();
     translated_entities.sort_by_key(|(entity, _characters)| *entity);

--- a/examples/custom_formatter_alt_text.rs
+++ b/examples/custom_formatter_alt_text.rs
@@ -6,10 +6,10 @@
 use comrak::nodes::{Node, NodeLink, NodeValue};
 use comrak::{parse_document, Arena};
 
-fn autotitle_images<'a>(
+fn autotitle_images(
     nl: &mut NodeLink,
     _context: &mut comrak::html::Context,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) {
     if !entering || !nl.title.is_empty() {

--- a/examples/s-expr.rs
+++ b/examples/s-expr.rs
@@ -21,7 +21,7 @@ use std::io::{self, BufWriter, Read, Write};
 use comrak::nodes::{Node, NodeValue};
 use comrak::{options, parse_document, Arena, Options};
 
-fn iter_nodes<'a, W: Write>(node: Node<'a>, writer: &mut W, indent: usize) -> io::Result<()> {
+fn iter_nodes<W: Write>(node: Node<'_>, writer: &mut W, indent: usize) -> io::Result<()> {
     use NodeValue::*;
 
     macro_rules! try_node_inline {

--- a/examples/traverse_demo.rs
+++ b/examples/traverse_demo.rs
@@ -18,7 +18,7 @@ use comrak::{
 
 // Note: root can be any Node, not just document root.
 
-fn extract_text_traverse<'a>(root: Node<'a>) -> String {
+fn extract_text_traverse(root: Node<'_>) -> String {
     let mut output_text = String::new();
 
     // Use `traverse` to get an iterator of `NodeEdge` and process each.

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -25,20 +25,20 @@ pub trait SyntaxHighlighterAdapter: Send + Sync {
     /// `<pre>` tag possibly with some HTML attribute pre-filled.
     ///
     /// `attributes`: A map of HTML attributes provided by Comrak.
-    fn write_pre_tag<'s>(
+    fn write_pre_tag(
         &self,
         output: &mut dyn fmt::Write,
-        attributes: HashMap<&'static str, Cow<'s, str>>,
+        attributes: HashMap<&'static str, Cow<'_, str>>,
     ) -> fmt::Result;
 
     /// Generates the opening `<code>` tag. Some syntax highlighter libraries might include their own
     /// `<code>` tag possibly with some HTML attribute pre-filled.
     ///
     /// `attributes`: A map of HTML attributes provided by Comrak.
-    fn write_code_tag<'s>(
+    fn write_code_tag(
         &self,
         output: &mut dyn fmt::Write,
-        attributes: HashMap<&'static str, Cow<'s, str>>,
+        attributes: HashMap<&'static str, Cow<'_, str>>,
     ) -> fmt::Result;
 }
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -31,11 +31,7 @@ pub use anchorizer::Anchorizer;
 pub use context::Context;
 
 /// Formats an AST as HTML, modified by the given options.
-pub fn format_document<'a>(
-    root: Node<'a>,
-    options: &Options,
-    output: &mut dyn Write,
-) -> fmt::Result {
+pub fn format_document(root: Node<'_>, options: &Options, output: &mut dyn Write) -> fmt::Result {
     format_document_with_formatter(
         root,
         options,
@@ -47,8 +43,8 @@ pub fn format_document<'a>(
 }
 
 /// Formats an AST as HTML, modified by the given options. Accepts custom plugins.
-pub fn format_document_with_plugins<'a>(
-    root: Node<'a>,
+pub fn format_document_with_plugins(
+    root: Node<'_>,
     options: &Options,
     output: &mut dyn fmt::Write,
     plugins: &Plugins,
@@ -406,9 +402,9 @@ pub fn format_document_with_formatter<'a, 'o, 'c: 'o, T>(
 /// [`format_document_with_plugins`] and as the fallback for any node types not
 /// handled in custom formatters created by [`create_formatter!`].
 #[inline]
-pub fn format_node_default<'a, T>(
+pub fn format_node_default<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     match node.data().value {
@@ -480,7 +476,7 @@ pub fn format_node_default<'a, T>(
 /// This function renders anything iff `context.options.render.sourcepos` is
 /// true, and includes a leading space if so, so you can use it  unconditionally
 /// immediately before writing a closing `>` in your opening HTML tag.
-pub fn render_sourcepos<'a, T>(context: &mut Context<T>, node: Node<'a>) -> fmt::Result {
+pub fn render_sourcepos<T>(context: &mut Context<T>, node: Node<'_>) -> fmt::Result {
     if context.options.render.sourcepos {
         let ast = node.data();
         if ast.sourcepos.start.line > 0 {
@@ -490,9 +486,9 @@ pub fn render_sourcepos<'a, T>(context: &mut Context<T>, node: Node<'a>) -> fmt:
     Ok(())
 }
 
-fn render_block_quote<'a, T>(
+fn render_block_quote<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -507,9 +503,9 @@ fn render_block_quote<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_code<'a, T>(
+fn render_code<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
     nc: &NodeCode,
 ) -> Result<ChildRendering, fmt::Error> {
@@ -524,9 +520,9 @@ fn render_code<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_code_block<'a, T>(
+fn render_code_block<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
     ncb: &NodeCodeBlock,
 ) -> Result<ChildRendering, fmt::Error> {
@@ -602,9 +598,9 @@ fn render_code_block<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_emph<'a, T>(
+fn render_emph<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -618,9 +614,9 @@ fn render_emph<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_heading<'a, T>(
+fn render_heading<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
     nh: &NodeHeading,
 ) -> Result<ChildRendering, fmt::Error> {
@@ -743,9 +739,9 @@ fn render_html_inline<T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_image<'a, T>(
+fn render_image<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
     nl: &NodeLink,
 ) -> Result<ChildRendering, fmt::Error> {
@@ -785,9 +781,9 @@ fn render_image<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_item<'a, T>(
+fn render_item<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -802,9 +798,9 @@ fn render_item<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_line_break<'a, T>(
+fn render_line_break<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -816,9 +812,9 @@ fn render_line_break<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_link<'a, T>(
+fn render_link<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
     nl: &NodeLink,
 ) -> Result<ChildRendering, fmt::Error> {
@@ -852,9 +848,9 @@ fn render_link<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_list<'a, T>(
+fn render_list<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
     nl: &NodeList,
 ) -> Result<ChildRendering, fmt::Error> {
@@ -891,9 +887,9 @@ fn render_list<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_paragraph<'a, T>(
+fn render_paragraph<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     let tight = node
@@ -930,9 +926,9 @@ fn render_paragraph<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_soft_break<'a, T>(
+fn render_soft_break<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -948,9 +944,9 @@ fn render_soft_break<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_strong<'a, T>(
+fn render_strong<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     let parent_node = node.parent();
@@ -982,9 +978,9 @@ fn render_text<T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_thematic_break<'a, T>(
+fn render_thematic_break<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -999,9 +995,9 @@ fn render_thematic_break<'a, T>(
 
 // GFM
 
-fn render_footnote_definition<'a, T>(
+fn render_footnote_definition<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
     nfd: &NodeFootnoteDefinition,
 ) -> Result<ChildRendering, fmt::Error> {
@@ -1027,9 +1023,9 @@ fn render_footnote_definition<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_footnote_reference<'a, T>(
+fn render_footnote_reference<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
     nfr: &NodeFootnoteReference,
 ) -> Result<ChildRendering, fmt::Error> {
@@ -1051,9 +1047,9 @@ fn render_footnote_reference<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_strikethrough<'a, T>(
+fn render_strikethrough<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -1067,9 +1063,9 @@ fn render_strikethrough<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_highlight<'a, T>(
+fn render_highlight<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -1083,9 +1079,9 @@ fn render_highlight<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_table<'a, T>(
+fn render_table<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -1109,9 +1105,9 @@ fn render_table<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_table_cell<'a, T>(
+fn render_table_cell<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     let Some(row_node) = node.parent() else {
@@ -1174,9 +1170,9 @@ fn render_table_cell<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_table_row<'a, T>(
+fn render_table_row<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
     thead: bool,
 ) -> Result<ChildRendering, fmt::Error> {
@@ -1204,9 +1200,9 @@ fn render_table_row<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_task_item<'a, T>(
+fn render_task_item<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
     symbol: Option<char>,
 ) -> Result<ChildRendering, fmt::Error> {
@@ -1245,9 +1241,9 @@ fn render_task_item<'a, T>(
 
 // Extensions
 
-fn render_alert<'a, T>(
+fn render_alert<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
     alert: &NodeAlert,
 ) -> Result<ChildRendering, fmt::Error> {
@@ -1274,9 +1270,9 @@ fn render_alert<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_description_details<'a, T>(
+fn render_description_details<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -1290,9 +1286,9 @@ fn render_description_details<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_description_list<'a, T>(
+fn render_description_list<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -1307,9 +1303,9 @@ fn render_description_list<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_description_term<'a, T>(
+fn render_description_term<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -1323,9 +1319,9 @@ fn render_description_term<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_escaped<'a, T>(
+fn render_escaped<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if context.options.render.escaped_char_spans {
@@ -1353,9 +1349,9 @@ fn render_escaped_tag<T>(
 
 /// Renders a math dollar inline, `$...$` and `$$...$$` using `<span>` to be
 /// similar to other renderers.
-pub fn render_math<'a, T>(
+pub fn render_math<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
     nm: &NodeMath,
 ) -> Result<ChildRendering, fmt::Error> {
@@ -1380,9 +1376,9 @@ pub fn render_math<'a, T>(
 }
 
 /// Renders a math code block, ```` ```math ```` using `<pre><code>`.
-pub fn render_math_code_block<'a, T>(
+pub fn render_math_code_block<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     literal: &str,
 ) -> Result<ChildRendering, fmt::Error> {
     context.cr()?;
@@ -1416,9 +1412,9 @@ pub fn render_math_code_block<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_multiline_block_quote<'a, T>(
+fn render_multiline_block_quote<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -1448,7 +1444,7 @@ fn render_raw<T>(
 }
 
 #[cfg(feature = "shortcodes")]
-fn render_short_code<'a, T>(
+fn render_short_code<T>(
     context: &mut Context<T>,
     entering: bool,
     nsc: &NodeShortCode,
@@ -1461,9 +1457,9 @@ fn render_short_code<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_spoiler_text<'a, T>(
+fn render_spoiler_text<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -1477,9 +1473,9 @@ fn render_spoiler_text<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_subscript<'a, T>(
+fn render_subscript<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -1493,9 +1489,9 @@ fn render_subscript<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_subtext<'a, T>(
+fn render_subtext<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -1510,9 +1506,9 @@ fn render_subtext<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_superscript<'a, T>(
+fn render_superscript<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -1526,9 +1522,9 @@ fn render_superscript<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_underline<'a, T>(
+fn render_underline<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
@@ -1542,9 +1538,9 @@ fn render_underline<'a, T>(
     Ok(ChildRendering::HTML)
 }
 
-fn render_wiki_link<'a, T>(
+fn render_wiki_link<T>(
     context: &mut Context<T>,
-    node: Node<'a>,
+    node: Node<'_>,
     entering: bool,
     nwl: &NodeWikiLink,
 ) -> Result<ChildRendering, fmt::Error> {
@@ -1571,7 +1567,7 @@ fn render_wiki_link<'a, T>(
 /// order, returning the concatenated literal contents of text, code and math
 /// blocks. Line breaks and soft breaks are represented as a single whitespace
 /// character.
-pub fn collect_text<'a>(node: Node<'a>) -> String {
+pub fn collect_text(node: Node<'_>) -> String {
     let mut text = String::with_capacity(20);
     collect_text_append(node, &mut text);
     text
@@ -1581,7 +1577,7 @@ pub fn collect_text<'a>(node: Node<'a>) -> String {
 /// order, appending the literal contents of text, code and math blocks to
 /// an output buffer. Line breaks and soft breaks are represented as a single
 /// whitespace character.
-pub fn collect_text_append<'a>(node: Node<'a>, output: &mut String) {
+pub fn collect_text_append(node: Node<'_>, output: &mut String) {
     match node.data().value {
         NodeValue::Text(ref literal) => output.push_str(literal),
         NodeValue::Code(NodeCode { ref literal, .. }) => output.push_str(literal),

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -447,7 +447,6 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
         self.scanner.pos += 1;
 
         if self.peek_byte().map_or(false, ispunct) {
-            let inl;
             self.scanner.pos += 1;
 
             let inline_text = self.make_inline(
@@ -460,7 +459,7 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
                 self.scanner.pos - 1,
             );
 
-            inl = self.make_inline(
+            let inl = self.make_inline(
                 NodeValue::Escaped,
                 self.scanner.pos - 2,
                 self.scanner.pos - 1,
@@ -762,7 +761,7 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
             self.scanner.pos - 1,
         );
         self.adjust_node_newlines(inl, matchlen, 0, parent_line_offsets);
-        return Some(inl);
+        Some(inl)
     }
 
     #[cfg(feature = "phoenix_heex")]
@@ -776,7 +775,7 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
             self.scanner.pos - 1,
         );
         self.adjust_node_newlines(inl, matchlen, 0, parent_line_offsets);
-        return Some(inl);
+        Some(inl)
     }
 
     fn handle_hyphen(&mut self) -> Node<'a> {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2304,7 +2304,7 @@ where
 
         // There must be at most one `char`'s worth of content in `matched`,
         // otherwise we ignore it.
-        if !chars.next().is_none() {
+        if chars.next().is_some() {
             return;
         }
 
@@ -2437,16 +2437,14 @@ where
 
         lab = strings::normalize_label(&lab, Case::Fold);
         let mut rr = None;
-        if !lab.is_empty() {
-            if !self.refmap.map.contains_key(&lab) {
-                rr = Some((
-                    lab,
-                    ResolvedReference {
-                        url: strings::clean_url(&url).into(),
-                        title: strings::clean_title(&title).into(),
-                    },
-                ));
-            }
+        if !lab.is_empty() && !self.refmap.map.contains_key(&lab) {
+            rr = Some((
+                lab,
+                ResolvedReference {
+                    url: strings::clean_url(&url).into(),
+                    title: strings::clean_title(title).into(),
+                },
+            ));
         }
         Some((scanner.pos, rr))
     }
@@ -2583,7 +2581,7 @@ fn lists_match(list_data: &NodeList, item_data: &NodeList) -> bool {
         && list_data.bullet_char == item_data.bullet_char
 }
 
-fn reopen_ast_nodes<'a>(mut ast: Node<'a>) {
+fn reopen_ast_nodes(mut ast: Node<'_>) {
     loop {
         ast.data_mut().open = true;
         ast = match ast.parent() {

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -358,7 +358,7 @@ fn unescape_pipes(string: &str) -> Cow<'_, str> {
 // The purpose of this is to prevent a malicious input from generating a very
 // large number of autocompleted cells, which could cause a denial of service
 // vulnerability.
-fn adjust_table_counters<'a>(container: Node<'a>, i: usize, end: LineColumn) {
+fn adjust_table_counters(container: Node<'_>, i: usize, end: LineColumn) {
     let mut ast = container.data_mut();
     let NodeValue::Table(ref mut nt) = ast.value else {
         unreachable!();
@@ -369,7 +369,7 @@ fn adjust_table_counters<'a>(container: Node<'a>, i: usize, end: LineColumn) {
 }
 
 // Calculate the number of autocompleted cells.
-fn get_num_autocompleted_cells<'a>(container: Node<'a>) -> usize {
+fn get_num_autocompleted_cells(container: Node<'_>) -> usize {
     return match container.data().value {
         NodeValue::Table(ref node_table) => {
             let num_cells = node_table.num_columns * node_table.num_rows;

--- a/src/plugins/syntect.rs
+++ b/src/plugins/syntect.rs
@@ -105,10 +105,10 @@ impl SyntaxHighlighterAdapter for SyntectAdapter {
         }
     }
 
-    fn write_pre_tag<'s>(
+    fn write_pre_tag(
         &self,
         output: &mut dyn Write,
-        attributes: HashMap<&'static str, Cow<'s, str>>,
+        attributes: HashMap<&'static str, Cow<'_, str>>,
     ) -> fmt::Result {
         match &self.theme {
             Some(theme) => {
@@ -127,10 +127,10 @@ impl SyntaxHighlighterAdapter for SyntectAdapter {
         }
     }
 
-    fn write_code_tag<'s>(
+    fn write_code_tag(
         &self,
         output: &mut dyn Write,
-        attributes: HashMap<&'static str, Cow<'s, str>>,
+        attributes: HashMap<&'static str, Cow<'_, str>>,
     ) -> fmt::Result {
         html::write_opening_tag(output, "code", attributes)
     }

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -128,7 +128,7 @@ pub fn remove_trailing_blank_lines_slice(line: &str) -> &str {
 
 fn remove_trailing_blank_lines_ix(line: &str) -> usize {
     let line_bytes = line.as_bytes();
-    if line.len() == 0 {
+    if line.is_empty() {
         return 0;
     }
     let mut i = line.len() - 1;
@@ -447,7 +447,7 @@ pub fn count_newlines(input: &str) -> (usize, usize) {
 pub fn newlines_of(s: &str) -> usize {
     if s.ends_with("\r\n") {
         2
-    } else if s.ends_with("\r") || s.ends_with("\n") {
+    } else if s.ends_with('\r') || s.ends_with('\n') {
         1
     } else {
         0
@@ -530,7 +530,7 @@ pub fn phoenix_inline_tag(s: &str) -> Option<usize> {
 
 #[cfg(feature = "phoenix_heex")]
 pub fn phoenix_inline_expression(s: &str) -> Option<usize> {
-    if s.chars().next() != Some('{') {
+    if !s.starts_with('{') {
         return None;
     }
     find_matching_brace(s, 1)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -234,7 +234,7 @@ where
     compare_strs(&output_from_rt, expected, "roundtrip", &md);
 }
 
-fn assert_node_eq<'a>(node: Node<'a>, location: &[usize], expected: &NodeValue) {
+fn assert_node_eq(node: Node<'_>, location: &[usize], expected: &NodeValue) {
     let node = location
         .iter()
         .fold(node, |node, &n| node.children().nth(n).unwrap());
@@ -355,7 +355,7 @@ enum AstMatchContent {
 
 impl AstMatchTree {
     #[track_caller]
-    fn assert_match<'a>(&self, node: Node<'a>) {
+    fn assert_match(&self, node: Node<'_>) {
         let ast = node.data();
         assert_eq!(self.name, ast.value.xml_node_name(), "node type matches");
         assert_eq!(self.sourcepos, ast.sourcepos, "sourcepos are equal");

--- a/src/tests/code.rs
+++ b/src/tests/code.rs
@@ -9,14 +9,11 @@ fn fenced_codeblock_closed_and_unclosed_root() {
     let root = parse_document(&arena, md_closed, &options);
     let mut found = false;
     for n in root.descendants() {
-        match &n.data().value {
-            NodeValue::CodeBlock(ncb) => {
-                assert!(ncb.fenced, "expected fenced code block");
-                assert!(ncb.closed, "expected closed code block");
-                found = true;
-                break;
-            }
-            _ => {}
+        if let NodeValue::CodeBlock(ncb) = &n.data().value {
+            assert!(ncb.fenced, "expected fenced code block");
+            assert!(ncb.closed, "expected closed code block");
+            found = true;
+            break;
         }
     }
     assert!(found, "expected a code block node");
@@ -25,14 +22,11 @@ fn fenced_codeblock_closed_and_unclosed_root() {
     let root2 = parse_document(&arena, md_unclosed, &options);
     let mut found2 = false;
     for n in root2.descendants() {
-        match &n.data().value {
-            NodeValue::CodeBlock(ncb) => {
-                assert!(ncb.fenced, "expected fenced code block");
-                assert!(!ncb.closed, "expected unclosed code block");
-                found2 = true;
-                break;
-            }
-            _ => {}
+        if let NodeValue::CodeBlock(ncb) = &n.data().value {
+            assert!(ncb.fenced, "expected fenced code block");
+            assert!(!ncb.closed, "expected unclosed code block");
+            found2 = true;
+            break;
         }
     }
     assert!(found2, "expected a code block node");
@@ -47,14 +41,11 @@ fn fenced_codeblock_closed_and_unclosed_in_blockquote() {
     let root = parse_document(&arena, md_closed, &options);
     let mut found = false;
     for n in root.descendants() {
-        match &n.data().value {
-            NodeValue::CodeBlock(ncb) => {
-                assert!(ncb.fenced, "expected fenced code block in blockquote");
-                assert!(ncb.closed, "expected closed code block in blockquote");
-                found = true;
-                break;
-            }
-            _ => {}
+        if let NodeValue::CodeBlock(ncb) = &n.data().value {
+            assert!(ncb.fenced, "expected fenced code block in blockquote");
+            assert!(ncb.closed, "expected closed code block in blockquote");
+            found = true;
+            break;
         }
     }
     assert!(found, "expected a code block node");
@@ -63,14 +54,11 @@ fn fenced_codeblock_closed_and_unclosed_in_blockquote() {
     let root2 = parse_document(&arena, md_unclosed, &options);
     let mut found2 = false;
     for n in root2.descendants() {
-        match &n.data().value {
-            NodeValue::CodeBlock(ncb) => {
-                assert!(ncb.fenced, "expected fenced code block in blockquote");
-                assert!(!ncb.closed, "expected unclosed code block in blockquote");
-                found2 = true;
-                break;
-            }
-            _ => {}
+        if let NodeValue::CodeBlock(ncb) = &n.data().value {
+            assert!(ncb.fenced, "expected fenced code block in blockquote");
+            assert!(!ncb.closed, "expected unclosed code block in blockquote");
+            found2 = true;
+            break;
         }
     }
     assert!(found2, "expected a code block node");

--- a/src/tests/pathological.rs
+++ b/src/tests/pathological.rs
@@ -6,7 +6,7 @@ use ntest::timeout;
 #[timeout(4000)]
 fn pathological_emphases() {
     let n = 50_000;
-    let input = "*a_ ".repeat(n).to_string();
+    let input = "*a_ ".repeat(n);
     let mut exp = format!("<p>{}", input);
     // Right-most space is trimmed in output.
     exp.pop();
@@ -64,7 +64,7 @@ fn pathological_footnotes() {
     let input = format!("{}{}", "[^1]:".repeat(n), "\n".repeat(n));
     let exp = "";
 
-    html_opts!([extension.footnotes], &input, &exp);
+    html_opts!([extension.footnotes], &input, exp);
 }
 
 #[test]

--- a/src/tests/sourcepos.rs
+++ b/src/tests/sourcepos.rs
@@ -460,7 +460,7 @@ fn node_values() -> HashMap<NodeValueDiscriminants, TestCase> {
     NodeValueDiscriminants::VARIANTS
         .iter()
         .filter(|v| !matches!(v, Raw))
-        .filter_map(|v| {
+        .map(|v| {
             let text = match v {
                 Document => DOCUMENT,
                 FrontMatter => FRONT_MATTER,
@@ -512,7 +512,7 @@ fn node_values() -> HashMap<NodeValueDiscriminants, TestCase> {
                 #[cfg(feature = "phoenix_heex")]
                 HeexInline => HEEX_INLINE,
             };
-            Some((*v, text))
+            (*v, text)
         })
         .collect()
 }

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -10,17 +10,13 @@ use crate::parser::options::{Options, Plugins};
 const MAX_INDENT: u32 = 40;
 
 /// Formats an AST as HTML, modified by the given options.
-pub fn format_document<'a>(
-    root: Node<'a>,
-    options: &Options,
-    output: &mut dyn Write,
-) -> fmt::Result {
+pub fn format_document(root: Node<'_>, options: &Options, output: &mut dyn Write) -> fmt::Result {
     format_document_with_plugins(root, options, output, &Plugins::default())
 }
 
 /// Formats an AST as HTML, modified by the given options. Accepts custom plugins.
-pub fn format_document_with_plugins<'a>(
-    root: Node<'a>,
+pub fn format_document_with_plugins(
+    root: Node<'_>,
     options: &Options,
     output: &mut dyn Write,
     plugins: &Plugins,
@@ -72,7 +68,7 @@ impl<'o, 'c> XmlFormatter<'o, 'c> {
         Ok(())
     }
 
-    fn format<'a>(&mut self, node: Node<'a>, plain: bool) -> fmt::Result {
+    fn format(&mut self, node: Node<'_>, plain: bool) -> fmt::Result {
         // Traverse the AST iteratively using a work stack, with pre- and
         // post-child-traversal phases. During pre-order traversal render the
         // opening tags, then push the node back onto the stack for the
@@ -134,7 +130,7 @@ impl<'o, 'c> XmlFormatter<'o, 'c> {
         Ok(())
     }
 
-    fn format_node<'a>(&mut self, node: Node<'a>, entering: bool) -> fmt::Result {
+    fn format_node(&mut self, node: Node<'_>, entering: bool) -> fmt::Result {
         if !self.options.render.escaped_char_spans && node_matches!(node, NodeValue::Escaped) {
             return Ok(());
         }


### PR DESCRIPTION
Close #695

Hi @kivikakk here's a proposal to clean up clippy warnings. Most changes are "just" eliding lifetimes, I don't know if there's a preference but I'm happy to adjust if needed.

```
❯ rustc --version
rustc 1.70.0 (90c541806 2023-05-31)

❯ cargo --version
cargo 1.70.0 (ec8a8a0ca 2023-04-25)
```

If this is good and gets merded, should the CI fail on clippy warns/errors?