### PR TITLE
fix: HTML block in blockquote in multiline block quotes has no content

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -542,10 +542,12 @@ where
             // Make sure it's finalized.
             if container.last_child_is_open() {
                 let mut child = container.last_child().unwrap();
-                // Descend to the deepest-last open child
-                // before finalizing it. This ensures nested open children
-                // (e.g. indented code blocks) are closed first.
-                while child.last_child_is_open() {
+                // Descend to the deepest-last open child before finalizing it.
+                // Stop descending when encountering a `List` node because
+                // list structure must be finalized at the item level. This
+                // ensures nested open children (e.g. indented code blocks)
+                // are closed first while avoiding descending into lists.
+                while child.last_child_is_open() && !node_matches!(child, NodeValue::List(..)) {
                     child = child.last_child().unwrap();
                 }
                 let child_ast = &mut child.data_mut();

--- a/src/tests/multiline_block_quotes.rs
+++ b/src/tests/multiline_block_quotes.rs
@@ -264,3 +264,22 @@ fn html_block_in_blockquote_in_mbq() {
         ),
     );
 }
+
+#[test]
+fn mbq_as_list_item_with_list_item() {
+    html_opts!(
+        [extension.multiline_block_quotes, render.r#unsafe],
+        concat!(" -  >>>\n", "    - foo\n", "    >>>"),
+        concat!(
+            "<ul>\n",
+            "<li>\n",
+            "<blockquote>\n",
+            "<ul>\n",
+            "<li>foo</li>\n",
+            "</ul>\n",
+            "</blockquote>\n",
+            "</li>\n",
+            "</ul>\n",
+        ),
+    );
+}


### PR DESCRIPTION
This PR improves the handling of open child nodes to ensure that when finalizing open child nodes, the parser now descends to the deepest-last open child before finalizing, which prevents nested open children (such as indented code blocks) from being left open.

Fixes #697 