### PR TITLE
chore(ci): promote clippy warns to errors

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,6 +112,6 @@ jobs:
     - name: Obtain Rust
       run: rustup override set $MSRV
     - name: Check clippy
-      run: rustup component add clippy && cargo clippy
+      run: rustup component add clippy && cargo clippy -- -Dwarnings
     - name: Check formatting
       run: rustup component add rustfmt && cargo fmt -- --check


### PR DESCRIPTION
Ref: https://github.com/kivikakk/comrak/pull/700#issuecomment-3573318413

Doc: https://doc.rust-lang.org/clippy/usage.html#command-line

### Before

Warnings, no errors.

```
❯ cargo clippy
   Compiling comrak v0.48.0 (/Users/leandro/code/leandrocp/comrak)
warning: single-character string constant used as pattern
  --> build.rs:19:42
   |
19 |         .filter(|e| e.entity.starts_with("&") && e.entity.ends_with(';'))
   |                                          ^^^ help: try using a `char` instead: `'&'`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern
   = note: `#[warn(clippy::single_char_pattern)]` on by default

warning: `comrak` (build script) generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 1.78s

❯ echo $?
0
```

### After

Actual errors checked on CI.

```
❯ cargo clippy -- -Dwarnings
   Compiling comrak v0.48.0 (/Users/leandro/code/leandrocp/comrak)
error: single-character string constant used as pattern
  --> build.rs:19:42
   |
19 |         .filter(|e| e.entity.starts_with("&") && e.entity.ends_with(';'))
   |                                          ^^^ help: try using a `char` instead: `'&'`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern
   = note: `-D clippy::single-char-pattern` implied by `-D warnings`

error: could not compile `comrak` (build script) due to previous error

❯ echo $?
101
```

_Not an actual issue, just for demoing._ 😄