### PR TITLE
Update headers for improved accessibility 

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -613,7 +613,7 @@ fn render_heading<T>(
                     let id = context.anchorizer.anchorize(&text_content);
 
                     write!(context, r##" id="{prefix}{id}""##)?;
-                    context.current_id = Some(id);
+                    context.current_anchorized_id = Some(id);
                 };
 
                 render_sourcepos(context, node)?;
@@ -622,7 +622,7 @@ fn render_heading<T>(
                 if let Some(prefix) = context.options.extension.effective_header_id_prefix() {
                     let text_content = collect_text(node);
                     // let id = context.anchorizer.anchorize(&text_content);
-                    let id = context.current_id.take().unwrap();
+                    let id = context.current_anchorized_id.take().unwrap();
                     let href_prefix = if context.options.extension.header_id_prefix_in_href {
                         prefix.as_str()
                     } else {

--- a/src/html.rs
+++ b/src/html.rs
@@ -621,7 +621,6 @@ fn render_heading<T>(
             } else {
                 if let Some(prefix) = context.options.extension.effective_header_id_prefix() {
                     let text_content = collect_text(node);
-                    // let id = context.anchorizer.anchorize(&text_content);
                     let id = context.current_anchorized_id.take().unwrap();
                     let href_prefix = if context.options.extension.header_id_prefix_in_href {
                         prefix.as_str()

--- a/src/html.rs
+++ b/src/html.rs
@@ -607,9 +607,18 @@ fn render_heading<T>(
             if entering {
                 context.cr()?;
                 write!(context, "<h{}", nh.level)?;
+
+                if let Some(prefix) = context.options.extension.effective_header_id_prefix() {
+                    let text_content = collect_text(node);
+                    let id = context.anchorizer.anchorize(&text_content);
+
+                    write!(context, r##" id="{prefix}{id}""##)?;
+                    // TODO (ozerova): figure out if we care about context.user.last_heading
+                };
+
                 render_sourcepos(context, node)?;
                 context.write_str(">")?;
-
+            } else {
                 if let Some(prefix) = context.options.extension.effective_header_id_prefix() {
                     let text_content = collect_text(node);
                     let id = context.anchorizer.anchorize(&text_content);
@@ -620,11 +629,13 @@ fn render_heading<T>(
                     };
                     write!(
                         context,
-                        "<a href=\"#{}{}\" aria-hidden=\"true\" class=\"anchor\" id=\"{}{}\"></a>",
-                        href_prefix, id, prefix, id
+                        r##"<a href="#{href_prefix}{id}" aria-label="Link to heading '"##
                     )?;
+                    context.escape(&text_content)?;
+                    context.write_str(r#"'" data-heading-content=""#)?;
+                    context.escape(&text_content)?;
+                    context.write_str(r#"" class="anchor"></a>"#)?;
                 }
-            } else {
                 write!(context, "</h{}>", nh.level)?;
                 context.lf()?;
             }

--- a/src/html.rs
+++ b/src/html.rs
@@ -613,7 +613,7 @@ fn render_heading<T>(
                     let id = context.anchorizer.anchorize(&text_content);
 
                     write!(context, r##" id="{prefix}{id}""##)?;
-                    // TODO (ozerova): figure out if we care about context.user.last_heading
+                    context.current_id = Some(id);
                 };
 
                 render_sourcepos(context, node)?;
@@ -621,7 +621,8 @@ fn render_heading<T>(
             } else {
                 if let Some(prefix) = context.options.extension.effective_header_id_prefix() {
                     let text_content = collect_text(node);
-                    let id = context.anchorizer.anchorize(&text_content);
+                    // let id = context.anchorizer.anchorize(&text_content);
+                    let id = context.current_id.take().unwrap();
                     let href_prefix = if context.options.extension.header_id_prefix_in_href {
                         prefix.as_str()
                     } else {

--- a/src/html/context.rs
+++ b/src/html/context.rs
@@ -19,8 +19,8 @@ pub struct Context<'o, 'c, T = ()> {
     pub anchorizer: Anchorizer,
     /// Any user data used by the [`Context`].
     pub user: T,
-    /// TEST REMOVE ME
-    pub current_id: Option<String>,
+    /// Current anchorized id being rendered.
+    pub current_anchorized_id: Option<String>,
 
     pub(super) footnote_ix: u32,
     pub(super) written_footnote_ix: u32,
@@ -40,7 +40,7 @@ impl<'o, 'c, T> Context<'o, 'c, T> {
             plugins,
             anchorizer: Anchorizer::new(),
             user,
-            current_id: None, // Heck, I probs shouldn't be adding a new struct member :(( Will ask @kivikakk
+            current_anchorized_id: None,
             footnote_ix: 0,
             written_footnote_ix: 0,
         }

--- a/src/html/context.rs
+++ b/src/html/context.rs
@@ -1,5 +1,5 @@
 use crate::html::{self, Anchorizer};
-use crate::{Options, options::Plugins};
+use crate::{options::Plugins, Options};
 
 use std::cell::Cell;
 use std::fmt::{self, Write};
@@ -19,6 +19,8 @@ pub struct Context<'o, 'c, T = ()> {
     pub anchorizer: Anchorizer,
     /// Any user data used by the [`Context`].
     pub user: T,
+    /// TEST REMOVE ME
+    pub current_id: Option<String>,
 
     pub(super) footnote_ix: u32,
     pub(super) written_footnote_ix: u32,
@@ -38,6 +40,7 @@ impl<'o, 'c, T> Context<'o, 'c, T> {
             plugins,
             anchorizer: Anchorizer::new(),
             user,
+            current_id: None, // Heck, I probs shouldn't be adding a new struct member :(( Will ask @kivikakk
             footnote_ix: 0,
             written_footnote_ix: 0,
         }

--- a/src/html/context.rs
+++ b/src/html/context.rs
@@ -1,5 +1,5 @@
 use crate::html::{self, Anchorizer};
-use crate::{options::Plugins, Options};
+use crate::{Options, options::Plugins};
 
 use std::cell::Cell;
 use std::fmt::{self, Write};

--- a/src/parser/options.rs
+++ b/src/parser/options.rs
@@ -130,7 +130,7 @@ pub struct Extension<'c> {
     /// let mut options = Options::default();
     /// options.extension.header_id_prefix = Some("user-content-".to_string());
     /// assert_eq!(markdown_to_html("# README\n", &options),
-    ///            "<h1><a href=\"#readme\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-readme\"></a>README</h1>\n");
+    ///            "<h1 id=\"user-content-readme\">README<a href=\"#readme\" aria-label=\"Link to heading 'README'\" data-heading-content=\"README\" class=\"anchor\"></a></h1>\n");
     /// ```
     pub header_id_prefix: Option<String>,
 
@@ -150,7 +150,7 @@ pub struct Extension<'c> {
     /// options.extension.header_id_prefix = Some("user-content-".to_string());
     /// options.extension.header_id_prefix_in_href = true;
     /// assert_eq!(markdown_to_html("# README\n", &options),
-    ///            "<h1><a href=\"#user-content-readme\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-readme\"></a>README</h1>\n");
+    ///            "<h1 id=\"user-content-readme\">README<a href=\"#user-content-readme\" aria-label=\"Link to heading 'README'\" data-heading-content=\"README\" class=\"anchor\"></a></h1>\n");
     /// ```
     #[cfg_attr(feature = "bon", builder(default))]
     pub header_id_prefix_in_href: bool,

--- a/src/tests/header_id_prefix.rs
+++ b/src/tests/header_id_prefix.rs
@@ -13,21 +13,13 @@ fn header_id_prefix() {
             "# Isn't it grand?"
         ),
         concat!(
-            "<h1 id=\"user-content-hi\">Hi.<a href=\"#hi-1\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h1>\n",
-            "<h2 id=\"user-content-hi-1-1\">Hi 1.<a href=\"#hi-1-2\" aria-label=\"Link to heading 'Hi 1.'\" data-heading-content=\"Hi 1.\" class=\"anchor\"></a></h2>\n",
-            "<h3 id=\"user-content-hi-2\">Hi.<a href=\"#hi-3\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h3>\n",
-            "<h4 id=\"user-content-hello\">Hello.<a href=\"#hello-1\" aria-label=\"Link to heading 'Hello.'\" data-heading-content=\"Hello.\" class=\"anchor\"></a></h4>\n",
-            "<h5 id=\"user-content-hi-4\">Hi.<a href=\"#hi-5\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h5>\n",
-            "<h6 id=\"user-content-hello-2\">Hello.<a href=\"#hello-3\" aria-label=\"Link to heading 'Hello.'\" data-heading-content=\"Hello.\" class=\"anchor\"></a></h6>\n",
-            "<h1 id=\"user-content-isnt-it-grand\">Isn't it grand?<a href=\"#isnt-it-grand-1\" aria-label=\"Link to heading 'Isn't it grand?'\" data-heading-content=\"Isn't it grand?\" class=\"anchor\"></a></h1>\n",
-            
-            // "<h1>Hi.<a href=\"#hi\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi\"></a></h1>\n",
-            // "<h2><a href=\"#hi-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-1\"></a>Hi 1.</h2>\n",
-            // "<h3><a href=\"#hi-2\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-2\"></a>Hi.</h3>\n",
-            // "<h4><a href=\"#hello\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello\"></a>Hello.</h4>\n",
-            // "<h5><a href=\"#hi-3\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-3\"></a>Hi.</h5>\n",
-            // "<h6><a href=\"#hello-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello-1\"></a>Hello.</h6>\n",
-            // "<h1><a href=\"#isnt-it-grand\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-isnt-it-grand\"></a>Isn't it grand?</h1>\n"
+            "<h1 id=\"user-content-hi\">Hi.<a href=\"#hi\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h1>\n",
+            "<h2 id=\"user-content-hi-1\">Hi 1.<a href=\"#hi-1\" aria-label=\"Link to heading 'Hi 1.'\" data-heading-content=\"Hi 1.\" class=\"anchor\"></a></h2>\n",
+            "<h3 id=\"user-content-hi-2\">Hi.<a href=\"#hi-2\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h3>\n",
+            "<h4 id=\"user-content-hello\">Hello.<a href=\"#hello\" aria-label=\"Link to heading 'Hello.'\" data-heading-content=\"Hello.\" class=\"anchor\"></a></h4>\n",
+            "<h5 id=\"user-content-hi-3\">Hi.<a href=\"#hi-3\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h5>\n",
+            "<h6 id=\"user-content-hello-1\">Hello.<a href=\"#hello-1\" aria-label=\"Link to heading 'Hello.'\" data-heading-content=\"Hello.\" class=\"anchor\"></a></h6>\n",
+            "<h1 id=\"user-content-isnt-it-grand\">Isn't it grand?<a href=\"#isnt-it-grand\" aria-label=\"Link to heading 'Isn't it grand?'\" data-heading-content=\"Isn't it grand?\" class=\"anchor\"></a></h1>\n"
         ),
         true,
         |opts| opts.extension.header_id_prefix = Some("user-content-".to_owned()),
@@ -47,21 +39,13 @@ fn header_ids_prefix_in_href() {
             "# Isn't it grand?"
         ),
         concat!(
-            "<h1 id=\"user-content-hi\">Hi.<a href=\"#user-content-hi-1\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h1>\n",
-            "<h2 id=\"user-content-hi-1-1\">Hi 1.<a href=\"#user-content-hi-1-2\" aria-label=\"Link to heading 'Hi 1.'\" data-heading-content=\"Hi 1.\" class=\"anchor\"></a></h2>\n",
-            "<h3 id=\"user-content-hi-2\">Hi.<a href=\"#user-content-hi-3\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h3>\n",
-            "<h4 id=\"user-content-hello\">Hello.<a href=\"#user-content-hello-1\" aria-label=\"Link to heading 'Hello.'\" data-heading-content=\"Hello.\" class=\"anchor\"></a></h4>\n",
-            "<h5 id=\"user-content-hi-4\">Hi.<a href=\"#user-content-hi-5\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h5>\n",
-            "<h6 id=\"user-content-hello-2\">Hello.<a href=\"#user-content-hello-3\" aria-label=\"Link to heading 'Hello.'\" data-heading-content=\"Hello.\" class=\"anchor\"></a></h6>\n",
-            "<h1 id=\"user-content-isnt-it-grand\">Isn't it grand?<a href=\"#user-content-isnt-it-grand-1\" aria-label=\"Link to heading 'Isn't it grand?'\" data-heading-content=\"Isn't it grand?\" class=\"anchor\"></a></h1>\n",
-            
-            // "<h1><a href=\"#user-content-hi\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi\"></a>Hi.</h1>\n",
-            // "<h2><a href=\"#user-content-hi-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-1\"></a>Hi 1.</h2>\n",
-            // "<h3><a href=\"#user-content-hi-2\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-2\"></a>Hi.</h3>\n",
-            // "<h4><a href=\"#user-content-hello\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello\"></a>Hello.</h4>\n",
-            // "<h5><a href=\"#user-content-hi-3\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-3\"></a>Hi.</h5>\n",
-            // "<h6><a href=\"#user-content-hello-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello-1\"></a>Hello.</h6>\n",
-            // "<h1><a href=\"#user-content-isnt-it-grand\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-isnt-it-grand\"></a>Isn't it grand?</h1>\n"
+            "<h1 id=\"user-content-hi\">Hi.<a href=\"#user-content-hi\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h1>\n",
+            "<h2 id=\"user-content-hi-1\">Hi 1.<a href=\"#user-content-hi-1\" aria-label=\"Link to heading 'Hi 1.'\" data-heading-content=\"Hi 1.\" class=\"anchor\"></a></h2>\n",
+            "<h3 id=\"user-content-hi-2\">Hi.<a href=\"#user-content-hi-2\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h3>\n",
+            "<h4 id=\"user-content-hello\">Hello.<a href=\"#user-content-hello\" aria-label=\"Link to heading 'Hello.'\" data-heading-content=\"Hello.\" class=\"anchor\"></a></h4>\n",
+            "<h5 id=\"user-content-hi-3\">Hi.<a href=\"#user-content-hi-3\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h5>\n",
+            "<h6 id=\"user-content-hello-1\">Hello.<a href=\"#user-content-hello-1\" aria-label=\"Link to heading 'Hello.'\" data-heading-content=\"Hello.\" class=\"anchor\"></a></h6>\n",
+            "<h1 id=\"user-content-isnt-it-grand\">Isn't it grand?<a href=\"#user-content-isnt-it-grand\" aria-label=\"Link to heading 'Isn't it grand?'\" data-heading-content=\"Isn't it grand?\" class=\"anchor\"></a></h1>\n"
         ),
         true,
         |opts| {

--- a/src/tests/header_id_prefix.rs
+++ b/src/tests/header_id_prefix.rs
@@ -13,13 +13,21 @@ fn header_id_prefix() {
             "# Isn't it grand?"
         ),
         concat!(
-            "<h1><a href=\"#hi\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi\"></a>Hi.</h1>\n",
-            "<h2><a href=\"#hi-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-1\"></a>Hi 1.</h2>\n",
-            "<h3><a href=\"#hi-2\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-2\"></a>Hi.</h3>\n",
-            "<h4><a href=\"#hello\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello\"></a>Hello.</h4>\n",
-            "<h5><a href=\"#hi-3\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-3\"></a>Hi.</h5>\n",
-            "<h6><a href=\"#hello-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello-1\"></a>Hello.</h6>\n",
-            "<h1><a href=\"#isnt-it-grand\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-isnt-it-grand\"></a>Isn't it grand?</h1>\n"
+            "<h1 id=\"user-content-hi\">Hi.<a href=\"#hi-1\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h1>\n",
+            "<h2 id=\"user-content-hi-1-1\">Hi 1.<a href=\"#hi-1-2\" aria-label=\"Link to heading 'Hi 1.'\" data-heading-content=\"Hi 1.\" class=\"anchor\"></a></h2>\n",
+            "<h3 id=\"user-content-hi-2\">Hi.<a href=\"#hi-3\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h3>\n",
+            "<h4 id=\"user-content-hello\">Hello.<a href=\"#hello-1\" aria-label=\"Link to heading 'Hello.'\" data-heading-content=\"Hello.\" class=\"anchor\"></a></h4>\n",
+            "<h5 id=\"user-content-hi-4\">Hi.<a href=\"#hi-5\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h5>\n",
+            "<h6 id=\"user-content-hello-2\">Hello.<a href=\"#hello-3\" aria-label=\"Link to heading 'Hello.'\" data-heading-content=\"Hello.\" class=\"anchor\"></a></h6>\n",
+            "<h1 id=\"user-content-isnt-it-grand\">Isn't it grand?<a href=\"#isnt-it-grand-1\" aria-label=\"Link to heading 'Isn't it grand?'\" data-heading-content=\"Isn't it grand?\" class=\"anchor\"></a></h1>\n",
+            
+            // "<h1>Hi.<a href=\"#hi\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi\"></a></h1>\n",
+            // "<h2><a href=\"#hi-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-1\"></a>Hi 1.</h2>\n",
+            // "<h3><a href=\"#hi-2\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-2\"></a>Hi.</h3>\n",
+            // "<h4><a href=\"#hello\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello\"></a>Hello.</h4>\n",
+            // "<h5><a href=\"#hi-3\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-3\"></a>Hi.</h5>\n",
+            // "<h6><a href=\"#hello-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello-1\"></a>Hello.</h6>\n",
+            // "<h1><a href=\"#isnt-it-grand\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-isnt-it-grand\"></a>Isn't it grand?</h1>\n"
         ),
         true,
         |opts| opts.extension.header_id_prefix = Some("user-content-".to_owned()),
@@ -39,13 +47,21 @@ fn header_ids_prefix_in_href() {
             "# Isn't it grand?"
         ),
         concat!(
-            "<h1><a href=\"#user-content-hi\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi\"></a>Hi.</h1>\n",
-            "<h2><a href=\"#user-content-hi-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-1\"></a>Hi 1.</h2>\n",
-            "<h3><a href=\"#user-content-hi-2\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-2\"></a>Hi.</h3>\n",
-            "<h4><a href=\"#user-content-hello\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello\"></a>Hello.</h4>\n",
-            "<h5><a href=\"#user-content-hi-3\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-3\"></a>Hi.</h5>\n",
-            "<h6><a href=\"#user-content-hello-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello-1\"></a>Hello.</h6>\n",
-            "<h1><a href=\"#user-content-isnt-it-grand\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-isnt-it-grand\"></a>Isn't it grand?</h1>\n"
+            "<h1 id=\"user-content-hi\">Hi.<a href=\"#user-content-hi-1\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h1>\n",
+            "<h2 id=\"user-content-hi-1-1\">Hi 1.<a href=\"#user-content-hi-1-2\" aria-label=\"Link to heading 'Hi 1.'\" data-heading-content=\"Hi 1.\" class=\"anchor\"></a></h2>\n",
+            "<h3 id=\"user-content-hi-2\">Hi.<a href=\"#user-content-hi-3\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h3>\n",
+            "<h4 id=\"user-content-hello\">Hello.<a href=\"#user-content-hello-1\" aria-label=\"Link to heading 'Hello.'\" data-heading-content=\"Hello.\" class=\"anchor\"></a></h4>\n",
+            "<h5 id=\"user-content-hi-4\">Hi.<a href=\"#user-content-hi-5\" aria-label=\"Link to heading 'Hi.'\" data-heading-content=\"Hi.\" class=\"anchor\"></a></h5>\n",
+            "<h6 id=\"user-content-hello-2\">Hello.<a href=\"#user-content-hello-3\" aria-label=\"Link to heading 'Hello.'\" data-heading-content=\"Hello.\" class=\"anchor\"></a></h6>\n",
+            "<h1 id=\"user-content-isnt-it-grand\">Isn't it grand?<a href=\"#user-content-isnt-it-grand-1\" aria-label=\"Link to heading 'Isn't it grand?'\" data-heading-content=\"Isn't it grand?\" class=\"anchor\"></a></h1>\n",
+            
+            // "<h1><a href=\"#user-content-hi\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi\"></a>Hi.</h1>\n",
+            // "<h2><a href=\"#user-content-hi-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-1\"></a>Hi 1.</h2>\n",
+            // "<h3><a href=\"#user-content-hi-2\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-2\"></a>Hi.</h3>\n",
+            // "<h4><a href=\"#user-content-hello\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello\"></a>Hello.</h4>\n",
+            // "<h5><a href=\"#user-content-hi-3\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hi-3\"></a>Hi.</h5>\n",
+            // "<h6><a href=\"#user-content-hello-1\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-hello-1\"></a>Hello.</h6>\n",
+            // "<h1><a href=\"#user-content-isnt-it-grand\" aria-hidden=\"true\" class=\"anchor\" id=\"user-content-isnt-it-grand\"></a>Isn't it grand?</h1>\n"
         ),
         true,
         |opts| {

--- a/www/index.html
+++ b/www/index.html
@@ -15,11 +15,11 @@
     <meta name="description" content="Homepage of Comrak, a CommonMark and GitHub Flavored Markdown parser and renderer. Standalone tool and Rust library.">
     <meta property="og:image" content="https://comrak.ee/comrak.png">
 </head>
-<body>
-<h1><a href="#comrak" aria-hidden="true" class="anchor" id="comrak"></a>Comrak</h1>
+  <body>    
+<h1 id="comrak">Comrak<a href="#comrak" aria-label="Link to heading 'Comrak'" data-heading-content="Comrak" class="anchor"></a></h1>
 <p>Comrak is a <a href="https://commonmark.org/">CommonMark</a> and <a href="https://github.github.com/gfm/">GitHub Flavored Markdown</a> compatible parser and renderer, written in Rust.</p>
 <p>It is <a href="https://github.com/kivikakk/comrak">developed on GitHub</a> by a community of contributors, and released under the <a href="https://github.com/kivikakk/comrak/blob/main/COPYING">BSD 2-clause license</a>, forever<sup class="footnote-ref"><a href="#fn-no-cla" id="fnref-no-cla" data-footnote-ref>1</a></sup>, for use by all.</p>
-<h2><a href="#features" aria-hidden="true" class="anchor" id="features"></a>Features</h2>
+<h2 id="features">Features<a href="#features" aria-label="Link to heading 'Features'" data-heading-content="Features" class="anchor"></a></h2>
 <ul>
 <li>Compatible with <a href="https://spec.commonmark.org/0.31.2/">CommonMark 0.31.2</a> by default.</li>
 <li>One option to toggle on all <a href="https://github.github.com/gfm/">GitHub Flavored Markdown</a> extensions (or enable them separately).</li>
@@ -28,7 +28,7 @@
 <li><a href="https://github.com/kivikakk/comrak#plugins">Pluggable</a> syntax highlighting for code blocks.</li>
 <li><a href="https://docs.rs/comrak/latest/comrak/macro.create_formatter.html">Custom formatter</a> support to override the rendering of any node type.</li>
 </ul>
-<h2><a href="#usage" aria-hidden="true" class="anchor" id="usage"></a>Usage</h2>
+<h2 id="usage">Usage<a href="#usage" aria-label="Link to heading 'Usage'" data-heading-content="Usage" class="anchor"></a></h2>
 <p>Comrak can be used directly on the command-line or as part of a batch processing pipeline, and is available pre-built on <a href="https://github.com/kivikakk/comrak#cli">many platforms</a>.</p>
 <p>It can also be used as a library in Rust as a Cargo dependency, or with <a href="#bindings">bindings to other languages</a>.
 The WASM target lets it be used <a href="https://gitlab-org.gitlab.io/ruby/gems/gitlab-glfm-markdown/">directly in webpages</a>.</p>
@@ -39,14 +39,14 @@ The WASM target lets it be used <a href="https://gitlab-org.gitlab.io/ruby/gems/
 <li><a href="https://github.com/kivikakk/comrak/blob/main/www/footer.html"><code>footer.html</code></a></li>
 </ul>
 <p>The CLI help for the latest version is available in the <a href="https://github.com/kivikakk/comrak#usage">README</a>, and the Rust documentation is on <a href="https://docs.rs/comrak/latest/comrak/">docs.rs</a>.</p>
-<h2><a href="#bindings" aria-hidden="true" class="anchor" id="bindings"></a>Bindings</h2>
+<h2 id="bindings">Bindings<a href="#bindings" aria-label="Link to heading 'Bindings'" data-heading-content="Bindings" class="anchor"></a></h2>
 <ul>
 <li><a href="https://github.com/gjtorikian/commonmarker">Commonmarker</a>, <a href="https://gitlab.com/gitlab-org/ruby/gems/gitlab-glfm-markdown">gitlab-glfm-markdown</a> (Ruby)</li>
 <li><a href="https://mdelixir.dev">MDEx</a> (Elixir)</li>
 <li><a href="https://github.com/lmmx/comrak">comrak</a>, <a href="https://github.com/Martin005/comrak-ext">comrak-ext</a> (Python)</li>
 <li><a href="https://github.com/nberlette/comrak-wasm">comrak-wasm</a> (TypeScript)</li>
 </ul>
-<h2><a href="#who-uses-comrak" aria-hidden="true" class="anchor" id="who-uses-comrak"></a>Who uses Comrak?</h2>
+<h2 id="who-uses-comrak">Who uses Comrak?<a href="#who-uses-comrak" aria-label="Link to heading 'Who uses Comrak?'" data-heading-content="Who uses Comrak?" class="anchor"></a></h2>
 <ul>
 <li><a href="https://crates.io/">crates.io</a> and <a href="https://docs.rs/comrak/latest/comrak/">docs.rs</a></li>
 <li><a href="https://gitlab.com/">GitLab</a></li>
@@ -55,7 +55,7 @@ The WASM target lets it be used <a href="https://gitlab-org.gitlab.io/ruby/gems/
 <li><a href="https://lockbook.net/">Lockbook</a></li>
 <li><a href="https://github.com/kivikakk/comrak/network/dependents">many</a> <a href="https://crates.io/crates/comrak/reverse_dependencies">more!</a></li>
 </ul>
-<h2><a href="#questions-commits-cat-pictures" aria-hidden="true" class="anchor" id="questions-commits-cat-pictures"></a>Questions? Commits? Cat pictures?</h2>
+<h2 id="questions-commits-cat-pictures">Questions? Commits? Cat pictures?<a href="#questions-commits-cat-pictures" aria-label="Link to heading 'Questions? Commits? Cat pictures?'" class="anchor"></a></h2>
 <p>You can contact the maintainers and community <a href="https://github.com/kivikakk/comrak">on GitHub</a>, or you can
 email the author at <a href="mailto:ashe@kivikakk.ee"><code>ashe@kivikakk.ee</code></a>.
 Please report security issues to that email address.</p>


### PR DESCRIPTION
Work to address [Issue 573: Heading anchors should include the inert property](https://github.com/kivikakk/comrak/issues/573).

Tested with cargo-nextest, heavily plagiarized from the wonderful example code at https://gitlab.com/gitlab-org/ruby/gems/gitlab-glfm-markdown/-/blob/33aa7fa32744e4b5249ed18519a11f3295afa9ea/ext/gitlab_glfm_markdown/src/formatter.rs#L473-512, and ummm.. I hope it is alright :3 
