### PR TITLE
support raw nodes with children

### DIFF
--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -928,6 +928,9 @@ impl<'a> arena_tree::Node<'a, RefCell<Ast>> {
     /// Returns true if the given node can contain a node with the given value.
     pub fn can_contain_type(&self, child: &NodeValue) -> bool {
         match *child {
+            NodeValue::Raw(_) => {
+                return true;
+            }
             NodeValue::Document => {
                 return false;
             }


### PR DESCRIPTION
This allows creating an AST within which `Raw` nodes can have children. This allows e.g. to wrap existing nodes into `Raw` nodes (in my case, I use this when printing markdown to a terminal to inject escape characters).