### PR TITLE
Support comma-delimited language tokens in syntect

### DIFF
--- a/src/plugins/syntect.rs
+++ b/src/plugins/syntect.rs
@@ -86,7 +86,7 @@ impl SyntaxHighlighterAdapter for SyntectAdapter {
         let fallback_syntax = "Plain Text";
 
         let lang: &str = match lang {
-            Some(l) if !l.is_empty() => l,
+            Some(l) if !l.is_empty() => l.split_once(',').map(|(left, _)| left).unwrap_or(l),
             _ => fallback_syntax,
         };
 

--- a/src/tests/plugins.rs
+++ b/src/tests/plugins.rs
@@ -363,18 +363,32 @@ fn heading_adapter_plugin() {
 fn syntect_plugin_with_base16_ocean_dark_theme() {
     let adapter = crate::plugins::syntect::SyntectAdapter::new(Some("base16-ocean.dark"));
 
-    let input = concat!("```rust\n", "fn main<'a>();\n", "```\n");
-    let expected = concat!(
-        "<pre style=\"background-color:#2b303b;\"><code class=\"language-rust\">",
-        "<span style=\"color:#b48ead;\">fn </span><span style=\"color:#8fa1b3;\">main</span><span style=\"color:#c0c5ce;\">",
-        "&lt;</span><span style=\"color:#b48ead;\">&#39;a</span><span style=\"color:#c0c5ce;\">&gt;();\n</span>",
-        "</code></pre>\n"
-    );
+    let cases: [(&str, &str); 2] = [
+        (
+            concat!("```rust\n", "fn main<'a>();\n", "```\n"),
+            concat!(
+                "<pre style=\"background-color:#2b303b;\"><code class=\"language-rust\">",
+                "<span style=\"color:#b48ead;\">fn </span><span style=\"color:#8fa1b3;\">main</span><span style=\"color:#c0c5ce;\">",
+                "&lt;</span><span style=\"color:#b48ead;\">&#39;a</span><span style=\"color:#c0c5ce;\">&gt;();\n</span>",
+                "</code></pre>\n"
+            ),
+        ),
+        (
+            concat!("```rust,ignore\n", "fn main() {}\n", "```\n"),
+            concat!(
+                "<pre style=\"background-color:#2b303b;\"><code class=\"language-rust,ignore\">",
+                "<span style=\"color:#b48ead;\">fn </span><span style=\"color:#8fa1b3;\">main</span><span style=\"color:#c0c5ce;\">() {}\n</span>",
+                "</code></pre>\n"
+            ),
+        ),
+    ];
 
     let mut plugins = options::Plugins::default();
     plugins.render.codefence_syntax_highlighter = Some(&adapter);
 
-    html_plugins(input, expected, &plugins);
+    for (input, expected) in cases {
+        html_plugins(input, expected, &plugins);
+    }
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to #328, addressing #246.

Background:
- `cmark-gfm` uses whitespace-delimited info parsing and preserves `language-rust,ignore`.
- GitHub rendering still highlights `rust,ignore` as Rust.

This PR keeps Comrak's HTML class behavior unchanged while improving syntect syntax selection by splitting the language token on the first comma for lookup only.

What changed:
- `SyntectAdapter::write_highlighted`: use the part before `,` when selecting syntax.
- Add a regression test for fenced code using `rust,ignore` to ensure Rust highlighting applies.

Notes:
- This is the plugin-scoped approach from #328's discussion (no global parsing behavior change).
- Includes co-author attribution to the original contributor.
