### PR TITLE
Don't wrap text in table cells

### DIFF
--- a/src/tests/commonmark.rs
+++ b/src/tests/commonmark.rs
@@ -145,3 +145,16 @@ fn dont_create_autolinks() {
 
     commonmark(expected, expected, Some(&options));
 }
+
+#[test]
+fn dont_wrap_table_cell() {
+    let input = r#"| option | description |
+| --- | --- |
+| -o | Write output to FILE instead of stdout |
+| --gfm | Use GFM-style quirks in output HTML, such as not nesting <strong> tags, which otherwise breaks CommonMark compatibility |
+"#;
+    let mut options = Options::default();
+    options.extension.table = true;
+    options.render.width = 80;
+    commonmark(input, input, Some(&options));
+}


### PR DESCRIPTION
Currently, formatting a file in-place while using the `--width` flag wraps text in table cells at that width, which breaks table rendering. E.g., running `comrak -i --gfm --width 80` on the following:

```md
| option | description |
| ------ | ----------- |
| --width | Wraps at the given column number |
| --gfm | Use GFM-style quirks in output HTML, such as not nesting <strong> tags, which otherwise breaks CommonMark compatibility |
```
will produce:
```md
| option | description |
| --- | --- |
| --width | Wraps at the given column number |
| --gfm | Use GFM-style quirks in output HTML, such as not nesting <strong>
tags, which otherwise breaks CommonMark compatibility |
```

This PR checks if a text node is in a table cell, and passes that check to the `wrap` parameter of `output`, which prevents line breaks from being added to table cells.