### PR TITLE
fix: Incorrect `sourcepos` for inserted table cells

### DIFF
--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -192,7 +192,10 @@ fn try_opening_row<'a>(
     }
 
     while i < alignments.len() {
-        parser.add_child(new_row, NodeValue::TableCell, last_column);
+        let cell_node = parser.add_child(new_row, NodeValue::TableCell, last_column + 1);
+        // for autocompleted (empty) cells, set end column equal to start
+        let cell_ast = &mut cell_node.data_mut();
+        cell_ast.sourcepos.end.column = last_column + 1;
         i += 1;
     }
 

--- a/src/tests/table.rs
+++ b/src/tests/table.rs
@@ -423,3 +423,99 @@ fn table_with_trailing_para_and_leading_whitespace() {
         ])
     );
 }
+
+#[test]
+fn table_missing_cell_sourcepos() {
+    assert_ast_match!(
+        [extension.table],
+        "|a|b|\n"
+        "|-|-|\n"
+        "|c|\n"
+        ,
+        (document (1:1-3:3) [
+            (table (1:1-3:3) [
+                (table_row (1:1-1:5) [
+                    (table_cell (1:2-1:2) [
+                        (text (1:2-1:2) "a")
+                    ])
+                    (table_cell (1:4-1:4) [
+                        (text (1:4-1:4) "b")
+                    ])
+                ])
+                (table_row (3:1-3:3) [
+                    (table_cell (3:2-3:2) [
+                        (text (3:2-3:2) "c")
+                    ])
+                    (table_cell (3:3-3:3)
+                    )
+                ])
+            ])
+        ])
+    );
+}
+
+#[test]
+fn table_missing_cell_with_text_sourcepos() {
+    assert_ast_match!(
+        [extension.table],
+        "|a|b|\n"
+        "|-|-|\n"
+        "|c|d\n"
+        ,
+        (document (1:1-3:4) [
+            (table (1:1-3:4) [
+                (table_row (1:1-1:5) [
+                    (table_cell (1:2-1:2) [
+                        (text (1:2-1:2) "a")
+                    ])
+                    (table_cell (1:4-1:4) [
+                        (text (1:4-1:4) "b")
+                    ])
+                ])
+                (table_row (3:1-3:4) [
+                    (table_cell (3:2-3:2) [
+                        (text (3:2-3:2) "c")
+                    ])
+                    (table_cell (3:4-3:4) [
+                        (text (3:4-3:4) "d")
+                    ])
+                ])
+            ])
+        ])
+    );
+}
+
+#[test]
+fn table_missing_cells_sourcepos() {
+    assert_ast_match!(
+        [extension.table],
+        "|a|b|c|\n"
+        "|-|-|-|\n"
+        "|d|\n"
+        ,
+        (document (1:1-3:3) [
+            (table (1:1-3:3) [
+                (table_row (1:1-1:7) [
+                    (table_cell (1:2-1:2) [
+                        (text (1:2-1:2) "a")
+                    ])
+                    (table_cell (1:4-1:4) [
+                        (text (1:4-1:4) "b")
+                    ])
+                    (table_cell (1:6-1:6) [
+                        (text (1:6-1:6) "c")
+                    ])
+                ])
+                (table_row (3:1-3:3) [
+                    (table_cell (3:2-3:2) [
+                        (text (3:2-3:2) "d")
+                    ])
+                    (table_cell (3:3-3:3)
+                    )
+                    (table_cell (3:3-3:3)
+                    )
+                ])
+            ])
+        ])
+    );
+}


### PR DESCRIPTION
This PR fixes incorrect `sourcepos` for inserted (autocompleted) table cells.

Fixes https://github.com/kivikakk/comrak/issues/745