### PR TITLE
feat: Add compact_html render option to suppress pretty-printing newlines

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -427,10 +427,12 @@ fn render_block_quote<T>(
         context.cr()?;
         context.write_str("<blockquote")?;
         render_sourcepos(context, node)?;
-        context.write_str(">\n")?;
+        context.write_str(">")?;
+        context.lf()?;
     } else {
         context.cr()?;
-        context.write_str("</blockquote>\n")?;
+        context.write_str("</blockquote>")?;
+        context.lf()?;
     }
     Ok(ChildRendering::HTML)
 }
@@ -524,7 +526,8 @@ fn render_code_block<T>(
 
                     context.escape(literal)?;
 
-                    context.write_str("</code></pre>\n")?
+                    context.write_str("</code></pre>")?;
+                    context.lf()?
                 }
                 Some(highlighter) => {
                     highlighter.write_pre_tag(context, pre_attributes)?;
@@ -532,7 +535,8 @@ fn render_code_block<T>(
 
                     highlighter.write_highlighted(context, Some(lang), &ncb.literal)?;
 
-                    context.write_str("</code></pre>\n")?
+                    context.write_str("</code></pre>")?;
+                    context.lf()?
                 }
             }
         }
@@ -581,7 +585,8 @@ fn render_heading<T>(
                     )?;
                 }
             } else {
-                writeln!(context, "</h{}>", nh.level)?;
+                write!(context, "</h{}>", nh.level)?;
+                context.lf()?;
             }
         }
         Some(adapter) => {
@@ -735,7 +740,8 @@ fn render_item<T>(
         render_sourcepos(context, node)?;
         context.write_str(">")?;
     } else {
-        context.write_str("</li>\n")?;
+        context.write_str("</li>")?;
+        context.lf()?;
     }
 
     Ok(ChildRendering::HTML)
@@ -749,7 +755,8 @@ fn render_line_break<T>(
     if entering {
         context.write_str("<br")?;
         render_sourcepos(context, node)?;
-        context.write_str(" />\n")?;
+        context.write_str(" />")?;
+        context.lf()?;
     }
 
     Ok(ChildRendering::HTML)
@@ -806,7 +813,8 @@ fn render_list<T>(
                     context.write_str(" class=\"contains-task-list\"")?;
                 }
                 render_sourcepos(context, node)?;
-                context.write_str(">\n")?;
+                context.write_str(">")?;
+                context.lf()?;
             }
             ListType::Ordered => {
                 context.write_str("<ol")?;
@@ -815,16 +823,20 @@ fn render_list<T>(
                 }
                 render_sourcepos(context, node)?;
                 if nl.start == 1 {
-                    context.write_str(">\n")?;
+                    context.write_str(">")?;
+                    context.lf()?;
                 } else {
-                    writeln!(context, " start=\"{}\">", nl.start)?;
+                    write!(context, " start=\"{}\">", nl.start)?;
+                    context.lf()?;
                 }
             }
         }
     } else if nl.list_type == ListType::Bullet {
-        context.write_str("</ul>\n")?;
+        context.write_str("</ul>")?;
+        context.lf()?;
     } else {
-        context.write_str("</ol>\n")?;
+        context.write_str("</ol>")?;
+        context.lf()?;
     }
 
     Ok(ChildRendering::HTML)
@@ -862,7 +874,8 @@ fn render_paragraph<T>(
                     }
                 }
             }
-            context.write_str("</p>\n")?;
+            context.write_str("</p>")?;
+            context.lf()?;
         }
     }
 
