### PR TITLE
fix: Incorrect `sourcepos` for HTML and HEEx blocks inside blockquotes

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1979,7 +1979,8 @@ where
                 let trimmed = strings::remove_trailing_blank_lines_slice(content);
                 let (num_lines, last_line_len) = strings::count_newlines(trimmed);
                 let end_line = ast.sourcepos.start.line + num_lines;
-                ast.sourcepos.end = (end_line, last_line_len).into();
+                let end_col = ast.line_offsets.get(num_lines).copied().unwrap_or(0) + last_line_len;
+                ast.sourcepos.end = (end_line, end_col).into();
 
                 mem::swap(&mut nhb.literal, content);
             }
@@ -1988,7 +1989,8 @@ where
                 let trimmed = strings::remove_trailing_blank_lines_slice(content);
                 let (num_lines, last_line_len) = strings::count_newlines(trimmed);
                 let end_line = ast.sourcepos.start.line + num_lines;
-                ast.sourcepos.end = (end_line, last_line_len).into();
+                let end_col = ast.line_offsets.get(num_lines).copied().unwrap_or(0) + last_line_len;
+                ast.sourcepos.end = (end_line, end_col).into();
 
                 mem::swap(&mut nhb.literal, content);
             }

--- a/src/tests/html.rs
+++ b/src/tests/html.rs
@@ -683,3 +683,86 @@ fn sourcepos_kind_7() {
         ])
     );
 }
+
+#[test]
+fn sourcepos_inside_blockquote() {
+    // Kind 1
+    assert_ast_match!(
+        [],
+        "> <script></script>",
+        (document (1:1-1:19) [
+            (block_quote (1:1-1:19) [
+                (html_block (1:3-1:19) "<script></script>")
+            ])
+        ])
+    );
+
+    // Kind 2
+    assert_ast_match!(
+        [],
+        "> <!---->",
+        (document (1:1-1:9) [
+            (block_quote (1:1-1:9) [
+                (html_block (1:3-1:9) "<!---->")
+            ])
+        ])
+    );
+
+    // Kind 3
+    assert_ast_match!(
+        [],
+        "> <??>",
+        (document (1:1-1:6) [
+            (block_quote (1:1-1:6) [
+                (html_block (1:3-1:6) "<??>")
+            ])
+        ])
+    );
+
+    // Kind 4
+    assert_ast_match!(
+        [],
+        "> <!a>",
+        (document (1:1-1:6) [
+            (block_quote (1:1-1:6) [
+                (html_block (1:3-1:6) "<!a>")
+            ])
+        ])
+    );
+
+    // Kind 5
+    assert_ast_match!(
+        [],
+        "> <![CDATA[]]>",
+        (document (1:1-1:14) [
+            (block_quote (1:1-1:14) [
+                (html_block (1:3-1:14) "<![CDATA[]]>")
+            ])
+        ])
+    );
+
+    // Kind 6
+    assert_ast_match!(
+        [],
+        "> <div></div>",
+        (document (1:1-1:13) [
+            (block_quote (1:1-1:13) [
+                (html_block (1:3-1:13) "<div></div>")
+            ])
+        ])
+    );
+
+    // Kind 7
+    assert_ast_match!(
+        [],
+        "> <testa></testa>",
+        (document (1:1-1:17) [
+            (block_quote (1:1-1:17) [
+                (paragraph (1:3-1:17) [
+                    (html_inline (1:3-1:9) "<testa>")
+                    (html_inline (1:10-1:17) "</testa>")
+                ])
+            ])
+        ])
+    );
+}

--- a/src/tests/phoenix_heex.rs
+++ b/src/tests/phoenix_heex.rs
@@ -1468,6 +1468,21 @@ fn sourcepos_with_content() {
 }
 
 #[test]
+fn block_with_content_inside_blockquote_sourcepos() {
+    assert_ast_match!(
+        [extension.phoenix_heex],
+        "> <.form>\n"
+        ">   <.input />\n"
+        "> </.form>\n",
+        (document (1:1-3:10) [
+            (block_quote (1:1-3:10) [
+                (heex_block (1:3-3:10) "<.form>\n  <.input />\n</.form>\n")
+            ])
+        ]),
+    );
+}
+
+#[test]
 fn block_with_code_fence() {
     assert_ast_match!(
         [extension.phoenix_heex],
@@ -1476,6 +1491,21 @@ fn block_with_code_fence() {
         "</.header>\n",
         (document (1:1-3:10) [
             (heex_block (1:1-3:10) "<.header>\n  ```elixir\n</.header>\n")
+        ]),
+    );
+}
+
+#[test]
+fn block_with_code_fence_inside_blockquote_sourcepos() {
+    assert_ast_match!(
+        [extension.phoenix_heex],
+        "> <.header>\n"
+        ">   ```elixir\n"
+        "> </.header>\n",
+        (document (1:1-3:12) [
+            (block_quote (1:1-3:12) [
+                (heex_block (1:3-3:12) "<.header>\n  ```elixir\n</.header>\n")
+            ])
         ]),
     );
 }
@@ -1499,6 +1529,26 @@ fn block_with_text_and_paragraph() {
 }
 
 #[test]
+fn block_with_text_and_paragraph_inside_blockquote_sourcepos() {
+    assert_ast_match!(
+        [extension.phoenix_heex],
+        "> <.header>\n"
+        "> hello\n"
+        "> </.header>\n"
+        ">\n"
+        "> hello world\n",
+        (document (1:1-5:13) [
+            (block_quote (1:1-5:13) [
+                (heex_block (1:3-3:12) "<.header>\nhello\n</.header>\n")
+                (paragraph (5:3-5:13) [
+                    (text (5:3-5:13) "hello world")
+                ])
+            ])
+        ]),
+    );
+}
+
+#[test]
 fn inline_expression_sourcepos() {
     assert_ast_match!(
         [extension.phoenix_heex],
@@ -1513,6 +1563,22 @@ fn inline_expression_sourcepos() {
 }
 
 #[test]
+fn inline_expression_inside_blockquote_sourcepos() {
+    assert_ast_match!(
+        [extension.phoenix_heex],
+        "> Here is a value: {user.name}\n",
+        (document (1:1-1:30) [
+            (block_quote (1:1-1:30) [
+                (paragraph (1:3-1:30) [
+                    (text (1:3-1:19) "Here is a value: ")
+                    (heex_inline (1:20-1:30) "{user.name}")
+                ])
+            ])
+        ]),
+    );
+}
+
+#[test]
 fn directive_sourcepos() {
     assert_ast_match!(
         [extension.phoenix_heex],
@@ -1521,6 +1587,22 @@ fn directive_sourcepos() {
             (paragraph (1:1-1:19) [
                 (text (1:1-1:7) "Value: ")
                 (heex_inline (1:8-1:19) "<%= @user %>")
+            ])
+        ]),
+    );
+}
+
+#[test]
+fn directive_inside_blockquote_sourcepos() {
+    assert_ast_match!(
+        [extension.phoenix_heex],
+        "> Here is a value: <%= @user %>\n",
+        (document (1:1-1:31) [
+            (block_quote (1:1-1:31) [
+                (paragraph (1:3-1:31) [
+                    (text (1:3-1:19) "Here is a value: ")
+                    (heex_inline (1:20-1:31) "<%= @user %>")
+                ])
             ])
         ]),
     );


### PR DESCRIPTION
This PR fixes incorrect `sourcepos` for HTML blocks and Phoenix HEEx blocks inside blockquotes.

Fixes #696 