### PR TITLE
feat: add MathAdapter plugin and pulldown-latex MathML renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "phf",
  "phf_codegen",
  "pretty_assertions",
+ "pulldown-latex",
  "rustc-hash",
  "shell-words",
  "slug",
@@ -836,6 +837,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulldown-latex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b8bc0583825170e3f560701d966dc2f0e3a16946da371e37d30d3ad7207fb7e"
+dependencies = [
+ "bumpalo",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ caseless = "0.2"
 fmt2io = { version = "1.0.0", optional = true }
 jetscii = "0.5.3"
 phf = "0.13"
+pulldown-latex = { version = "0.7", optional = true, default-features = false }
 rustc-hash = "2"
 smallvec = "1.13"
 finl_unicode = { version = "1.4.0", features = ["categories"] }
@@ -71,6 +72,7 @@ default = ["cli", "syntect", "bon"]
 cli = ["clap", "bon", "shell-words", "xdg", "fmt2io", "shortcodes", "phoenix_heex"]
 shortcodes = ["emojis"]
 phoenix_heex = []
+mathml = ["pulldown-latex"]
 bon = ["dep:bon"]
 
 [target.'cfg(all(not(windows), not(target_arch="wasm32")))'.dependencies]
@@ -106,3 +108,7 @@ required-features = [ "syntect" ]
 [[example]]
 name = "s-expr"
 required-features = [ "bon" ]
+
+[[example]]
+name = "math-mathml"
+required-features = [ "mathml" ]

--- a/examples/math-mathml.rs
+++ b/examples/math-mathml.rs
@@ -1,0 +1,33 @@
+//! This example shows how to use the bundled pulldown-latex MathML plugin
+//! to render math content as MathML.
+
+use comrak::plugins::pulldown_latex::PulldownLatexAdapter;
+use comrak::{Options, markdown_to_html_with_plugins, options};
+
+fn main() {
+    let adapter = PulldownLatexAdapter::default();
+
+    let mut options = Options::default();
+    options.extension.math_dollars = true;
+    options.extension.math_code = true;
+
+    let mut plugins = options::Plugins::default();
+    plugins.render.math_renderer = Some(&adapter);
+
+    let examples = [
+        ("Inline math", "The equation $E=mc^2$ is famous."),
+        ("Display math", "$$\\sum_{i=1}^{n} i = \\frac{n(n+1)}{2}$$"),
+        (
+            "Code block math",
+            "```math\n\\int_0^\\infty e^{-x} dx = 1\n```",
+        ),
+    ];
+
+    for (label, input) in examples {
+        println!("=== {} ===", label);
+        println!("Input:  {}", input);
+        let output = markdown_to_html_with_plugins(input, &options, &plugins);
+        println!("Output: {}", output);
+        println!();
+    }
+}

--- a/src/adapters.rs
+++ b/src/adapters.rs
@@ -86,3 +86,26 @@ pub trait HeadingAdapter: Send + Sync {
     /// Render the closing tag.
     fn exit(&self, output: &mut dyn fmt::Write, heading: &HeadingMeta) -> fmt::Result;
 }
+
+/// Implement this adapter for custom rendering of math content.
+///
+/// When set in [`crate::options::RenderPlugins::math_renderer`], this adapter
+/// is called instead of the default math rendering for both inline math
+/// (`$...$`, `` $`...`$ ``) and display math (`$$...$$`, ` ```math `).
+pub trait MathAdapter: Send + Sync {
+    /// Render the given LaTeX math content.
+    ///
+    /// `output`: Write the rendered HTML here.
+    /// `latex`: The raw LaTeX math content.
+    /// `display_math`: `true` for display/block math, `false` for inline math.
+    /// `dollar_math`: `true` for `$`/`$$` syntax, `false` for code math (`` $` `` / ` ```math `).
+    /// `sourcepos`: Source position if `render.sourcepos` is enabled.
+    fn render(
+        &self,
+        output: &mut dyn fmt::Write,
+        latex: &str,
+        display_math: bool,
+        dollar_math: bool,
+        sourcepos: Option<Sourcepos>,
+    ) -> fmt::Result;
+}

--- a/src/html.rs
+++ b/src/html.rs
@@ -1347,6 +1347,22 @@ pub fn render_math<T>(
     nm: &NodeMath,
 ) -> Result<ChildRendering, fmt::Error> {
     if entering {
+        if let Some(adapter) = context.plugins.render.math_renderer {
+            let sourcepos = if context.options.render.sourcepos {
+                Some(node.data().sourcepos)
+            } else {
+                None
+            };
+            adapter.render(
+                context,
+                &nm.literal,
+                nm.display_math,
+                nm.dollar_math,
+                sourcepos,
+            )?;
+            return Ok(ChildRendering::HTML);
+        }
+
         let mut tag_attributes: Vec<(&str, Cow<str>)> = Vec::new();
         let style_attr = if nm.display_math { "display" } else { "inline" };
         let tag: &str = if nm.dollar_math { "span" } else { "code" };
@@ -1372,6 +1388,18 @@ pub fn render_math_code_block<T>(
     node: Node<'_>,
     literal: &str,
 ) -> Result<ChildRendering, fmt::Error> {
+    if let Some(adapter) = context.plugins.render.math_renderer {
+        context.cr()?;
+        let sourcepos = if context.options.render.sourcepos {
+            Some(node.data().sourcepos)
+        } else {
+            None
+        };
+        adapter.render(context, literal, true, false, sourcepos)?;
+        context.lf()?;
+        return Ok(ChildRendering::HTML);
+    }
+
     context.cr()?;
 
     // use vectors to ensure attributes always written in the same order,

--- a/src/parser/options.rs
+++ b/src/parser/options.rs
@@ -8,7 +8,9 @@ use std::panic::RefUnwindSafe;
 use std::str;
 use std::sync::Arc;
 
-use crate::adapters::{CodefenceRendererAdapter, HeadingAdapter, SyntaxHighlighterAdapter};
+use crate::adapters::{
+    CodefenceRendererAdapter, HeadingAdapter, MathAdapter, SyntaxHighlighterAdapter,
+};
 use crate::parser::ResolvedReference;
 
 #[derive(Default, Debug, Clone)]
@@ -1270,6 +1272,17 @@ pub struct RenderPlugins<'p> {
 
     /// Optional heading adapter
     pub heading_adapter: Option<&'p dyn HeadingAdapter>,
+
+    /// Optional math rendering adapter.
+    ///
+    /// When set, math content (from `$...$`, `$$...$$`, `` $`...`$ ``, and
+    /// ` ```math ` blocks) is rendered using this adapter instead of the
+    /// default `<span>`/`<code>` wrapping.
+    ///
+    /// See [`MathAdapter`] for the trait to implement.
+    ///
+    /// [`MathAdapter`]: crate::adapters::MathAdapter
+    pub math_renderer: Option<&'p dyn MathAdapter>,
 }
 
 impl Debug for RenderPlugins<'_> {
@@ -1283,6 +1296,7 @@ impl Debug for RenderPlugins<'_> {
                 "codefence_syntax_highlighter",
                 &"impl SyntaxHighlighterAdapter",
             )
+            .field("math_renderer", &"impl MathAdapter")
             .finish()
     }
 }

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -3,3 +3,7 @@
 #[cfg(feature = "syntect")]
 #[cfg_attr(docsrs, doc(cfg(feature = "syntect")))]
 pub mod syntect;
