### PR TITLE
Add latex-style math delimiters #469

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ Options:
           
           [possible values: strikethrough, tagfilter, table, autolink, tasklist, superscript,
           footnotes, inline-footnotes, description-lists, multiline-block-quotes, math-dollars,
-          math-code, wikilinks-title-after-pipe, wikilinks-title-before-pipe, underline, subscript,
-          spoiler, greentext, alerts, cjk-friendly-emphasis, subtext, highlight, insert,
-          phoenix-heex, block-directive]
+          math-latex, math-code, wikilinks-title-after-pipe, wikilinks-title-before-pipe,
+          underline, subscript, spoiler, greentext, alerts, cjk-friendly-emphasis, subtext,
+          highlight, insert, phoenix-heex, block-directive]
 
   -t, --to <FORMAT>
           Specify output format

--- a/fuzz/fuzz_targets/all_options.rs
+++ b/fuzz/fuzz_targets/all_options.rs
@@ -63,6 +63,7 @@ struct FuzzExtensionOptions {
     fenced_code_attributes: bool,
     inline_code_attributes: bool,
     link_attributes: bool,
+    math_latex: bool,
     // non-bool below
     header_id_prefix: bool,
     front_matter_delimiter: bool,
@@ -107,6 +108,7 @@ impl FuzzExtensionOptions {
             fenced_code_attributes: self.fenced_code_attributes,
             inline_code_attributes: self.inline_code_attributes,
             link_attributes: self.link_attributes,
+            math_latex: self.math_latex,
             // non-bool below
             header_id_prefix: if self.header_id_prefix {
                 Some("user-content-".into())

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -1075,16 +1075,17 @@ impl<'a, 'o, 'c, 'w> CommonMarkFormatter<'a, 'o, 'c, 'w> {
     fn format_math(&mut self, math: &NodeMath, entering: bool) -> fmt::Result {
         if entering {
             let literal = &math.literal;
-            let start_fence = if math.dollar_math {
-                if math.display_math { "$$" } else { "$" }
-            } else {
-                "$`"
-            };
-
-            let end_fence = if start_fence == "$`" {
-                "`$"
-            } else {
-                start_fence
+            let (start_fence, end_fence) = match (
+                math.dollar_math,
+                math.display_math,
+                self.options.extension.math_latex,
+                self.options.extension.math_dollars,
+            ) {
+                (false, _, _, _) => ("$`", "`$"),
+                (true, true, true, false) => ("\\[", "\\]"),
+                (true, false, true, false) => ("\\(", "\\)"),
+                (true, true, _, _) => ("$$", "$$"),
+                (true, false, _, _) => ("$", "$"),
             };
 
             self.output(start_fence, false, Escaping::Literal)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,6 +204,7 @@ enum Extension {
     DescriptionLists,
     MultilineBlockQuotes,
     MathDollars,
+    MathLatex,
     MathCode,
     WikilinksTitleAfterPipe,
     WikilinksTitleBeforePipe,
@@ -298,6 +299,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .description_lists(exts.contains(&Extension::DescriptionLists))
         .multiline_block_quotes(exts.contains(&Extension::MultilineBlockQuotes))
         .math_dollars(exts.contains(&Extension::MathDollars))
+        .math_latex(exts.contains(&Extension::MathLatex))
         .math_code(exts.contains(&Extension::MathCode))
         .wikilinks_title_after_pipe(exts.contains(&Extension::WikilinksTitleAfterPipe))
         .wikilinks_title_before_pipe(exts.contains(&Extension::WikilinksTitleBeforePipe))

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -221,7 +221,7 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
             b'`' => Some(self.handle_backticks(&ast.line_offsets)),
             b'=' if self.options.extension.highlight => Some(self.handle_delim(b'=')),
             b'+' if self.options.extension.insert => Some(self.handle_delim(b'+')),
-            b'\\' => Some(self.handle_backslash()),
+            b'\\' => Some(self.handle_backslash(&ast.line_offsets)),
             b'&' => Some(self.handle_entity()),
             b'<' => Some(self.handle_pointy_brace(&ast.line_offsets)),
             #[cfg(feature = "phoenix_heex")]
@@ -458,9 +458,13 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
         node
     }
 
-    fn handle_backslash(&mut self) -> Node<'a> {
+    fn handle_backslash(&mut self, parent_line_offsets: &[usize]) -> Node<'a> {
         let startpos = self.scanner.pos;
         self.scanner.pos += 1;
+
+        if let Some(math) = self.handle_latex_math(startpos, parent_line_offsets) {
+            return math;
+        }
 
         if self.peek_byte().is_some_and(ispunct) {
             self.scanner.pos += 1;
@@ -495,6 +499,43 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
                 self.scanner.pos - 1,
             )
         }
+    }
+
+    fn handle_latex_math(
+        &mut self,
+        startpos: usize,
+        parent_line_offsets: &[usize],
+    ) -> Option<Node<'a>> {
+        if !self.options.extension.math_latex {
+            return None;
+        }
+
+        let (closing_delimiter, display_math) = match self.peek_byte()? {
+            b'(' => (b')', false),
+            b'[' => (b']', true),
+            _ => return None,
+        };
+        let content_start = self.scanner.pos + 1;
+        let endpos = self.scan_to_closing_latex_math(content_start, closing_delimiter)?;
+
+        if endpos == content_start {
+            return None;
+        }
+
+        let math = NodeMath {
+            dollar_math: true,
+            display_math,
+            literal: self.input[content_start..endpos].to_string(),
+        };
+        self.scanner.pos = endpos + 2;
+        let node = self.make_inline(NodeValue::Math(math), startpos, self.scanner.pos - 1);
+        self.adjust_node_newlines(
+            node,
+            self.scanner.pos - startpos - 2,
+            2,
+            parent_line_offsets,
+        );
+        Some(node)
     }
 
     fn handle_entity(&mut self) -> Node<'a> {
@@ -2149,6 +2190,20 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
                 return Some(self.scanner.pos);
             }
         }
+    }
+
+    fn scan_to_closing_latex_math(&self, startpos: usize, closing_delimiter: u8) -> Option<usize> {
+        let mut pos = startpos;
+        let bytes = self.input.as_bytes();
+
+        while pos + 1 < bytes.len() {
+            if bytes[pos] == b'\\' && bytes[pos + 1] == closing_delimiter {
+                return Some(pos);
+            }
+            pos += 1;
+        }
+
+        None
     }
 
     fn get_before_char(&self, pos: usize) -> (char, Option<usize>) {

--- a/src/parser/options.rs
+++ b/src/parser/options.rs
@@ -323,6 +323,22 @@ pub struct Extension<'c> {
     #[cfg_attr(feature = "bon", builder(default))]
     pub math_dollars: bool,
 
+    /// Enables math using LaTeX-style delimiters.
+    ///
+    /// ```markdown
+    /// Inline math \(1 + 2\) and display math \[x + y\]
+    /// ```
+    ///
+    /// ```rust
+    /// # use comrak::{markdown_to_html, Options};
+    /// let mut options = Options::default();
+    /// options.extension.math_latex = true;
+    /// assert_eq!(markdown_to_html("\\(1 + 2\\) and \\[x = y\\]", &options),
+    ///            "<p><span data-math-style=\"inline\">1 + 2</span> and <span data-math-style=\"display\">x = y</span></p>\n");
+    /// ```
+    #[cfg_attr(feature = "bon", builder(default))]
+    pub math_latex: bool,
+
     /// Enables math using code syntax.
     ///
     /// ````markdown

--- a/src/tests/commonmark.rs
+++ b/src/tests/commonmark.rs
@@ -67,6 +67,24 @@ fn commonmark_math(markdown: &str, cm: &str) {
     commonmark(markdown, cm, None);
 }
 
+#[test_case("\\(x^2\\) and \\[y^2\\]", "\\(x^2\\) and \\[y^2\\]\n")]
+#[test_case("\\[\nx^2\n\\]", "\\[\nx^2\n\\]\n")]
+fn commonmark_latex_math(markdown: &str, cm: &str) {
+    let mut options = Options::default();
+    options.extension.math_latex = true;
+
+    commonmark(markdown, cm, Some(&options));
+}
+
+#[test_case("\\(x^2\\) and \\[y^2\\]", "$x^2$ and $$y^2$$\n")]
+fn commonmark_latex_math_with_dollars_enabled(markdown: &str, cm: &str) {
+    let mut options = Options::default();
+    options.extension.math_latex = true;
+    options.extension.math_dollars = true;
+
+    commonmark(markdown, cm, Some(&options));
+}
+
 #[test_case("This [[url]] that", "This [[url|url]] that\n")]
 #[test_case("This [[url|link label]] that", "This [[url|link%20label]] that\n")]
 fn commonmark_wikilinks(markdown: &str, cm: &str) {

--- a/src/tests/math.rs
+++ b/src/tests/math.rs
@@ -69,6 +69,45 @@ fn math_dollars_block(markdown: &str, html: &str) {
     html_opts!([extension.math_dollars], markdown, &result);
 }
 
+#[test_case("\\(2+2\\)", "<p><math>2+2</math></p>\n")]
+#[test_case(
+    "Calc \\(x^2\\) and \\(y^2\\)",
+    "<p>Calc <math>x^2</math> and <math>y^2</math></p>\n"
+)]
+#[test_case("\\(\\alpha + \\beta\\)", "<p><math>\\alpha + \\beta</math></p>\n")]
+fn math_latex_inline(markdown: &str, html: &str) {
+    let result = html
+        .replace("<math>", "<span data-math-style=\"inline\">")
+        .replace("</math>", "</span>");
+
+    html_opts!([extension.math_latex], markdown, &result);
+}
+
+#[test_case("\\[2+2\\]", "<p><math>2+2</math></p>\n")]
+#[test_case("\\[\n2+2\n\\]", "<p><math>\n2+2\n</math></p>\n")]
+fn math_latex_display(markdown: &str, html: &str) {
+    let result = html
+        .replace("<math>", "<span data-math-style=\"display\">")
+        .replace("</math>", "</span>");
+
+    html_opts!([extension.math_latex], markdown, &result);
+}
+
+#[test_case("`\\(2+2\\)`", "<p><code>\\(2+2\\)</code></p>\n")]
+#[test_case(
+    "```text\n\\[2+2\\]\n```",
+    "<pre><code class=\"language-text\">\\[2+2\\]\n</code></pre>\n"
+)]
+#[test_case("\\(2+2", "<p>(2+2</p>\n")]
+#[test_case("\\[2+2", "<p>[2+2</p>\n")]
+#[test_case("\\(x\\]", "<p>(x]</p>\n")]
+#[test_case("\\[x\\)", "<p>[x)</p>\n")]
+#[test_case("\\(\\)", "<p>()</p>\n")]
+#[test_case("\\[\\]", "<p>[]</p>\n")]
+fn math_latex_unrecognized_syntax(markdown: &str, html: &str) {
+    html_opts!([extension.math_latex], markdown, html);
+}
+
 #[test_case("$`2+2`$", "<p><math>2+2</math></p>\n")]
 #[test_case("$22 and $`2+2`$", "<p>$22 and <math>2+2</math></p>\n")]
 #[test_case("$`1+\\$2`$", "<p><math>1+\\$2</math></p>\n")]
@@ -158,6 +197,28 @@ fn sourcepos() {
                 (math (3:1-5:2) "\na^2\n")
             ])
             (code_block (7:1-9:3) info:"math" "b^2\n")
+        ])
+    );
+}
+
+#[test]
+fn math_latex_sourcepos() {
+    assert_ast_match!(
+        [extension.math_latex],
+        "\\(x^2\\) and \\[y^2\\]\n"
+        "\n"
+        "\\[\n"
+        "a^2\n"
+        "\\]\n",
+        (document (1:1-5:2) [
+            (paragraph (1:1-1:19) [
+                (math (1:1-1:7) "x^2")
+                (text (1:8-1:12) " and ")
+                (math (1:13-1:19) "y^2")
+            ])
+            (paragraph (3:1-5:2) [
+                (math (3:1-5:2) "\na^2\n")
+            ])
         ])
     );
 }


### PR DESCRIPTION
Added support for  latex `\(` `\)` and `\[` `\]` math delimiters.
Reuses existing math nodes. 
Relates to #469