@@ -878,7 +891,8 @@ fn render_soft_break<T>(
         if context.options.render.hardbreaks {
             context.write_str("<br")?;
             render_sourcepos(context, node)?;
-            context.write_str(" />\n")?;
+            context.write_str(" />")?;
+            context.lf()?;
         } else {
             context.write_str("\n")?;
         }
@@ -930,7 +944,8 @@ fn render_thematic_break<T>(
         context.cr()?;
         context.write_str("<hr")?;
         render_sourcepos(context, node)?;
-        context.write_str(" />\n")?;
+        context.write_str(" />")?;
+        context.lf()?;
     }
 
     Ok(ChildRendering::HTML)
@@ -948,7 +963,10 @@ fn render_footnote_definition<T>(
         if context.footnote_ix == 0 {
             context.write_str("<section")?;
             render_sourcepos(context, node)?;
-            context.write_str(" class=\"footnotes\" data-footnotes>\n<ol>\n")?;
+            context.write_str(" class=\"footnotes\" data-footnotes>")?;
+            context.lf()?;
+            context.write_str("<ol>")?;
+            context.lf()?;
         }
         context.footnote_ix += 1;
         context.write_str("<li")?;
@@ -958,9 +976,10 @@ fn render_footnote_definition<T>(
         context.write_str("\">")?;
     } else {
         if put_footnote_backref(context, nfd)? {
-            context.write_str("\n")?;
+            context.lf()?;
         }
-        context.write_str("</li>\n")?;
+        context.write_str("</li>")?;
+        context.lf()?;
     }
 
     Ok(ChildRendering::HTML)
@@ -1047,7 +1066,8 @@ fn render_table<T>(
         context.cr()?;
         context.write_str("<table")?;
         render_sourcepos(context, node)?;
-        context.write_str(">\n")?;
+        context.write_str(">")?;
+        context.lf()?;
     } else {
         if let Some(true) = node
             .last_child()
@@ -1055,10 +1075,12 @@ fn render_table<T>(
         // node.first_child() guaranteed to exist in block since last_child does!
         {
             context.cr()?;
-            context.write_str("</tbody>\n")?;
+            context.write_str("</tbody>")?;
+            context.lf()?;
         }
         context.cr()?;
-        context.write_str("</table>\n")?;
+        context.write_str("</table>")?;
+        context.lf()?;
     }
 
     Ok(ChildRendering::HTML)
@@ -1138,10 +1160,12 @@ fn render_table_row<T>(
     if entering {
         context.cr()?;
         if thead {
-            context.write_str("<thead>\n")?;
+            context.write_str("<thead>")?;
+            context.lf()?;
         } else if let Some(n) = node.previous_sibling() {
             if let NodeValue::TableRow(true) = n.data().value {
-                context.write_str("<tbody>\n")?;
+                context.write_str("<tbody>")?;
+                context.lf()?;
             }
         }
         context.write_str("<tr")?;
@@ -1192,7 +1216,8 @@ fn render_task_item<T>(
         }
         context.write_str(" disabled=\"\" /> ")?;
     } else if write_li {
-        context.write_str("</li>\n")?;
+        context.write_str("</li>")?;
+        context.lf()?;
     }
 
     Ok(ChildRendering::HTML)
@@ -1212,7 +1237,8 @@ fn render_alert<T>(
         context.write_str(alert.alert_type.css_class())?;
         context.write_str("\"")?;
         render_sourcepos(context, node)?;
-        context.write_str(">\n")?;
+        context.write_str(">")?;
+        context.lf()?;
         context.write_str("<p class=\"markdown-alert-title\">")?;
         match alert.title {
             Some(ref title) => context.escape(title)?,
@@ -1220,10 +1246,12 @@ fn render_alert<T>(
                 context.write_str(alert.alert_type.default_title())?;
             }
         }
-        context.write_str("</p>\n")?;
+        context.write_str("</p>")?;
+        context.lf()?;
     } else {
         context.cr()?;
-        context.write_str("</div>\n")?;
+        context.write_str("</div>")?;
+        context.lf()?;
     }
 
     Ok(ChildRendering::HTML)
@@ -1239,7 +1267,8 @@ fn render_description_details<T>(
         render_sourcepos(context, node)?;
         context.write_str(">")?;
     } else {
-        context.write_str("</dd>\n")?;
+        context.write_str("</dd>")?;
+        context.lf()?;
     }
 
     Ok(ChildRendering::HTML)
@@ -1254,9 +1283,11 @@ fn render_description_list<T>(
         context.cr()?;
         context.write_str("<dl")?;
         render_sourcepos(context, node)?;
-        context.write_str(">\n")?;
+        context.write_str(">")?;
+        context.lf()?;
     } else {
-        context.write_str("</dl>\n")?;
+        context.write_str("</dl>")?;
+        context.lf()?;
     }
 
     Ok(ChildRendering::HTML)
@@ -1272,7 +1303,8 @@ fn render_description_term<T>(
         render_sourcepos(context, node)?;
         context.write_str(">")?;
     } else {
-        context.write_str("</dt>\n")?;
+        context.write_str("</dt>")?;
+        context.lf()?;
     }
 
     Ok(ChildRendering::HTML)
@@ -1366,7 +1398,8 @@ pub fn render_math_code_block<T>(
     write_opening_tag(context, "code", code_attributes.into_iter())?;
 
     context.escape(literal)?;
-    context.write_str("</code></pre>\n")?;
+    context.write_str("</code></pre>")?;
+    context.lf()?;
 
     Ok(ChildRendering::HTML)
 }
@@ -1380,10 +1413,12 @@ fn render_multiline_block_quote<T>(
         context.cr()?;
         context.write_str("<blockquote")?;
         render_sourcepos(context, node)?;
-        context.write_str(">\n")?;
+        context.write_str(">")?;
+        context.lf()?;
     } else {
         context.cr()?;
-        context.write_str("</blockquote>\n")?;
+        context.write_str("</blockquote>")?;
+        context.lf()?;
     }
 
     Ok(ChildRendering::HTML)
@@ -1459,7 +1494,8 @@ fn render_subtext<T>(
         render_sourcepos(context, node)?;
         context.write_str(">")?;
     } else {
-        writeln!(context, "</sub></p>")?;
+        write!(context, "</sub></p>")?;
+        context.lf()?;
     }
 
     Ok(ChildRendering::HTML)

--- a/src/html/context.rs
+++ b/src/html/context.rs
@@ -45,7 +45,10 @@ impl<'o, 'c, T> Context<'o, 'c, T> {
 
     pub(super) fn finish(mut self) -> Result<T, fmt::Error> {
         if self.footnote_ix > 0 {
-            self.write_str("</ol>\n</section>\n")?;
+            self.write_str("</ol>")?;
+            self.lf()?;
+            self.write_str("</section>")?;
+            self.lf()?;
         }
         Ok(self.user)
     }
@@ -54,8 +57,21 @@ impl<'o, 'c, T> Context<'o, 'c, T> {
     /// LINE FEED, writes one. Otherwise, does nothing.
     ///
     /// (In other words, ensures the output is at a new line.)
+    ///
+    /// No-op when [`compact_html`](crate::Render::compact_html) is on.
     pub fn cr(&mut self) -> fmt::Result {
+        if self.options.render.compact_html {
+            return Ok(());
+        }
         if !self.last_was_lf.get() {
+            self.write_str("\n")?;
+        }
+        Ok(())
+    }
+
+    /// Writes `\n` unless [`compact_html`](crate::Render::compact_html) is on.
+    pub fn lf(&mut self) -> fmt::Result {
+        if !self.options.render.compact_html {
             self.write_str("\n")?;
         }
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,6 +162,10 @@ struct Cli {
     /// Minimise escapes in CommonMark output using a trial-and-error algorithm
     #[arg(long)]
     experimental_minimize_commonmark: bool,
+
+    /// Suppress pretty-printing newlines between block-level HTML elements
+    #[arg(long)]
+    compact: bool,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -316,6 +320,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .list_style(cli.list_style.into())
         .sourcepos(cli.sourcepos)
         .experimental_minimize_commonmark(cli.experimental_minimize_commonmark)
+        .compact_html(cli.compact)
         .escaped_char_spans(cli.escaped_char_spans)
         .ignore_empty_links(cli.ignore_empty_links)
         .gfm_quirks(cli.gfm_quirks || cli.gfm)

--- a/src/parser/options.rs
+++ b/src/parser/options.rs
@@ -1176,6 +1176,24 @@ pub struct Render {
     /// ```
     #[cfg_attr(feature = "bon", builder(default))]
     pub experimental_minimize_commonmark: bool,
+
+    /// Suppress pretty-printing newlines between block-level HTML elements.
+    ///
+    /// Normally comrak puts a `\n` after closing tags like `</p>`, `</li>`,
+    /// etc.  With this option on, those newlines are omitted.
+    ///
+    /// ```rust
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
+    /// assert_eq!(markdown_to_html("# Hello\n\nWorld.\n", &options),
+    ///            "<h1>Hello</h1>\n<p>World.</p>\n");
+    ///
+    /// options.render.compact_html = true;
+    /// assert_eq!(markdown_to_html("# Hello\n\nWorld.\n", &options),
+    ///            "<h1>Hello</h1><p>World.</p>");
+    /// ```
+    #[cfg_attr(feature = "bon", builder(default))]
+    pub compact_html: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11,6 +11,7 @@ mod autolink;
 mod cjk_friendly_emphasis;
 mod code;
 mod commonmark;
+mod compact_html;
 mod core;
 mod description_lists;
 mod empty;

--- a/src/tests/compact_html.rs
+++ b/src/tests/compact_html.rs
@@ -1,0 +1,87 @@
+use super::*;
+
+#[test]
+fn compact_paragraph() {
+    html_opts!(
+        [render.compact_html],
+        "Hello world.\n",
+        "<p>Hello world.</p>",
+    );
+}
+
+#[test]
+fn compact_multiple_paragraphs() {
+    html_opts!(
+        [render.compact_html],
+        "Paragraph one.\n\nParagraph two.\n",
+        "<p>Paragraph one.</p><p>Paragraph two.</p>",
+    );
+}
+
+#[test]
+fn compact_heading() {
+    html_opts!(
+        [render.compact_html],
+        "# Hello\n\nWorld.\n",
+        "<h1>Hello</h1><p>World.</p>",
+    );
+}
+
+#[test]
+fn compact_list() {
+    html_opts!(
+        [render.compact_html],
+        "- one\n- two\n- three\n",
+        "<ul><li>one</li><li>two</li><li>three</li></ul>",
+    );
+}
+
+#[test]
+fn compact_ordered_list() {
+    html_opts!(
+        [render.compact_html],
+        "1. one\n2. two\n3. three\n",
+        "<ol><li>one</li><li>two</li><li>three</li></ol>",
+    );
+}
+
+#[test]
+fn compact_blockquote() {
+    html_opts!(
+        [render.compact_html],
+        "> quoted\n",
+        "<blockquote><p>quoted</p></blockquote>",
+    );
+}
+
+#[test]
+fn compact_code_block() {
+    html_opts!(
+        [render.compact_html],
+        "```\nhello\n```\n",
+        "<pre><code>hello\n</code></pre>",
+    );
+}
+
+#[test]
+fn compact_thematic_break() {
+    html_opts!([render.compact_html], "---\n", "<hr />",);
+}
+
+#[test]
+fn compact_table() {
+    html_opts!(
+        [extension.table, render.compact_html],
+        "| a | b |\n|---|---|\n| c | d |\n",
+        "<table><thead><tr><th>a</th><th>b</th></tr></thead><tbody><tr><td>c</td><td>d</td></tr></tbody></table>",
+    );
+}
+
+#[test]
+fn compact_default_off() {
+    html_opts!(
+        [render.compact_html = false],
+        "# Hello\n\nWorld.\n",
+        "<h1>Hello</h1>\n<p>World.</p>\n",
+    );
+}


### PR DESCRIPTION
Adds a `compact_html` boolean to `Render` that turns off the `\n` characters comrak normally writes after block-level closing tags (`</p>`, `</li>`, etc).

When the option is off (default) nothing changes. When it's on you get output like:

```html
<h1>Hello</h1><p>World.</p>
```

instead of:

```html
<h1>Hello</h1>
<p>World.</p>
```

Exposed as `--compact` on the CLI.

Closes #768