### PR TITLE
Add `alerts` (admonitions) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Comrak additionally supports its own extensions, which are yet to be specced out
 - Underline
 - Spoiler text
 - "Greentext"
+- Alerts
 - [CJK friendly emphasis](https://github.com/tats-u/markdown-cjk-friendly)
 
 By default none are enabled; they are individually enabled with each parse by setting the appropriate values in the


### PR DESCRIPTION
Addresses issue [#526](https://github.com/kivikakk/comrak/issues/526) by mentioning alerts in the README (first introduced in [v0.34.0](https://github.com/kivikakk/comrak/releases/tag/v0.34.0)). 

Since [#519](https://github.com/kivikakk/comrak/pull/519/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) already mentions it for the `-e` flag in the CLI, I only added it to the supported extensions list. Went with `Alerts` instead of `Admonitions` since that's what Github & Gitlab seem to refer to it by.

