### PR TITLE
Fix off-by-one in hex entity digit limit

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -34,10 +34,12 @@ pub fn unescape(text: &str) -> Option<(Cow<'static, str>, usize)> {
             0
         };
 
+        let is_hex = bytes[1] == b'x' || bytes[1] == b'X';
+
         if i < bytes.len()
             && bytes[i] == b';'
-            && (((bytes[1] == b'x' || bytes[1] == b'X') && (1..=6).contains(&num_digits))
-                || (1..=7).contains(&num_digits))
+            && ((is_hex && (1..=6).contains(&num_digits))
+                || (!is_hex && (1..=7).contains(&num_digits)))
         {
             if codepoint == 0 || (0xD800..=0xE000).contains(&codepoint) || codepoint >= 0x110000 {
                 codepoint = 0xFFFD;

--- a/src/tests/regressions.rs
+++ b/src/tests/regressions.rs
@@ -278,3 +278,15 @@ fn sourcepos_newline_kinds() {
         ])
     );
 }
+
+#[test]
+fn hex_entity_digit_limit() {
+    // 6 hex digits: valid
+    html("&#x000041;\n", "<p>A</p>\n");
+
+    // 7 hex digits: invalid, should be literal
+    html("&#x0000041;\n", "<p>&amp;#x0000041;</p>\n");
+
+    // 7 decimal digits: valid (decimal 100 = 'd')
+    html("&#0000100;\n", "<p>d</p>\n");
+}


### PR DESCRIPTION
## Summary

- Hex character references (`&#xHHHH;`) must have 1-6 hex digits per [CommonMark spec section 2.5](https://spec.commonmark.org/0.31.2/#entity-and-numeric-character-references), but the decimal branch's `(1..=7)` check was unconditionally OR'd, so 7-digit hex entities were also accepted
- Extract `is_hex` and gate each branch: hex allows 1-6 digits, decimal allows 1-7
- `&#x0000041;` (7 hex digits) was incorrectly parsed as `A`; now correctly treated as literal text