### PR TITLE
use static builds on darwin too

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
           default = comrak;
 
           comrak = mkComrak pkgs;
-          comrak-musl = mkComrak pkgs.pkgsStatic;
+          comrak-static = mkComrak pkgs.pkgsStatic;
         }
       );
 

--- a/script/build-releases
+++ b/script/build-releases
@@ -25,9 +25,9 @@ function build {
     fi
 }
 
-build aarch64-apple-darwin packages.aarch64-darwin.default
-build x86_64-apple-darwin packages.x86_64-darwin.default
-build aarch64-unknown-linux-musl packages.aarch64-linux.comrak-musl
-build x86_64-unknown-linux-musl packages.x86_64-linux.comrak-musl
+build aarch64-apple-darwin packages.aarch64-darwin.comrak-static
+build x86_64-apple-darwin packages.x86_64-darwin.comrak-static
+build aarch64-unknown-linux-musl packages.aarch64-linux.comrak-static
+build x86_64-unknown-linux-musl packages.x86_64-linux.comrak-static
 
 file "comrak-$version-"*


### PR DESCRIPTION
Otherwise they depend on libiconv in the Nix store:

https://github.com/kivikakk/comrak/issues/720#issuecomment-3762542423

Hopefully fixes #720; will wait for confirmation.