+
+#[cfg(feature = "mathml")]
+#[cfg_attr(docsrs, doc(cfg(feature = "mathml")))]
+pub mod pulldown_latex;

--- a/src/plugins/pulldown_latex.rs
+++ b/src/plugins/pulldown_latex.rs
@@ -1,0 +1,97 @@
+//! Adapter for the pulldown-latex MathML rendering plugin.
+
+use std::fmt;
+
+use crate::adapters::MathAdapter;
+use crate::nodes::Sourcepos;
+
+#[derive(Debug, Clone, Copy)]
+/// A MathML renderer using [`pulldown_latex`](https://crates.io/crates/pulldown-latex).
+///
+/// Converts LaTeX math content to MathML using the pulldown-latex crate.
+///
+/// When rendering fails (e.g., invalid LaTeX), the adapter falls back to
+/// rendering the raw LaTeX source wrapped in `<span class="math-error">`.
+///
+/// # Example
+///
+/// ```rust
+/// use comrak::plugins::pulldown_latex::PulldownLatexAdapter;
+/// use comrak::{Options, markdown_to_html_with_plugins, options};
+///
+/// let adapter = PulldownLatexAdapter::default();
+/// let mut options = Options::default();
+/// options.extension.math_dollars = true;
+/// let mut plugins = options::Plugins::default();
+/// plugins.render.math_renderer = Some(&adapter);
+///
+/// let result = markdown_to_html_with_plugins("$E=mc^2$", &options, &plugins);
+/// assert!(result.contains("<math"));
+/// ```
+pub struct PulldownLatexAdapter {
+    /// Whether to include a `<annotation>` element with the original LaTeX source.
+    pub include_annotation: bool,
+}
+
+impl Default for PulldownLatexAdapter {
+    fn default() -> Self {
+        Self {
+            include_annotation: true,
+        }
+    }
+}
+
+impl MathAdapter for PulldownLatexAdapter {
+    fn render(
+        &self,
+        output: &mut dyn fmt::Write,
+        latex: &str,
+        display_math: bool,
+        _dollar_math: bool,
+        sourcepos: Option<Sourcepos>,
+    ) -> fmt::Result {
+        let display_mode = if display_math {
+            ::pulldown_latex::config::DisplayMode::Block
+        } else {
+            ::pulldown_latex::config::DisplayMode::Inline
+        };
+
+        let config = ::pulldown_latex::config::RenderConfig {
+            display_mode,
+            annotation: if self.include_annotation {
+                Some(latex)
+            } else {
+                None
+            },
+            ..Default::default()
+        };
+
+        let storage = ::pulldown_latex::Storage::new();
+        let parser = ::pulldown_latex::Parser::new(latex, &storage);
+
+        let mut mathml = String::new();
+        match ::pulldown_latex::mathml::push_mathml(&mut mathml, parser, config) {
+            Ok(()) => {
+                if let Some(sp) = sourcepos {
+                    // pulldown-latex always starts its output with `<math`. We inject
+                    // the data-sourcepos attribute right after that opening token.
+                    // If the output format ever changes, we fall back to writing
+                    // the MathML without sourcepos rather than panicking.
+                    if let Some(rest) = mathml.strip_prefix("<math") {
+                        write!(output, "<math data-sourcepos=\"{sp}\"{rest}")
+                    } else {
+                        output.write_str(&mathml)
+                    }
+                } else {
+                    output.write_str(&mathml)
+                }
+            }
+            Err(_) => {
+                // Graceful fallback: render as escaped text in a <span> with error class.
+                output.write_str("<span class=\"math-error\">")?;
+                crate::html::escape(output, latex)?;
+                output.write_str("</span>")
+            }
+        }
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -206,6 +206,21 @@ fn html_plugins(input: &str, expected: &str, plugins: &options::Plugins) {
 }
 
 #[track_caller]
+fn html_opts_plugins<'c, F>(input: &str, expected: &str, opts: F, plugins: &options::Plugins)
+where
+    F: FnOnce(&mut Options<'c>),
+{
+    let arena = Arena::new();
+    let mut options = Options::default();
+    opts(&mut options);
+
+    let root = parse_document(&arena, input, &options);
+    let mut output = String::new();
+    html::format_document_with_plugins(root, &options, &mut output, plugins).unwrap();
+    compare_strs(&output, expected, "regular", input);
+}
+
+#[track_caller]
 fn xml(input: &str, expected: &str) {
     xml_opts(input, expected, |_| ());
 }

--- a/src/tests/plugins.rs
+++ b/src/tests/plugins.rs
@@ -434,3 +434,318 @@ fn syntect_plugin_with_prefixed_css_classes() {
 
     html_plugins(input, expected, &plugins);
 }
+
+#[test]
+fn math_adapter_inline_dollar() {
+    struct MockMathAdapter;
+
+    impl crate::adapters::MathAdapter for MockMathAdapter {
+        fn render(
+            &self,
+            output: &mut dyn std::fmt::Write,
+            latex: &str,
+            display_math: bool,
+            dollar_math: bool,
+            sourcepos: Option<Sourcepos>,
+        ) -> std::fmt::Result {
+            let display = if display_math { "block" } else { "inline" };
+            let syntax = if dollar_math { "dollar" } else { "code" };
+            if let Some(sp) = sourcepos {
+                write!(
+                    output,
+                    "<math display=\"{display}\" data-syntax=\"{syntax}\" data-sourcepos=\"{sp}\">{latex}</math>"
+                )
+            } else {
+                write!(
+                    output,
+                    "<math display=\"{display}\" data-syntax=\"{syntax}\">{latex}</math>"
+                )
+            }
+        }
+    }
+
+    let adapter = MockMathAdapter;
+    let mut plugins = options::Plugins::default();
+    plugins.render.math_renderer = Some(&adapter);
+
+    html_opts_plugins(
+        "$2+2$",
+        "<p><math display=\"inline\" data-syntax=\"dollar\">2+2</math></p>\n",
+        |opts| opts.extension.math_dollars = true,
+        &plugins,
+    );
+}
+
+#[test]
+fn math_adapter_display_dollar() {
+    struct MockMathAdapter;
+
+    impl crate::adapters::MathAdapter for MockMathAdapter {
+        fn render(
+            &self,
+            output: &mut dyn std::fmt::Write,
+            latex: &str,
+            display_math: bool,
+            _dollar_math: bool,
+            _sourcepos: Option<Sourcepos>,
+        ) -> std::fmt::Result {
+            let display = if display_math { "block" } else { "inline" };
+            write!(output, "<math display=\"{display}\">{latex}</math>")
+        }
+    }
+
+    let adapter = MockMathAdapter;
+    let mut plugins = options::Plugins::default();
+    plugins.render.math_renderer = Some(&adapter);
+
+    html_opts_plugins(
+        "$$2+2$$",
+        "<p><math display=\"block\">2+2</math></p>\n",
+        |opts| opts.extension.math_dollars = true,
+        &plugins,
+    );
+}
+
+#[test]
+fn math_adapter_code_inline() {
+    struct MockMathAdapter;
+
+    impl crate::adapters::MathAdapter for MockMathAdapter {
+        fn render(
+            &self,
+            output: &mut dyn std::fmt::Write,
+            latex: &str,
+            display_math: bool,
+            dollar_math: bool,
+            _sourcepos: Option<Sourcepos>,
+        ) -> std::fmt::Result {
+            let display = if display_math { "block" } else { "inline" };
+            let syntax = if dollar_math { "dollar" } else { "code" };
+            write!(
+                output,
+                "<math display=\"{display}\" data-syntax=\"{syntax}\">{latex}</math>"
+            )
+        }
+    }
+
+    let adapter = MockMathAdapter;
+    let mut plugins = options::Plugins::default();
+    plugins.render.math_renderer = Some(&adapter);
+
+    html_opts_plugins(
+        "$`2+2`$",
+        "<p><math display=\"inline\" data-syntax=\"code\">2+2</math></p>\n",
+        |opts| opts.extension.math_code = true,
+        &plugins,
+    );
+}
+
+#[test]
+fn math_adapter_code_block() {
+    struct MockMathAdapter;
+
+    impl crate::adapters::MathAdapter for MockMathAdapter {
+        fn render(
+            &self,
+            output: &mut dyn std::fmt::Write,
+            latex: &str,
+            display_math: bool,
+            _dollar_math: bool,
+            _sourcepos: Option<Sourcepos>,
+        ) -> std::fmt::Result {
+            let display = if display_math { "block" } else { "inline" };
+            write!(output, "<math display=\"{display}\">{latex}</math>")
+        }
+    }
+
+    let adapter = MockMathAdapter;
+    let mut plugins = options::Plugins::default();
+    plugins.render.math_renderer = Some(&adapter);
+
+    html_opts_plugins(
+        "```math\nx^2\n```",
+        "<math display=\"block\">x^2\n</math>\n",
+        |opts| opts.extension.math_dollars = true,
+        &plugins,
+    );
+}
+
+#[test]
+fn math_adapter_with_sourcepos() {
+    struct MockMathAdapter;
+
+    impl crate::adapters::MathAdapter for MockMathAdapter {
+        fn render(
+            &self,
+            output: &mut dyn std::fmt::Write,
+            latex: &str,
+            display_math: bool,
+            _dollar_math: bool,
+            sourcepos: Option<Sourcepos>,
+        ) -> std::fmt::Result {
+            let display = if display_math { "block" } else { "inline" };
+            if let Some(sp) = sourcepos {
+                write!(
+                    output,
+                    "<math display=\"{display}\" data-sourcepos=\"{sp}\">{latex}</math>"
+                )
+            } else {
+                write!(output, "<math display=\"{display}\">{latex}</math>")
+            }
+        }
+    }
+
+    let adapter = MockMathAdapter;
+    let mut plugins = options::Plugins::default();
+    plugins.render.math_renderer = Some(&adapter);
+
+    html_opts_plugins(
+        "$x$",
+        "<p data-sourcepos=\"1:1-1:3\"><math display=\"inline\" data-sourcepos=\"1:1-1:3\">x</math></p>\n",
+        |opts| {
+            opts.extension.math_dollars = true;
+            opts.render.sourcepos = true;
+        },
+        &plugins,
+    );
+}
+
+#[test]
+fn math_adapter_none_falls_back_to_default() {
+    let plugins = options::Plugins::default();
+
+    html_opts_plugins(
+        "$2+2$",
+        "<p><span data-math-style=\"inline\">2+2</span></p>\n",
+        |opts| opts.extension.math_dollars = true,
+        &plugins,
+    );
+}
+
+#[test]
+#[cfg(feature = "mathml")]
+fn pulldown_latex_inline_math() {
+    let adapter = crate::plugins::pulldown_latex::PulldownLatexAdapter::default();
+    let mut plugins = options::Plugins::default();
+    plugins.render.math_renderer = Some(&adapter);
+
+    let arena = Arena::new();
+    let mut options = Options::default();
+    options.extension.math_dollars = true;
+
+    let root = parse_document(&arena, "$E=mc^2$", &options);
+    let mut output = String::new();
+    html::format_document_with_plugins(root, &options, &mut output, &plugins).unwrap();
+
+    assert!(
+        output.contains("<math"),
+        "Expected MathML output, got: {output}"
+    );
+    assert!(
+        output.contains("display=\"inline\""),
+        "Expected inline display mode, got: {output}"
+    );
+    assert!(
+        output.contains("<annotation encoding=\"application/x-tex\">"),
+        "Expected annotation, got: {output}"
+    );
+}
+
+#[test]
+#[cfg(feature = "mathml")]
+fn pulldown_latex_display_math() {
+    let adapter = crate::plugins::pulldown_latex::PulldownLatexAdapter::default();
+    let mut plugins = options::Plugins::default();
+    plugins.render.math_renderer = Some(&adapter);
+
+    let arena = Arena::new();
+    let mut options = Options::default();
+    options.extension.math_dollars = true;
+
+    let root = parse_document(&arena, "$$\\sum_{i=1}^n i$$", &options);
+    let mut output = String::new();
+    html::format_document_with_plugins(root, &options, &mut output, &plugins).unwrap();
+
+    assert!(
+        output.contains("<math"),
+        "Expected MathML output, got: {output}"
+    );
+    assert!(
+        output.contains("display=\"block\""),
+        "Expected block display mode, got: {output}"
+    );
+}
+
+#[test]
+#[cfg(feature = "mathml")]
+fn pulldown_latex_code_block_math() {
+    let adapter = crate::plugins::pulldown_latex::PulldownLatexAdapter::default();
+    let mut plugins = options::Plugins::default();
+    plugins.render.math_renderer = Some(&adapter);
+
+    let arena = Arena::new();
+    let mut options = Options::default();
+    options.extension.math_dollars = true;
+
+    let root = parse_document(&arena, "```math\n\\frac{1}{2}\n```", &options);
+    let mut output = String::new();
+    html::format_document_with_plugins(root, &options, &mut output, &plugins).unwrap();
+
+    assert!(
+        output.contains("<math"),
+        "Expected MathML output, got: {output}"
+    );
+    assert!(
+        output.contains("display=\"block\""),
+        "Expected block display mode for code block, got: {output}"
+    );
+}
+
+#[test]
+#[cfg(feature = "mathml")]
+fn pulldown_latex_no_annotation() {
+    let adapter = crate::plugins::pulldown_latex::PulldownLatexAdapter {
+        include_annotation: false,
+    };
+    let mut plugins = options::Plugins::default();
+    plugins.render.math_renderer = Some(&adapter);
+
+    let arena = Arena::new();
+    let mut options = Options::default();
+    options.extension.math_dollars = true;
+
+    let root = parse_document(&arena, "$x$", &options);
+    let mut output = String::new();
+    html::format_document_with_plugins(root, &options, &mut output, &plugins).unwrap();
+
+    assert!(
+        output.contains("<math"),
+        "Expected MathML output, got: {output}"
+    );
+    assert!(
+        !output.contains("<annotation"),
+        "Expected no annotation, got: {output}"
+    );
+}
+
+#[test]
+#[cfg(feature = "mathml")]
+fn pulldown_latex_with_sourcepos() {
+    let adapter = crate::plugins::pulldown_latex::PulldownLatexAdapter::default();
+    let mut plugins = options::Plugins::default();
+    plugins.render.math_renderer = Some(&adapter);
+
+    let arena = Arena::new();
+    let mut options = Options::default();
+    options.extension.math_dollars = true;
+    options.render.sourcepos = true;
+
+    let root = parse_document(&arena, "$x$", &options);
+    let mut output = String::new();
+    html::format_document_with_plugins(root, &options, &mut output, &plugins).unwrap();
+
+    assert!(
+        output.contains("data-sourcepos="),
+        "Expected sourcepos attribute, got: {output}"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a `MathAdapter` plugin trait and a built-in `PulldownLatexAdapter` that converts LaTeX math to MathML, addressing #537.

- **`MathAdapter` trait** in `adapters.rs` — custom rendering hook for all math content (`$...$`, `$$...$$`, `` $`...`$ ``, ` ```math `)
- **`math_renderer` field** in `RenderPlugins` — follows the existing `SyntaxHighlighterAdapter` + `SyntectAdapter` pattern
- **`PulldownLatexAdapter`** behind optional `mathml` cargo feature — uses [`pulldown-latex`](https://crates.io/crates/pulldown-latex) (actively maintained, MathML Core spec compliant)
- Graceful fallback: invalid LaTeX renders as escaped text in `<span class="math-error">` instead of failing
- LaTeX source preserved in `<annotation encoding="application/x-tex">` by default (configurable)
- Zero impact when adapter is not set — existing behavior is completely unchanged

## Usage

```rust
use comrak::plugins::pulldown_latex::PulldownLatexAdapter;
use comrak::{Options, markdown_to_html_with_plugins, options};

let adapter = PulldownLatexAdapter::default();
let mut options = Options::default();
options.extension.math_dollars = true;
let mut plugins = options::Plugins::default();
plugins.render.math_renderer = Some(&adapter);

let html = markdown_to_html_with_plugins("$E=mc^2$", &options, &plugins);
// <p><math display="inline"><semantics><mrow>...</mrow>
//   <annotation encoding="application/x-tex">E=mc^2</annotation>
// </semantics></math></p>
```

## Design decisions

- **Plugin adapter (not render option)**: Follows the `SyntaxHighlighterAdapter` pattern. Users can implement `MathAdapter` for custom renderers (KaTeX, MathJax, etc.) without depending on pulldown-latex.
- **`pulldown-latex` over `latex2mathml`**: latex2mathml hasn't been updated since 2020. pulldown-latex is actively maintained (last release Nov 2024), follows MathML Core spec, and has a clean pull-parser API.
- **Optional feature**: `mathml` feature flag keeps the dependency opt-in, not in `default`.

## Test plan

- [x] 6 mock adapter tests (inline dollar, display dollar, code inline, code block, sourcepos, fallback)
- [x] 5 pulldown-latex integration tests (inline, display, code block, no-annotation, sourcepos)
- [x] 1 doctest on `PulldownLatexAdapter`
- [x] All 606 existing tests pass without `mathml` feature (zero regression)
- [x] All 611 tests pass with `mathml` feature
- [x] Clippy clean, `cargo fmt` clean

Closes #537