### PR TITLE
feat: Replace `unicode_categories` with `finl_unicode` for Unicode character categories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "codspeed-divan-compat",
  "emojis",
  "entities",
+ "finl_unicode",
  "fmt2io",
  "glob",
  "jetscii",
@@ -339,7 +340,6 @@ dependencies = [
  "syntect",
  "toml",
  "typed-arena",
- "unicode_categories",
  "xdg",
 ]
 
@@ -495,6 +495,12 @@ name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "flate2"
@@ -1239,12 +1245,6 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ harness = false
 
 [dependencies]
 typed-arena = "2.0.2"
-unicode_categories = "0.1.1"
 shell-words = { version = "1.1", optional = true }
 emojis = { version = "0.8", optional = true }
 arbitrary = { version = "1", optional = true, features = ["derive"] }
@@ -51,6 +50,7 @@ jetscii = "0.5.3"
 phf = "0.13"
 rustc-hash = "2"
 smallvec = "1.13"
+finl_unicode = { version = "1.4.0", features = ["categories"] }
 
 [dev-dependencies]
 ntest = "0.9"

--- a/src/html/anchorizer.rs
+++ b/src/html/anchorizer.rs
@@ -1,6 +1,6 @@
+use finl_unicode::categories::CharacterCategories;
 use std::borrow::Cow;
 use std::collections::HashSet;
-use unicode_categories::UnicodeCategories;
 
 /// Converts header strings to canonical, unique, but still human-readable,
 /// anchors.

--- a/src/parser/autolink.rs
+++ b/src/parser/autolink.rs
@@ -1,6 +1,6 @@
+use finl_unicode::categories::CharacterCategories;
 use std::borrow::Cow;
 use std::str;
-use unicode_categories::UnicodeCategories;
 
 use crate::Arena;
 use crate::character_set::character_set;

--- a/src/parser/inlines/cjk.rs
+++ b/src/parser/inlines/cjk.rs
@@ -1,4 +1,4 @@
-use unicode_categories::UnicodeCategories;
+use finl_unicode::categories::CharacterCategories;
 
 pub(crate) trait FlankingCheckHelper
 where


### PR DESCRIPTION
This PR updates the Unicode character category handling by switching from the [`unicode_categories` crate](https://crates.io/crates/unicode_categories) to the [`finl_unicode` crate](https://crates.io/crates/finl_unicode), which provides the same functionality.

The `unicode_categories` crate:
- was last [updated over 9 years ago](https://crates.io/crates/unicode_categories/versions),
- [isn't publishing new updates on crates.io](https://github.com/swgillespie/unicode-categories/issues/12),
- uses old Unicode data (hard to say which version, but it is older than Unicode 14, as a new version with [that commit hasn't been published yet](https://github.com/swgillespie/unicode-categories/commits/master/)).

The `finl_unicode` crate, on the other hand:
- is [updated frequently](https://crates.io/crates/finl_unicode/versions) (5 months ago the last time)
- uses the [newest Unicode 17 in the used 1.4.0 version](https://github.com/dahosek/finl_unicode?tab=readme-ov-file#version-history)
- according to [its benchmarks](https://github.com/dahosek/finl_unicode?tab=readme-ov-file#unicode-categories), it is **at least 20x faster** than `unicode_categories` (even more on some types of text)