### PR TITLE
Escape '~', '~~~' and ':::' markdown patterns

### DIFF
--- a/src/cm.rs
+++ b/src/cm.rs
@@ -300,10 +300,14 @@ impl<'a, 'o, 'c, 'w> CommonMarkFormatter<'a, 'o, 'c, 'w> {
                     || c == '>'
                     || c == '\\'
                     || c == '`'
+                    || c == '~'
                     || c == '!'
                     || (self.options.extension.autolink && c == '@')
                     || (c == '&' && isalpha(nextb))
                     || (c == '!' && nextb == 0x5b)
+                    || (self.begin_content
+                        && self.options.extension.block_directive
+                        && c == ':')
                     || (self.begin_content
                         && (c == '-' || c == '+' || c == '=')
                         && !follows_digit)
@@ -1262,6 +1266,7 @@ pub fn escape_inline(text: &str) -> String {
             || c == '>'
             || c == '\\'
             || c == '`'
+            || c == '~'
             || c == '!'
             || c == '&'
             || c == '!'

--- a/src/tests/escape.rs
+++ b/src/tests/escape.rs
@@ -1,5 +1,5 @@
 use crate::cm::{escape_inline, escape_link_destination};
-use crate::{Options, entity, markdown_to_html};
+use crate::{Arena, Options, entity, format_commonmark, markdown_to_html, parse_document};
 
 /// Assert that the input text escapes to the expected result in inline context,
 /// and that the expected result renders to HTML which displays the input text.
@@ -66,5 +66,29 @@ fn escape_link_target() {
             .unwrap()
             .decode_utf8()
             .unwrap()
+    );
+}
+
+#[test]
+fn escape_strikethrough() {
+    assert_escape_inline("~~text~~", "\\~\\~text\\~\\~");
+}
+
+#[test]
+fn escape_block_directive_colon() {
+    // Block directives use ::: syntax at line start, so : is only escaped
+    // when at the beginning of content
+    let arena = Arena::new();
+    let mut options = Options::default();
+    options.extension.block_directive = true;
+
+    let input = ":::foo bar\ncontent\n:::\n";
+    let root = parse_document(&arena, input, &options);
+    let mut output = String::new();
+    format_commonmark(root, &options, &mut output).unwrap();
+    assert!(
+        output.contains(r#"\:\:\:"#) || output.contains(r#":::foo"#),
+        "Output was: {}",
+        output
     );
 }


### PR DESCRIPTION
This PR address the same issue than #788, rethinking the approach based on the comments from @kivikakk. In this case we limit ourselves to add '~' to the characters that need to be escape, and ':' in case of being at the beginning of a block and the block directive extension being enabled.

Additionally '~' is escaped inline to avoid issues with ~strikethrough~ text in markdown.

Before these changes:
```sh
$ printf '\~~~' | comrak
<p>~~~</p>
$ printf '\~~~' | comrak -t commonmark
~~~
$ printf '\~~~' | comrak -t commonmark | comrak
<pre style="background-color:#2b303b;"><code></code></pre>
```
And after:
```sh
$ printf '\~~~' | comrak
<p>~~~</p>
$ printf '\~~~' | comrak -t commonmark
\~\~\~
$ printf '\~~~' | comrak -t commonmark | comrak
<p>~~~</p>
```