### PR TITLE
fix: expose alternative syntect backends

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Setup for wasm
       run: rustup target add wasm32-unknown-unknown
     - name: Build
-      run: cargo build --locked --verbose --target wasm32-unknown-unknown --lib
+      run: cargo build --locked --verbose --target wasm32-unknown-unknown --lib --no-default-features --features cli,syntect-fancy,bon
   no_features_build_test:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,11 +68,19 @@ entities = "1"
 phf_codegen = "0.13"
 
 [features]
-default = ["cli", "syntect", "bon"]
+default = ["cli", "syntect-onig", "bon"]
 cli = ["clap", "bon", "shell-words", "xdg", "fmt2io", "shortcodes", "phoenix_heex"]
 shortcodes = ["emojis"]
 phoenix_heex = []
 bon = ["dep:bon"]
+# `syntect` enables the syntect plugin but is backend-neutral; pick a regex
+# backend via `syntect-onig` (C Oniguruma, the default) or `syntect-fancy`
+# (pure-Rust fancy-regex). The fancy backend avoids linking onig_sys, which is
+# required on hosts that already export Oniguruma symbols (e.g. Ruby on Windows
+# mingw), where a second static copy collides at link time.
+syntect = ["dep:syntect"]
+syntect-onig = ["syntect", "syntect/regex-onig"]
+syntect-fancy = ["syntect", "syntect/regex-fancy"]
 
 [target.'cfg(all(not(windows), not(target_arch="wasm32")))'.dependencies]
 xdg = { version = "3", optional = true }
@@ -87,7 +95,6 @@ syntect = { version = "5", optional = true, default-features = false, features =
     "default-themes",
     "default-syntaxes",
     "html",
-    "regex-onig",
 ] }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]


### PR DESCRIPTION
https://github.com/gjtorikian/commonmarker/issues/467 very thoroughly reports a bug which boils down to this: 

* syntect uses Oniguruma as its default regex engine
* Ruby's runtime DLL (on Windows) by default bundles and exports Oniguruma symbols
* at link time, on Windows mingw, there are two definitions of every Oniguruma symbol — one from the statically-linked onig_sys crate, one from Ruby's import library

The best option to fix this that I can think of is to expose "alternative backends" to syntect; fortunately, syntect [allows you to choose your own regex engine](https://github.com/trishume/syntect/#pure-rust-fancy-regex-mode-without-onig). As the pure Rust [fancy-regex](https://github.com/fancy-regex/fancy-regex) is slower than Oniguruma, it makes sense to expose this as a feature, so current users aren't adversely affected.

The one change here that I genuinely feel bad about: I could not for the life of me [figure out how to get the existing wasm builds to work](https://github.com/kivikakk/comrak/actions/runs/28519560234/job/84539864190), without appending `--no-default-features`. The reason is annoying: making the backend selectable means oniguruma can't live in the target-specific dependency table anymore, it has to become a feature, and that feature is on by default. But default features aren't target-aware, so a plain `cargo build --target wasm32-unknown-unknown` cheerfully tries to drag in `onig_sys`, which can't compile for wasm at all (syntect docs note this, too). 

As far as I can tell, Cargo gives me no way to say "onig by default, except on wasm." So the wasm build has to bow out of defaults and ask for syntect-fancy explicitly. If there's a nicer trick here, I'd love to hear it.
