### PR TITLE
Add root.validate() calls under html and xml format_document()

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -32,7 +32,7 @@ pub use context::Context;
 
 /// Formats an AST as HTML, modified by the given options.
 pub fn format_document(root: Node<'_>, options: &Options, output: &mut dyn Write) -> fmt::Result {
-    // Validate the AST as part of the debug build. See https://github.com/kivikakk/comrak/issues/371
+    // Validate the AST as part of the debug build. See https://github.com/kivikakk/comrak/issues/371.
     #[cfg(debug_assertions)]
     root.validate().unwrap_or_else(|e| {
         panic!("The document to format is ill-formed: {:?}", e);
@@ -170,7 +170,7 @@ macro_rules! create_formatter {
                 output: &mut dyn ::std::fmt::Write,
                 $(user: $user_type,)?
             ) -> ::std::result::Result<$type, ::std::fmt::Error> {
-                // Validate the ast as part of the debug build. See https://github.com/kivikakk/comrak/issues/371
+                // Validate the AST as part of the debug build. See https://github.com/kivikakk/comrak/issues/371.
                 #[cfg(debug_assertions)]
                 root.validate().unwrap_or_else(|e| {
                     panic!("The document to format is ill-formed: {:?}", e);

--- a/src/html.rs
+++ b/src/html.rs
@@ -32,6 +32,12 @@ pub use context::Context;
 
 /// Formats an AST as HTML, modified by the given options.
 pub fn format_document(root: Node<'_>, options: &Options, output: &mut dyn Write) -> fmt::Result {
+    // Validate the AST as part of the debug build. See https://github.com/kivikakk/comrak/issues/371
+    #[cfg(debug_assertions)]
+    root.validate().unwrap_or_else(|e| {
+        panic!("The document to format is ill-formed: {:?}", e);
+    });
+
     format_document_with_formatter(
         root,
         options,
@@ -164,6 +170,12 @@ macro_rules! create_formatter {
                 output: &mut dyn ::std::fmt::Write,
                 $(user: $user_type,)?
             ) -> ::std::result::Result<$type, ::std::fmt::Error> {
+                // Validate the ast as part of the debug build. See https://github.com/kivikakk/comrak/issues/371
+                #[cfg(debug_assertions)]
+                root.validate().unwrap_or_else(|e| {
+                    panic!("The document to format is ill-formed: {:?}", e);
+                });
+
                 #[allow(unused_mut)]
                 let mut maybe_user = None$(::<$user_type>)?;
                 $(maybe_user = Some::<$user_type>(user);)?

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -11,7 +11,7 @@ const MAX_INDENT: u32 = 40;
 
 /// Formats an AST as HTML, modified by the given options.
 pub fn format_document(root: Node<'_>, options: &Options, output: &mut dyn Write) -> fmt::Result {
-    // Validate the AST as part of the debug build. See https://github.com/kivikakk/comrak/issues/371
+    // Validate the AST as part of the debug build. See https://github.com/kivikakk/comrak/issues/371.
     #[cfg(debug_assertions)]
     root.validate().unwrap_or_else(|e| {
         panic!("The document to format is ill-formed: {:?}", e);

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -11,6 +11,12 @@ const MAX_INDENT: u32 = 40;
 
 /// Formats an AST as HTML, modified by the given options.
 pub fn format_document(root: Node<'_>, options: &Options, output: &mut dyn Write) -> fmt::Result {
+    // Validate the AST as part of the debug build. See https://github.com/kivikakk/comrak/issues/371
+    #[cfg(debug_assertions)]
+    root.validate().unwrap_or_else(|e| {
+        panic!("The document to format is ill-formed: {:?}", e);
+    });
+
     format_document_with_plugins(root, options, output, &Plugins::default())
 }
 


### PR DESCRIPTION
PR for the issue requesting the addition of [AST Validation to non-CommonMark outputs](https://github.com/kivikakk/comrak/issues/441), attempting to follow the footsteps of https://github.com/kivikakk/comrak/pull/425/changes.

## Changes
- Add `root.validate(..)` debug assertions to `format_document(..)`:
  - html.rs
  - xml.rs

## Questions

1. I had wanted to ask, I've never worked with macro definitions, and it made me wonder if it was correct to also add the debug validation call under the `create_formatter` macro. I assumed yes, but had enough doubt that I wanted to ask just in case! 

Sorry for any silly questions or silly assumptions - the longer I looked at things, the more I heard the voices of doubt creep in, so I thought I would get a draft up, and then continue to look through the code to see if I can figure things out/quadruple check that I didn't just fully misunderstand and miss a chunk of required changes :3 