### PR TITLE
Attribute support

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -29,4 +29,4 @@ jobs:
         uses: CodSpeedHQ/action@fa0c9b1770f933c1bc025c83a9b42946b102f4e6 # v4.10.4
         with:
           mode: instrumentation
-          run: cargo codspeed run
+          run: cargo codspeed run --no-default-features

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Install cargo-codspeed
         run: cargo install cargo-codspeed
       - name: Build benchmarks
-        run: cargo codspeed build
+        run: cargo codspeed build --no-default-features
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@fa0c9b1770f933c1bc025c83a9b42946b102f4e6 # v4.10.4
         with:
           mode: instrumentation
-          run: cargo codspeed run --no-default-features
+          run: cargo codspeed run

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -9,3 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: crate-ci/typos@78bc6fb2c0d734235d57a2d6b9de923cc325ebdd # v1.43.4
+        extend_words: ['egal']

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -9,4 +9,3 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
       - uses: crate-ci/typos@78bc6fb2c0d734235d57a2d6b9de923cc325ebdd # v1.43.4
-        extend_words: ['egal']

--- a/.typos.toml
+++ b/.typos.toml
@@ -5,4 +5,7 @@ extend-ignore-re = [
 
   # Ignore hello world fixture demo
   "worl[^\\w]",
+
+  # it's german
+  "egal",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,10 @@ phf_codegen = "0.13"
 
 [features]
 default = ["cli", "syntect-onig", "bon"]
-cli = ["clap", "bon", "shell-words", "xdg", "fmt2io", "shortcodes", "phoenix_heex"]
+cli = ["clap", "bon", "shell-words", "xdg", "fmt2io", "shortcodes", "phoenix_heex", "attributes"]
 shortcodes = ["emojis"]
 phoenix_heex = []
+attributes = []
 bon = ["dep:bon"]
 # `syntect` enables the syntect plugin but is backend-neutral; pick a regex
 # backend via `syntect-onig` (C Oniguruma, the default) or `syntect-fancy`

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ fn replace_text(document: &str, orig_string: &str, replacement: &str) -> String 
 
     // Iterate over all the descendants of root.
     for node in root.descendants() {
-        if let NodeValue::Text(ref mut text) = node.data.borrow_mut().value {
+        if let NodeValue::Text(ref mut text) = node.data_mut().value {
             // If the node is a text node, perform the string replacement.
             *text = text.to_mut().replace(orig_string, replacement).into()
         }

--- a/fuzz/fuzz_targets/all_options.rs
+++ b/fuzz/fuzz_targets/all_options.rs
@@ -5,8 +5,8 @@ use libfuzzer_sys::fuzz_target;
 use std::sync::Arc;
 
 use comrak::{
-    Options, ResolvedReference, markdown_to_commonmark, markdown_to_commonmark_xml,
-    markdown_to_html, options,
+    markdown_to_commonmark, markdown_to_commonmark_xml, markdown_to_html, options, Options,
+    ResolvedReference,
 };
 
 #[derive(Arbitrary, Debug)]
@@ -59,6 +59,11 @@ struct FuzzExtensionOptions {
     phoenix_heex: bool,
     insert: bool,
     header_id_prefix_in_href: bool,
+    header_attributes: bool,
+    fenced_code_attributes: bool,
+    inline_code_attributes: bool,
+    link_attributes: bool,
+    attributes: bool,
     // non-bool below
     header_id_prefix: bool,
     front_matter_delimiter: bool,
@@ -99,6 +104,11 @@ impl FuzzExtensionOptions {
             phoenix_heex: self.phoenix_heex,
             insert: self.insert,
             header_id_prefix_in_href: self.header_id_prefix_in_href,
+            header_attributes: self.header_attributes,
+            fenced_code_attributes: self.fenced_code_attributes,
+            inline_code_attributes: self.inline_code_attributes,
+            link_attributes: self.link_attributes,
+            attributes: self.attributes,
             // non-bool below
             header_id_prefix: if self.header_id_prefix {
                 Some("user-content-".into())

--- a/fuzz/fuzz_targets/all_options.rs
+++ b/fuzz/fuzz_targets/all_options.rs
@@ -5,8 +5,8 @@ use libfuzzer_sys::fuzz_target;
 use std::sync::Arc;
 
 use comrak::{
-    markdown_to_commonmark, markdown_to_commonmark_xml, markdown_to_html, options, Options,
-    ResolvedReference,
+    Options, ResolvedReference, markdown_to_commonmark, markdown_to_commonmark_xml,
+    markdown_to_html, options,
 };
 
 #[derive(Arbitrary, Debug)]
@@ -63,7 +63,6 @@ struct FuzzExtensionOptions {
     fenced_code_attributes: bool,
     inline_code_attributes: bool,
     link_attributes: bool,
-    attributes: bool,
     // non-bool below
     header_id_prefix: bool,
     front_matter_delimiter: bool,
@@ -108,7 +107,6 @@ impl FuzzExtensionOptions {
             fenced_code_attributes: self.fenced_code_attributes,
             inline_code_attributes: self.inline_code_attributes,
             link_attributes: self.link_attributes,
-            attributes: self.attributes,
             // non-bool below
             header_id_prefix: if self.header_id_prefix {
                 Some("user-content-".into())

--- a/src/html/context.rs
+++ b/src/html/context.rs
@@ -61,7 +61,7 @@ impl<'o, 'c, T> Context<'o, 'c, T> {
     ///
     /// (In other words, ensures the output is at a new line.)
     ///
-    /// No-op when [`compact_html`](crate::Render::compact_html) is on.
+    /// No-op when [`compact_html`](crate::options::Render::compact_html) is on.
     pub fn cr(&mut self) -> fmt::Result {
         if self.options.render.compact_html {
             return Ok(());
@@ -72,7 +72,7 @@ impl<'o, 'c, T> Context<'o, 'c, T> {
         Ok(())
     }
 
-    /// Writes `\n` unless [`compact_html`](crate::Render::compact_html) is on.
+    /// Writes `\n` unless [`compact_html`](crate::options::Render::compact_html) is on.
     pub fn lf(&mut self) -> fmt::Result {
         if !self.options.render.compact_html {
             self.write_str("\n")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,6 +218,11 @@ enum Extension {
     Insert,
     PhoenixHeex,
     BlockDirective,
+    HeaderAttributes,
+    FencedCodeAttributes,
+    InlineCodeAttributes,
+    LinkAttributes,
+    Attributes,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -309,6 +314,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         .insert(exts.contains(&Extension::Insert))
         .phoenix_heex(exts.contains(&Extension::PhoenixHeex))
         .block_directive(exts.contains(&Extension::BlockDirective));
+
+    #[cfg(feature = "attributes")]
+    let extension = extension
+        .header_attributes(exts.contains(&Extension::HeaderAttributes))
+        .fenced_code_attributes(exts.contains(&Extension::FencedCodeAttributes))
+        .inline_code_attributes(exts.contains(&Extension::InlineCodeAttributes))
+        .link_attributes(exts.contains(&Extension::LinkAttributes))
+        .attributes(exts.contains(&Extension::Attributes));
 
     #[cfg(feature = "shortcodes")]
     let extension = extension.shortcodes(cli.gemoji);

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,7 +222,6 @@ enum Extension {
     FencedCodeAttributes,
     InlineCodeAttributes,
     LinkAttributes,
-    Attributes,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -320,8 +319,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .header_attributes(exts.contains(&Extension::HeaderAttributes))
         .fenced_code_attributes(exts.contains(&Extension::FencedCodeAttributes))
         .inline_code_attributes(exts.contains(&Extension::InlineCodeAttributes))
-        .link_attributes(exts.contains(&Extension::LinkAttributes))
-        .attributes(exts.contains(&Extension::Attributes));
+        .link_attributes(exts.contains(&Extension::LinkAttributes));
 
     #[cfg(feature = "shortcodes")]
     let extension = extension.shortcodes(cli.gemoji);

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -611,6 +611,20 @@ pub struct NodeBlockDirective {
     pub info: String,
 }
 
+/// TODO
+#[cfg(feature = "attributes")]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct Attributes {
+    /// TODO
+    pub id: Option<String>,
+
+    /// TODO
+    pub classes: Vec<String>,
+
+    /// TODO
+    pub pairs: Vec<(String, String)>,
+}
+
 impl NodeValue {
     /// Indicates whether this node is a block node or inline node.
     pub fn block(&self) -> bool {
@@ -758,6 +772,10 @@ pub struct Ast {
     /// The positions in the source document this node comes from.
     pub sourcepos: Sourcepos,
 
+    #[cfg(feature = "attributes")]
+    /// TODO
+    pub attrs: Option<Box<Attributes>>,
+
     pub(crate) content: String,
     pub(crate) open: bool,
     pub(crate) last_line_blank: bool,
@@ -772,13 +790,13 @@ impl std::fmt::Debug for Ast {
 }
 
 #[allow(dead_code)]
-#[cfg(target_pointer_width = "64")]
+#[cfg(all(target_pointer_width = "64", not(feature = "attributes")))]
 /// Assert the size of Ast is 128 bytes. It's pretty big; let's stop it getting
 /// bigger.
 const AST_SIZE_ASSERTION: [u8; 128] = [0; std::mem::size_of::<Ast>()];
 
 #[allow(dead_code)]
-#[cfg(target_pointer_width = "64")]
+#[cfg(all(target_pointer_width = "64", not(feature = "attributes")))]
 /// Assert the total size of what we allocate in the Arena, for reference.
 ///
 /// Note that the size adds to Ast:
@@ -883,6 +901,8 @@ impl Ast {
             value,
             content: String::new(),
             sourcepos: (start.line, start.column, start.line, 0).into(),
+            #[cfg(feature = "attributes")]
+            attrs: None,
             open: true,
             last_line_blank: false,
             table_visited: false,
@@ -896,6 +916,8 @@ impl Ast {
             value,
             content: String::new(),
             sourcepos,
+            #[cfg(feature = "attributes")]
+            attrs: None,
             open: true,
             last_line_blank: false,
             table_visited: false,

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -611,17 +611,44 @@ pub struct NodeBlockDirective {
     pub info: String,
 }
 
-/// TODO
+/// Attributes on the node, if any.
+///
+/// These are somewhat HTML-specific in nature, though none are formatted
+/// automatically to HTML.  There may be an `id` (specified like "#xyz" in the
+/// source document; last ID-like attribute wins), zero or more `classes`
+/// (specified like ".abc" in the source document), and zero or more `pairs`
+/// (specified like "a=b" in the source document).
+///
+/// Attribute values may be quoted as follows:
+///
+/// * `#"id with spaces in it"`
+/// * `."class with \"double quotes\" in it"`
+/// * `pair="with spaces and such in the value"`
+///
+/// Pair keys may not be quoted.  You can't open quotes late or close them early.
+/// Backslashes escape whatever character follows them within quotes.
+/// Newlines are not permitted in quoted values, but they are permitted around
+/// attribute values when attached to an inline, e.g.:
+///
+/// ```markdown
+/// Some `code`{
+///   a="hello"
+///   b="privyet"
+/// }
+/// ```
+///
+/// Take care that you don't lead such lines with four or more spaces relative to
+/// the block offset, or you'll get an unwanted code block!
 #[cfg(feature = "attributes")]
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct Attributes {
-    /// TODO
+    /// The id attribute, if any; specified like `#id` (last wins).
     pub id: Option<String>,
 
-    /// TODO
+    /// Class attributes, if any; specified like `.a .b`.
     pub classes: Vec<String>,
 
-    /// TODO
+    /// Attribute pairs, if any; specified like `a=b c=d`.
     pub pairs: Vec<(String, String)>,
 }
 
@@ -773,7 +800,7 @@ pub struct Ast {
     pub sourcepos: Sourcepos,
 
     #[cfg(feature = "attributes")]
-    /// TODO
+    /// [Attributes] on this node, if any.
     pub attrs: Option<Box<Attributes>>,
 
     pub(crate) content: String,

--- a/src/parser/attributes.rs
+++ b/src/parser/attributes.rs
@@ -156,38 +156,37 @@ pub fn parse_off_attributes(content: &mut String) -> Option<Attributes> {
 
         seen_close = seen_close || c == '}';
 
-        if c == '{'
-            && seen_close
-            && let Some((attrs, j)) = parse_attributes(&content[i..])
-        {
-            // There should be nothing but whitespace (if anything) after.
-            // Feeling generous so it can be Unicode whitespace even.
-            // XXX: We can possibly fold this assertion into the above state
-            // tracking? :inuthonk:
-            if !content[i + j..].chars().all(char::is_whitespace) {
-                return None;
-            }
+        if c == '{' && seen_close {
+            if let Some((attrs, j)) = parse_attributes(&content[i..]) {
+                // There should be nothing but whitespace (if anything) after.
+                // Feeling generous so it can be Unicode whitespace even.
+                // XXX: We can possibly fold this assertion into the above state
+                // tracking? :inuthonk:
+                if !content[i + j..].chars().all(char::is_whitespace) {
+                    return None;
+                }
 
-            // Either there's nothing left (fine!) ORRRRR there's *at least*
-            // one (but possibly multiple) whitespace, which we truncate.
-            let Some((mut i, c)) = ci.next() else {
+                // Either there's nothing left (fine!) ORRRRR there's *at least*
+                // one (but possibly multiple) whitespace, which we truncate.
+                let Some((mut i, c)) = ci.next() else {
+                    content.truncate(i);
+                    return Some(attrs);
+                };
+
+                if !c.is_whitespace() {
+                    return None;
+                }
+
+                while let Some((i2, c)) = ci.next() {
+                    if !c.is_whitespace() {
+                        break;
+                    }
+                    i = i2;
+                }
+
                 content.truncate(i);
                 return Some(attrs);
-            };
-
-            if !c.is_whitespace() {
-                return None;
             }
-
-            while let Some((i2, c)) = ci.next() {
-                if !c.is_whitespace() {
-                    break;
-                }
-                i = i2;
-            }
-
-            content.truncate(i);
-            return Some(attrs);
         }
     }
 }

--- a/src/parser/attributes.rs
+++ b/src/parser/attributes.rs
@@ -10,13 +10,23 @@ pub fn parse_attributes(input: &str) -> Option<(Attributes, usize)> {
 
     enum State {
         Betwixt,
-        Value(Kind, String),
+        Value(Kind, String, Quote),
+        Key(String),
+        PostQuote,
     }
 
+    #[derive(Default)]
     enum Kind {
+        #[default]
         Id,
         Class,
         Pair(String),
+    }
+
+    enum Quote {
+        Bare,
+        Quoted,
+        QuotedEscaped,
     }
 
     let mut state = State::Betwixt;
@@ -29,17 +39,26 @@ pub fn parse_attributes(input: &str) -> Option<(Attributes, usize)> {
             match state {
                 State::Betwixt => match c {
                     '#' => {
-                        state = State::Value(Kind::Id, String::new());
+                        state = State::Value(Kind::Id, String::new(), Quote::Bare);
                         break;
                     }
                     '.' => {
-                        state = State::Value(Kind::Class, String::new());
+                        state = State::Value(Kind::Class, String::new(), Quote::Bare);
+                        break;
+                    }
+                    'a'..='z' | 'A'..='Z' => {
+                        state = State::Key(c.to_string());
                         break;
                     }
                     '}' => return Some((attrs, i + 1)),
-                    _ => todo!(),
+                    ' ' | '\t' => break,
+                    _ => return None,
                 },
-                State::Value(ref kind, ref mut value) => match c {
+                State::Value(ref mut kind, ref mut value, Quote::Bare) => match c {
+                    '"' if value.is_empty() => {
+                        state = State::Value(mem::take(kind), mem::take(value), Quote::Quoted);
+                        break;
+                    }
                     // An id can contain [literally anything] in HTML5, just so long as it's non-empty.
                     // Consider looking at how Pandoc parses this part.
                     // Per above, classes are also literally anything, *except* ASCII whitespace.
@@ -51,14 +70,74 @@ pub fn parse_attributes(input: &str) -> Option<(Attributes, usize)> {
                     }
                     ' ' | '}' => {
                         match kind {
-                            Kind::Id => attrs.id = Some(mem::take(value)),
-                            Kind::Class => attrs.classes.push(mem::take(value)),
-                            _ => todo!(),
+                            Kind::Id => {
+                                if value.is_empty() {
+                                    return None;
+                                }
+                                attrs.id = Some(mem::take(value));
+                            }
+                            Kind::Class => {
+                                if value.is_empty() {
+                                    return None;
+                                }
+                                attrs.classes.push(mem::take(value));
+                            }
+                            Kind::Pair(key) => attrs.pairs.push((mem::take(key), mem::take(value))),
                         }
                         state = State::Betwixt;
                         // handle in loop
                     }
                     _ => todo!(),
+                },
+                State::Value(ref mut kind, ref mut value, Quote::Quoted) => match c {
+                    '"' => {
+                        // XXX: duplicates above, wish it didn't.
+                        match kind {
+                            Kind::Id => attrs.id = Some(mem::take(value)),
+                            Kind::Class => attrs.classes.push(mem::take(value)),
+                            Kind::Pair(key) => attrs.pairs.push((mem::take(key), mem::take(value))),
+                        }
+                        state = State::PostQuote;
+                        break;
+                    }
+                    '\\' => {
+                        state =
+                            State::Value(mem::take(kind), mem::take(value), Quote::QuotedEscaped);
+                        break;
+                    }
+                    _ => {
+                        value.push(c);
+                        break;
+                    }
+                },
+                State::Value(ref mut kind, ref mut value, Quote::QuotedEscaped) => {
+                    value.push(c);
+                    state = State::Value(mem::take(kind), mem::take(value), Quote::Quoted);
+                    break;
+                }
+                State::Key(ref mut key) => match c {
+                    // "Except where otherwise specified, attribute values on HTML elements may be any string value,
+                    // including the empty string, and there is no restriction on what text can be specified in such
+                    // attribute values."
+                    // ¯\_(ツ)_/¯ I'm not driving
+                    'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | ':' | '.' => {
+                        key.push(c);
+                        break;
+                    }
+                    '=' => {
+                        state =
+                            State::Value(Kind::Pair(mem::take(key)), String::new(), Quote::Bare);
+                        break;
+                    }
+                    _ => return None,
+                },
+                State::PostQuote => match c {
+                    // Require a space after quote before anything else.
+                    ' ' | '}' => {
+                        state = State::Betwixt;
+                        // handle in loop
+                    }
+                    _ => return None,
                 },
             }
         }
@@ -71,7 +150,7 @@ mod tests {
 
     #[test]
     fn trivial() {
-        assert!(parse_attributes("").is_none());
+        assert_eq!(parse_attributes(""), None);
 
         assert_eq!(
             parse_attributes("{#henlo} there"),
@@ -96,6 +175,17 @@ mod tests {
         );
 
         assert_eq!(
+            parse_attributes("{data-thingy=ya}"),
+            Some((
+                Attributes {
+                    pairs: vec![("data-thingy".to_string(), "ya".to_string())],
+                    ..Default::default()
+                },
+                16
+            ))
+        );
+
+        assert_eq!(
             parse_attributes("{.oken #yip m=26 .sure x=3 #yap} oh!"),
             Some((
                 Attributes {
@@ -106,28 +196,43 @@ mod tests {
                         ("x".to_string(), "3".to_string())
                     ]
                 },
-                7 // XXX
+                32
             ))
         );
 
         assert_eq!(
             parse_attributes(
-                "{#\"has space, will travel\" .\"ok\\\"en\" title=\"surely \\\"not\\\"\"}"
+                "{#\"has space, will travel\" .\"ok\\\"en\" title=\"是非 \\\"not\\\"\"}"
             ),
             Some((
                 Attributes {
                     id: Some("has space, will travel".to_string()),
                     classes: vec!["ok\"en".to_string(),],
-                    pairs: vec![("title".to_string(), "surely \"not\"".to_string())],
+                    pairs: vec![("title".to_string(), "是非 \"not\"".to_string())],
                 },
-                7 // XXX
+                60
             ))
         );
 
-        assert!(parse_attributes("{#}").is_none());
-        assert_eq!(parse_attributes("{}"), Some(Default::default()));
-        assert!(parse_attributes("{.}").is_none());
-        assert!(parse_attributes("{uh").is_none());
-        assert!(parse_attributes("{yeah\nnah}").is_none());
+        assert_eq!(parse_attributes("{#}"), None);
+        assert_eq!(parse_attributes("{}"), Some((Attributes::default(), 2)));
+        assert_eq!(parse_attributes("{.}"), None);
+        assert_eq!(parse_attributes("{uh"), None);
+        assert_eq!(parse_attributes("{yeah\nnah}"), None);
+
+        assert_eq!(
+            parse_attributes("{hi=}"),
+            Some((
+                Attributes {
+                    pairs: vec![("hi".to_string(), String::new())],
+                    ..Default::default()
+                },
+                5
+            ))
+        );
+
+        // XXX: I kind of feel like this should be equivalent to above.
+        // Check Pandoc.
+        assert_eq!(parse_attributes("{hi}"), None);
     }
 }

--- a/src/parser/attributes.rs
+++ b/src/parser/attributes.rs
@@ -72,19 +72,12 @@ pub fn parse(input: &str) -> Option<(Attributes, usize)> {
                         break;
                     }
                     ' ' | '\t' | '\r' | '\n' | '}' => {
+                        if value.is_empty() {
+                            return None;
+                        }
                         match kind {
-                            Kind::Id => {
-                                if value.is_empty() {
-                                    return None;
-                                }
-                                attrs.id = Some(mem::take(value));
-                            }
-                            Kind::Class => {
-                                if value.is_empty() {
-                                    return None;
-                                }
-                                attrs.classes.push(mem::take(value));
-                            }
+                            Kind::Id => attrs.id = Some(mem::take(value)),
+                            Kind::Class => attrs.classes.push(mem::take(value)),
                             Kind::Pair(key) => attrs.pairs.push((mem::take(key), mem::take(value))),
                         }
                         state = State::Betwixt;
@@ -321,20 +314,19 @@ mod tests {
             ))
         );
 
+        // Consistent with Pandoc's commonmark+attributes.
+        assert_eq!(parse("{hi}"), None);
+        assert_eq!(parse("{hi=}"), None);
         assert_eq!(
-            parse("{hi=}"),
+            parse("{hi=\"\"}"),
             Some((
                 Attributes {
                     pairs: vec![("hi".to_string(), String::new())],
                     ..Default::default()
                 },
-                5
+                7
             ))
         );
-
-        // XXX: I kind of feel like this should be equivalent to above.
-        // Check Pandoc.
-        assert_eq!(parse("{hi}"), None);
     }
 
     fn assert_parse_off(input: &str, expected_str: &str, expected_attrs: Option<Attributes>) {

--- a/src/parser/attributes.rs
+++ b/src/parser/attributes.rs
@@ -144,12 +144,60 @@ pub fn parse_attributes(input: &str) -> Option<(Attributes, usize)> {
     }
 }
 
+pub fn parse_off_attributes(content: &mut String) -> Option<Attributes> {
+    let mut ci = content.char_indices().rev();
+    // This is a very mid check. We can track state backwards
+    // to know exactly when to attempt the parse; we care only
+    // about '}', '"', '\', '}'. XXX
+    let mut seen_close = false;
+
+    loop {
+        let (i, c) = ci.next()?;
+
+        seen_close = seen_close || c == '}';
+
+        if c == '{'
+            && seen_close
+            && let Some((attrs, j)) = parse_attributes(&content[i..])
+        {
+            // There should be nothing but whitespace (if anything) after.
+            // Feeling generous so it can be Unicode whitespace even.
+            // XXX: We can possibly fold this assertion into the above state
+            // tracking? :inuthonk:
+            if !content[i + j..].chars().all(char::is_whitespace) {
+                return None;
+            }
+
+            // Either there's nothing left (fine!) ORRRRR there's *at least*
+            // one (but possibly multiple) whitespace, which we truncate.
+            let Some((mut i, c)) = ci.next() else {
+                content.truncate(i);
+                return Some(attrs);
+            };
+
+            if !c.is_whitespace() {
+                return None;
+            }
+
+            while let Some((i2, c)) = ci.next() {
+                if !c.is_whitespace() {
+                    break;
+                }
+                i = i2;
+            }
+
+            content.truncate(i);
+            return Some(attrs);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn trivial() {
+    fn fundamentals() {
         assert_eq!(parse_attributes(""), None);
 
         assert_eq!(
@@ -234,5 +282,25 @@ mod tests {
         // XXX: I kind of feel like this should be equivalent to above.
         // Check Pandoc.
         assert_eq!(parse_attributes("{hi}"), None);
+    }
+
+    fn assert_parse_off(input: &str, expected_str: &str, expected_attrs: Option<Attributes>) {
+        let mut s = input.to_string();
+        let attrs = parse_off_attributes(&mut s);
+        assert_eq!(s, expected_str);
+        assert_eq!(attrs, expected_attrs);
+    }
+
+    #[test]
+    fn parse_off() {
+        assert_parse_off("hi", "hi", None);
+        assert_parse_off(
+            "hi  {#yay}",
+            "hi",
+            Some(Attributes {
+                id: Some("yay".to_string()),
+                ..Default::default()
+            }),
+        );
     }
 }

--- a/src/parser/attributes.rs
+++ b/src/parser/attributes.rs
@@ -2,7 +2,7 @@ use std::mem;
 
 use crate::nodes::Attributes;
 
-pub fn parse_attributes(input: &str) -> Option<(Attributes, usize)> {
+pub fn parse(input: &str) -> Option<(Attributes, usize)> {
     let mut ci = input.char_indices();
     if ci.next()?.1 != '{' {
         return None;
@@ -147,50 +147,91 @@ pub fn parse_attributes(input: &str) -> Option<(Attributes, usize)> {
     }
 }
 
-pub fn parse_off_attributes(content: &mut String) -> Option<Attributes> {
+/// Use this only in contexts where there can *not* be any following text
+/// and the attribute set still valid; i.e. blocks are OK, inlines are not.
+pub fn parse_off(content: &mut String) -> Option<Attributes> {
     let mut ci = content.char_indices().rev();
-    // This is a very mid check. We can track state backwards
-    // to know exactly when to attempt the parse; we care only
-    // about '}', '"', '\', '}'. XXX
-    let mut seen_close = false;
+
+    enum State {
+        Pre,
+        Within,
+        Quoted,
+        /// We've hit an opening quote, but there could be a backslash behind it;
+        /// if there is, return to Quoted, otherwise go to Within and reparse.
+        MaybeQuoteEnd,
+    }
+
+    let mut state = State::Pre;
+    let mut end = None;
 
     loop {
         let (i, c) = ci.next()?;
 
-        seen_close = seen_close || c == '}';
-
-        if c == '{' && seen_close {
-            if let Some((attrs, j)) = parse_attributes(&content[i..]) {
-                // There should be nothing but whitespace (if anything) after.
-                // Feeling generous so it can be Unicode whitespace even.
-                // XXX: We can possibly fold this assertion into the above state
-                // tracking? :inuthonk:
-                if !content[i + j..].chars().all(char::is_whitespace) {
-                    // For now, we might be within an attribute value, so we
-                    // must keep on.
-                    continue;
-                }
-
-                // Either there's nothing left (fine!) ORRRRR there's *at least*
-                // one (but possibly multiple) whitespace, which we truncate.
-                let Some((mut i, c)) = ci.next() else {
-                    content.truncate(i);
-                    return Some(attrs);
-                };
-
-                if !c.is_whitespace() {
-                    return None;
-                }
-
-                for (i2, c) in ci {
-                    if !c.is_whitespace() {
+        loop {
+            match state {
+                State::Pre => match c {
+                    '}' => {
+                        end = Some(i + 1);
+                        state = State::Within;
                         break;
                     }
-                    i = i2;
-                }
+                    _ if c.is_whitespace() => break,
+                    _ => return None,
+                },
+                State::Within => match c {
+                    '"' => {
+                        state = State::Quoted;
+                        break;
+                    }
+                    '{' => {
+                        let (attrs, j) = parse(&content[i..])?;
 
-                content.truncate(i);
-                return Some(attrs);
+                        // We can't transition into Within without setting `end`.
+                        // If these don't match up, something is Bad.
+                        if i + j != end.unwrap() {
+                            return None;
+                        }
+
+                        // Either there's nothing left (fine!) ORRRRR there's *at least*
+                        // one (but possibly multiple) whitespace, which we truncate.
+                        let Some((mut i, c)) = ci.next() else {
+                            content.truncate(i);
+                            return Some(attrs);
+                        };
+
+                        if !c.is_whitespace() {
+                            return None;
+                        }
+
+                        for (i2, c) in ci {
+                            if !c.is_whitespace() {
+                                break;
+                            }
+                            i = i2;
+                        }
+
+                        content.truncate(i);
+                        return Some(attrs);
+                    }
+                    _ => break,
+                },
+                State::Quoted => match c {
+                    '"' => {
+                        state = State::MaybeQuoteEnd;
+                        break;
+                    }
+                    _ => break,
+                },
+                State::MaybeQuoteEnd => match c {
+                    '\\' => {
+                        state = State::Quoted;
+                        break;
+                    }
+                    _ => {
+                        state = State::Within;
+                        // handle in loop
+                    }
+                },
             }
         }
     }
@@ -202,10 +243,10 @@ mod tests {
 
     #[test]
     fn fundamentals() {
-        assert_eq!(parse_attributes(""), None);
+        assert_eq!(parse(""), None);
 
         assert_eq!(
-            parse_attributes("{#henlo} there"),
+            parse("{#henlo} there"),
             Some((
                 Attributes {
                     id: Some("henlo".to_string()),
@@ -216,7 +257,7 @@ mod tests {
         );
 
         assert_eq!(
-            parse_attributes("{.oken}"),
+            parse("{.oken}"),
             Some((
                 Attributes {
                     classes: vec!["oken".to_string()],
@@ -227,7 +268,7 @@ mod tests {
         );
 
         assert_eq!(
-            parse_attributes("{data-thingy=ya}"),
+            parse("{data-thingy=ya}"),
             Some((
                 Attributes {
                     pairs: vec![("data-thingy".to_string(), "ya".to_string())],
@@ -238,7 +279,7 @@ mod tests {
         );
 
         assert_eq!(
-            parse_attributes("{.oken #yip m=26 .sure x=3 #yap} oh!"),
+            parse("{.oken #yip m=26 .sure x=3 #yap} oh!"),
             Some((
                 Attributes {
                     id: Some("yap".to_string()),
@@ -253,9 +294,7 @@ mod tests {
         );
 
         assert_eq!(
-            parse_attributes(
-                "{#\"has space, will travel\" .\"ok\\\"en\" title=\"是非 \\\"not\\\"\"}"
-            ),
+            parse("{#\"has space, will travel\" .\"ok\\\"en\" title=\"是非 \\\"not\\\"\"}"),
             Some((
                 Attributes {
                     id: Some("has space, will travel".to_string()),
@@ -266,13 +305,13 @@ mod tests {
             ))
         );
 
-        assert_eq!(parse_attributes("{#}"), None);
-        assert_eq!(parse_attributes("{}"), Some((Attributes::default(), 2)));
-        assert_eq!(parse_attributes("{.}"), None);
-        assert_eq!(parse_attributes("{uh"), None);
+        assert_eq!(parse("{#}"), None);
+        assert_eq!(parse("{}"), Some((Attributes::default(), 2)));
+        assert_eq!(parse("{.}"), None);
+        assert_eq!(parse("{uh"), None);
 
         assert_eq!(
-            parse_attributes("{.why\n.not}"),
+            parse("{.why\n.not}"),
             Some((
                 Attributes {
                     classes: vec!["why".to_string(), "not".to_string()],
@@ -283,7 +322,7 @@ mod tests {
         );
 
         assert_eq!(
-            parse_attributes("{hi=}"),
+            parse("{hi=}"),
             Some((
                 Attributes {
                     pairs: vec![("hi".to_string(), String::new())],
@@ -295,18 +334,18 @@ mod tests {
 
         // XXX: I kind of feel like this should be equivalent to above.
         // Check Pandoc.
-        assert_eq!(parse_attributes("{hi}"), None);
+        assert_eq!(parse("{hi}"), None);
     }
 
     fn assert_parse_off(input: &str, expected_str: &str, expected_attrs: Option<Attributes>) {
         let mut s = input.to_string();
-        let attrs = parse_off_attributes(&mut s);
+        let attrs = parse_off(&mut s);
         assert_eq!(s, expected_str);
         assert_eq!(attrs, expected_attrs);
     }
 
     #[test]
-    fn parse_off() {
+    fn parses_off() {
         assert_parse_off("hi", "hi", None);
         assert_parse_off(
             "hi  {#yay}",

--- a/src/parser/attributes.rs
+++ b/src/parser/attributes.rs
@@ -1,7 +1,68 @@
+use std::mem;
+
 use crate::nodes::Attributes;
 
 pub fn parse_attributes(input: &str) -> Option<(Attributes, usize)> {
-    todo!()
+    let mut ci = input.char_indices();
+    if ci.next()?.1 != '{' {
+        return None;
+    }
+
+    enum State {
+        Betwixt,
+        Value(Kind, String),
+    }
+
+    enum Kind {
+        Id,
+        Class,
+        Pair(String),
+    }
+
+    let mut state = State::Betwixt;
+    let mut attrs = Attributes::default();
+
+    loop {
+        let (i, c) = ci.next()?;
+
+        loop {
+            match state {
+                State::Betwixt => match c {
+                    '#' => {
+                        state = State::Value(Kind::Id, String::new());
+                        break;
+                    }
+                    '.' => {
+                        state = State::Value(Kind::Class, String::new());
+                        break;
+                    }
+                    '}' => return Some((attrs, i + 1)),
+                    _ => todo!(),
+                },
+                State::Value(ref kind, ref mut value) => match c {
+                    // An id can contain [literally anything] in HTML5, just so long as it's non-empty.
+                    // Consider looking at how Pandoc parses this part.
+                    // Per above, classes are also literally anything, *except* ASCII whitespace.
+                    //
+                    // [literally anything]: https://html.spec.whatwg.org/multipage/dom.html#the-id-attribute
+                    'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | ':' | '.' => {
+                        value.push(c);
+                        break;
+                    }
+                    ' ' | '}' => {
+                        match kind {
+                            Kind::Id => attrs.id = Some(mem::take(value)),
+                            Kind::Class => attrs.classes.push(mem::take(value)),
+                            _ => todo!(),
+                        }
+                        state = State::Betwixt;
+                        // handle in loop
+                    }
+                    _ => todo!(),
+                },
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -11,5 +72,62 @@ mod tests {
     #[test]
     fn trivial() {
         assert!(parse_attributes("").is_none());
+
+        assert_eq!(
+            parse_attributes("{#henlo} there"),
+            Some((
+                Attributes {
+                    id: Some("henlo".to_string()),
+                    ..Default::default()
+                },
+                8
+            ))
+        );
+
+        assert_eq!(
+            parse_attributes("{.oken}"),
+            Some((
+                Attributes {
+                    classes: vec!["oken".to_string()],
+                    ..Default::default()
+                },
+                7
+            ))
+        );
+
+        assert_eq!(
+            parse_attributes("{.oken #yip m=26 .sure x=3 #yap} oh!"),
+            Some((
+                Attributes {
+                    id: Some("yap".to_string()),
+                    classes: vec!["oken".to_string(), "sure".to_string()],
+                    pairs: vec![
+                        ("m".to_string(), "26".to_string()),
+                        ("x".to_string(), "3".to_string())
+                    ]
+                },
+                7 // XXX
+            ))
+        );
+
+        assert_eq!(
+            parse_attributes(
+                "{#\"has space, will travel\" .\"ok\\\"en\" title=\"surely \\\"not\\\"\"}"
+            ),
+            Some((
+                Attributes {
+                    id: Some("has space, will travel".to_string()),
+                    classes: vec!["ok\"en".to_string(),],
+                    pairs: vec![("title".to_string(), "surely \"not\"".to_string())],
+                },
+                7 // XXX
+            ))
+        );
+
+        assert!(parse_attributes("{#}").is_none());
+        assert_eq!(parse_attributes("{}"), Some(Default::default()));
+        assert!(parse_attributes("{.}").is_none());
+        assert!(parse_attributes("{uh").is_none());
+        assert!(parse_attributes("{yeah\nnah}").is_none());
     }
 }

--- a/src/parser/attributes.rs
+++ b/src/parser/attributes.rs
@@ -163,7 +163,9 @@ pub fn parse_off_attributes(content: &mut String) -> Option<Attributes> {
                 // XXX: We can possibly fold this assertion into the above state
                 // tracking? :inuthonk:
                 if !content[i + j..].chars().all(char::is_whitespace) {
-                    return None;
+                    // For now, we might be within an attribute value, so we
+                    // must keep on.
+                    continue;
                 }
 
                 // Either there's nothing left (fine!) ORRRRR there's *at least*
@@ -298,6 +300,26 @@ mod tests {
             "hi",
             Some(Attributes {
                 id: Some("yay".to_string()),
+                ..Default::default()
+            }),
+        );
+
+        assert_parse_off("Well!{#yay}", "Well!{#yay}", None);
+
+        assert_parse_off(
+            "Well! {#okay} {Not really.}",
+            "Well! {#okay} {Not really.}",
+            None,
+        );
+
+        assert_parse_off(
+            "Well!! {cool=\"Lest \\\"{#confusion}\\\" sets in.\" } \t",
+            "Well!!",
+            Some(Attributes {
+                pairs: vec![(
+                    "cool".to_string(),
+                    "Lest \"{#confusion}\" sets in.".to_string(),
+                )],
                 ..Default::default()
             }),
         );

--- a/src/parser/attributes.rs
+++ b/src/parser/attributes.rs
@@ -177,7 +177,7 @@ pub fn parse_off_attributes(content: &mut String) -> Option<Attributes> {
                     return None;
                 }
 
-                while let Some((i2, c)) = ci.next() {
+                for (i2, c) in ci {
                     if !c.is_whitespace() {
                         break;
                     }

--- a/src/parser/attributes.rs
+++ b/src/parser/attributes.rs
@@ -32,6 +32,9 @@ pub fn parse_attributes(input: &str) -> Option<(Attributes, usize)> {
     let mut state = State::Betwixt;
     let mut attrs = Attributes::default();
 
+    // We permit ' ' | '\t' | '\r' | '\n' between/around attributes in the braces.
+    // Is ASCII whitespace also '\v' | '\f'? Does anyone mind?
+
     loop {
         let (i, c) = ci.next()?;
 
@@ -51,7 +54,7 @@ pub fn parse_attributes(input: &str) -> Option<(Attributes, usize)> {
                         break;
                     }
                     '}' => return Some((attrs, i + 1)),
-                    ' ' | '\t' => break,
+                    ' ' | '\t' | '\r' | '\n' => break,
                     _ => return None,
                 },
                 State::Value(ref mut kind, ref mut value, Quote::Bare) => match c {
@@ -68,7 +71,7 @@ pub fn parse_attributes(input: &str) -> Option<(Attributes, usize)> {
                         value.push(c);
                         break;
                     }
-                    ' ' | '}' => {
+                    ' ' | '\t' | '\r' | '\n' | '}' => {
                         match kind {
                             Kind::Id => {
                                 if value.is_empty() {
@@ -87,7 +90,7 @@ pub fn parse_attributes(input: &str) -> Option<(Attributes, usize)> {
                         state = State::Betwixt;
                         // handle in loop
                     }
-                    _ => todo!(),
+                    _ => return None,
                 },
                 State::Value(ref mut kind, ref mut value, Quote::Quoted) => match c {
                     '"' => {
@@ -133,7 +136,7 @@ pub fn parse_attributes(input: &str) -> Option<(Attributes, usize)> {
                 },
                 State::PostQuote => match c {
                     // Require a space after quote before anything else.
-                    ' ' | '}' => {
+                    ' ' | '\t' | '\r' | '\n' | '}' => {
                         state = State::Betwixt;
                         // handle in loop
                     }
@@ -267,7 +270,17 @@ mod tests {
         assert_eq!(parse_attributes("{}"), Some((Attributes::default(), 2)));
         assert_eq!(parse_attributes("{.}"), None);
         assert_eq!(parse_attributes("{uh"), None);
-        assert_eq!(parse_attributes("{yeah\nnah}"), None);
+
+        assert_eq!(
+            parse_attributes("{.why\n.not}"),
+            Some((
+                Attributes {
+                    classes: vec!["why".to_string(), "not".to_string()],
+                    ..Default::default()
+                },
+                11
+            ))
+        );
 
         assert_eq!(
             parse_attributes("{hi=}"),

--- a/src/parser/attributes.rs
+++ b/src/parser/attributes.rs
@@ -1,0 +1,15 @@
+use crate::nodes::Attributes;
+
+pub fn parse_attributes(input: &str) -> Option<(Attributes, usize)> {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trivial() {
+        assert!(parse_attributes("").is_none());
+    }
+}

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -16,6 +16,8 @@ use crate::nodes::{
     Ast, Node, NodeCode, NodeFootnoteDefinition, NodeFootnoteReference, NodeLink, NodeMath,
     NodeValue, NodeWikiLink, Sourcepos,
 };
+#[cfg(feature = "attributes")]
+use crate::parser::attributes;
 use crate::parser::inlines::cjk::FlankingCheckHelper;
 use crate::parser::options::{BrokenLinkReference, WikiLinksMode};
 #[cfg(feature = "shortcodes")]
@@ -425,32 +427,43 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
         let openticks = self.take_while(b'`');
         let endpos = self.scan_to_closing_backtick(openticks);
 
-        match endpos {
-            None => {
-                self.scanner.pos = startpos + openticks;
-                self.make_inline(
-                    NodeValue::Text("`".repeat(openticks).into()),
-                    startpos,
-                    self.scanner.pos - 1,
-                )
-            }
-            Some(endpos) => {
-                let buf = &self.input[startpos + openticks..endpos - openticks];
-                let buf = strings::normalize_code(buf);
-                let code = NodeCode {
-                    num_backticks: openticks,
-                    literal: buf.into(),
-                };
-                let node = self.make_inline(NodeValue::Code(code), startpos, endpos - 1);
-                self.adjust_node_newlines(
-                    node,
-                    endpos - startpos - openticks,
-                    openticks,
-                    parent_line_offsets,
-                );
-                node
+        let Some(endpos) = endpos else {
+            self.scanner.pos = startpos + openticks;
+            return self.make_inline(
+                NodeValue::Text("`".repeat(openticks).into()),
+                startpos,
+                self.scanner.pos - 1,
+            );
+        };
+
+        let buf = &self.input[startpos + openticks..endpos - openticks];
+        let buf = strings::normalize_code(buf);
+        let code = NodeCode {
+            num_backticks: openticks,
+            literal: buf.into(),
+        };
+        let node = self.make_inline(NodeValue::Code(code), startpos, endpos - 1);
+        self.adjust_node_newlines(
+            node,
+            endpos - startpos - openticks,
+            openticks,
+            parent_line_offsets,
+        );
+
+        #[cfg(feature = "attributes")]
+        if self.options.extension.inline_code_attributes && self.peek_byte() == Some(b'{') {
+            if let Some((attrs, i)) = attributes::parse_attributes(&self.input[self.scanner.pos..])
+            {
+                let mut ast = node.data_mut();
+                // TODO: what if newline!!
+                ast.sourcepos.end.column += i;
+                ast.attrs = Some(Box::new(attrs));
+
+                self.scanner.pos += i;
             }
         }
+
+        node
     }
 
     fn handle_backslash(&mut self) -> Node<'a> {

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -2330,7 +2330,7 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
             return;
         }
 
-        let Some((attrs, i)) = attributes::parse_attributes(&self.input[self.scanner.pos..]) else {
+        let Some((attrs, i)) = attributes::parse(&self.input[self.scanner.pos..]) else {
             return;
         };
 

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -310,7 +310,7 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
             }
             b']' => {
                 self.within_brackets = false;
-                self.handle_close_bracket()
+                self.handle_close_bracket(&ast.line_offsets)
             }
             b'!' => {
                 self.scanner.pos += 1;
@@ -451,24 +451,8 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
         );
 
         #[cfg(feature = "attributes")]
-        if self.options.extension.inline_code_attributes && self.peek_byte() == Some(b'{') {
-            if let Some((attrs, i)) = attributes::parse_attributes(&self.input[self.scanner.pos..])
-            {
-                let mut ast = node.data_mut();
-                let (lines, last_line) = count_newlines(&self.input[self.scanner.pos..][..i]);
-                if lines == 0 {
-                    ast.sourcepos.end.column += last_line;
-                } else {
-                    ast.sourcepos.end.line += lines;
-                    // XXX I really freestyled this next line.
-                    ast.sourcepos.end.column = parent_line_offsets
-                        [ast.sourcepos.end.line - ast.sourcepos.start.line]
-                        + last_line;
-                }
-                ast.attrs = Some(Box::new(attrs));
-
-                self.scanner.pos += i;
-            }
+        if self.options.extension.inline_code_attributes {
+            self.handle_potential_attribute(node, parent_line_offsets);
         }
 
         node
@@ -1693,7 +1677,7 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
         }
     }
 
-    fn handle_close_bracket(&mut self) -> Option<Node<'a>> {
+    fn handle_close_bracket(&mut self, parent_line_offsets: &[usize]) -> Option<Node<'a>> {
         self.scanner.pos += 1;
         let initial_pos = self.scanner.pos;
 
@@ -1782,6 +1766,7 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
                             url.into(),
                             title.into(),
                             source_end_pos,
+                            parent_line_offsets,
                         );
                         return None;
                     } else {
@@ -1833,7 +1818,13 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
             // When reff is Cow::Owned (from callback), into_owned() is a no-op
             // When reff is Cow::Borrowed (from refmap), into_owned() clones
             let reff = reff.into_owned();
-            self.close_bracket_match(is_image, reff.url, reff.title, self.scanner.pos);
+            self.close_bracket_match(
+                is_image,
+                reff.url,
+                reff.title,
+                self.scanner.pos,
+                parent_line_offsets,
+            );
             return None;
         }
 
@@ -1958,6 +1949,7 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
         url: String,
         title: String,
         source_end_pos: usize,
+        #[cfg_attr(not(feature = "attributes"), allow(unused))] parent_line_offsets: &[usize],
     ) {
         let last = self.brackets.pop().unwrap();
 
@@ -1982,6 +1974,11 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
             )
                 .into(),
         );
+
+        #[cfg(feature = "attributes")]
+        if self.options.extension.link_attributes {
+            self.handle_potential_attribute(inl, parent_line_offsets);
+        }
 
         last.inl_text.insert_before(inl);
         let mut itm = last.inl_text.next_sibling();
@@ -2325,6 +2322,31 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
             self.column_offset =
                 -(self.scanner.pos as isize) + since_newline as isize + extra as isize;
         }
+    }
+
+    #[cfg(feature = "attributes")]
+    fn handle_potential_attribute(&mut self, node: Node<'a>, parent_line_offsets: &[usize]) {
+        if self.peek_byte() != Some(b'{') {
+            return;
+        }
+
+        let Some((attrs, i)) = attributes::parse_attributes(&self.input[self.scanner.pos..]) else {
+            return;
+        };
+
+        let mut ast = node.data_mut();
+        let (lines, last_line) = count_newlines(&self.input[self.scanner.pos..][..i]);
+        if lines == 0 {
+            ast.sourcepos.end.column += last_line;
+        } else {
+            ast.sourcepos.end.line += lines;
+            // XXX I really freestyled this next line.
+            ast.sourcepos.end.column =
+                parent_line_offsets[ast.sourcepos.end.line - ast.sourcepos.start.line] + last_line;
+        }
+        ast.attrs = Some(Box::new(attrs));
+
+        self.scanner.pos += i;
     }
 }
 

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -169,6 +169,8 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
                 usize::try_from(end_column).unwrap(),
             )
                 .into(),
+            #[cfg(feature = "attributes")]
+            attrs: None,
             open: false,
             last_line_blank: false,
             table_visited: false,
@@ -2493,6 +2495,8 @@ pub(crate) fn make_inline<'a>(
         value,
         content: String::new(),
         sourcepos,
+        #[cfg(feature = "attributes")]
+        attrs: None,
         open: false,
         last_line_blank: false,
         table_visited: false,

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -455,8 +455,16 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
             if let Some((attrs, i)) = attributes::parse_attributes(&self.input[self.scanner.pos..])
             {
                 let mut ast = node.data_mut();
-                // TODO: what if newline!!
-                ast.sourcepos.end.column += i;
+                let (lines, last_line) = count_newlines(&self.input[self.scanner.pos..][..i]);
+                if lines == 0 {
+                    ast.sourcepos.end.column += last_line;
+                } else {
+                    ast.sourcepos.end.line += lines;
+                    // XXX I really freestyled this next line.
+                    ast.sourcepos.end.column = parent_line_offsets
+                        [ast.sourcepos.end.line - ast.sourcepos.start.line]
+                        + last_line;
+                }
                 ast.attrs = Some(Box::new(attrs));
 
                 self.scanner.pos += i;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2161,6 +2161,14 @@ where
                     strings::trim_cow(&mut info);
                     let mut info = info.into_owned();
                     strings::unescape(&mut info);
+
+                    #[cfg(feature = "attributes")]
+                    if self.options.extension.header_attributes {
+                        if let Some(attrs) = attributes::parse_off_attributes(&mut info) {
+                            ast.attrs = Some(Box::new(attrs));
+                        }
+                    }
+
                     if info.is_empty() {
                         ncb.info = self
                             .options

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "attributes")]
+mod attributes;
 mod autolink;
 mod inlines;
 pub mod options;
@@ -46,6 +48,8 @@ pub fn parse_document<'a>(arena: &'a Arena<'a>, md: &str, options: &Options) -> 
             value: NodeValue::Document,
             content: String::new(),
             sourcepos: (1, 1, 1, 1).into(),
+            #[cfg(feature = "attributes")]
+            attrs: None,
             open: true,
             last_line_blank: false,
             table_visited: false,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2164,7 +2164,7 @@ where
 
                     #[cfg(feature = "attributes")]
                     if self.options.extension.fenced_code_attributes {
-                        if let Some(attrs) = attributes::parse_off_attributes(&mut info) {
+                        if let Some(attrs) = attributes::parse_off(&mut info) {
                             ast.attrs = Some(Box::new(attrs));
                         }
                     }
@@ -2225,7 +2225,7 @@ where
             {
                 #[cfg(feature = "attributes")]
                 if self.options.extension.header_attributes {
-                    if let Some(attrs) = attributes::parse_off_attributes(content) {
+                    if let Some(attrs) = attributes::parse_off(content) {
                         ast.attrs = Some(Box::new(attrs));
                     }
                 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2213,12 +2213,13 @@ where
                     ast.sourcepos.end = candidate_end;
                 }
             }
-            NodeValue::Heading(_) => {
+            NodeValue::Heading(_) =>
+            {
                 #[cfg(feature = "attributes")]
-                if self.options.extension.header_attributes
-                    && let Some(attrs) = attributes::parse_off_attributes(content)
-                {
-                    ast.attrs = Some(Box::new(attrs));
+                if self.options.extension.header_attributes {
+                    if let Some(attrs) = attributes::parse_off_attributes(content) {
+                        ast.attrs = Some(Box::new(attrs));
+                    }
                 }
             }
             _ => (),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2163,7 +2163,7 @@ where
                     strings::unescape(&mut info);
 
                     #[cfg(feature = "attributes")]
-                    if self.options.extension.header_attributes {
+                    if self.options.extension.fenced_code_attributes {
                         if let Some(attrs) = attributes::parse_off_attributes(&mut info) {
                             ast.attrs = Some(Box::new(attrs));
                         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2213,6 +2213,14 @@ where
                     ast.sourcepos.end = candidate_end;
                 }
             }
+            NodeValue::Heading(_) => {
+                #[cfg(feature = "attributes")]
+                if self.options.extension.header_attributes
+                    && let Some(attrs) = attributes::parse_off_attributes(content)
+                {
+                    ast.attrs = Some(Box::new(attrs));
+                }
+            }
             _ => (),
         }
 

--- a/src/parser/options.rs
+++ b/src/parser/options.rs
@@ -628,30 +628,85 @@ pub struct Extension<'c> {
     #[cfg_attr(feature = "bon", builder(default))]
     pub block_directive: bool,
 
-    /// TODO
+    /// Parse attributes in setext and ATX headers.
+    /// ```rust
+    /// # use comrak::{parse_document, Arena, Options, nodes::NodeValue};
+    /// let mut options = Options::default();
+    /// options.extension.header_attributes = true;
+    /// let arena = Arena::new();
+    /// let input = "## Catgirl {author=\"City Girl\"}\n";
+    /// let root = parse_document(&arena, input, &options);
+    /// for node in root.descendants() {
+    ///   let ast = node.data();
+    ///   if let NodeValue::Heading(_) = ast.value {
+    ///     assert_eq!(ast.attrs.as_ref().unwrap().pairs,
+    ///                &[("author".to_string(), "City Girl".to_string())]);
+    ///   }
+    /// }
+    /// ```
     #[cfg(feature = "attributes")]
     #[cfg_attr(feature = "bon", builder(default))]
     pub header_attributes: bool,
 
-    /// TODO
+    /// Parse attributes in fenced code blocks' info strings.
+    /// ```rust
+    /// # use comrak::{parse_document, Arena, Options, nodes::NodeValue};
+    /// let mut options = Options::default();
+    /// options.extension.fenced_code_attributes = true;
+    /// let arena = Arena::new();
+    /// let input = "```german {#beispel}\nÄhm... egal.\n```\n";
+    /// let root = parse_document(&arena, input, &options);
+    /// for node in root.descendants() {
+    ///   let ast = node.data();
+    ///   if let NodeValue::CodeBlock(_) = ast.value {
+    ///     assert_eq!(ast.attrs.as_ref().unwrap().id,
+    ///                Some("beispel".to_string()));
+    ///   }
+    /// }
+    /// ```
     #[cfg(feature = "attributes")]
     #[cfg_attr(feature = "bon", builder(default))]
     pub fenced_code_attributes: bool,
 
-    /// TODO
+    /// Parse attributes immediately following inline code spans.
+    /// ```rust
+    /// # use comrak::{parse_document, Arena, Options, nodes::NodeValue};
+    /// let mut options = Options::default();
+    /// options.extension.inline_code_attributes = true;
+    /// let arena = Arena::new();
+    /// let input = "More inline spans should be `syntax-highlighted`{.common-lisp}.";
+    /// let root = parse_document(&arena, input, &options);
+    /// for node in root.descendants() {
+    ///   let ast = node.data();
+    ///   if let NodeValue::Code(_) = ast.value {
+    ///     assert_eq!(ast.attrs.as_ref().unwrap().classes,
+    ///                &["common-lisp".to_string()]);
+    ///   }
+    /// }
+    /// ```
     #[cfg(feature = "attributes")]
     #[cfg_attr(feature = "bon", builder(default))]
     pub inline_code_attributes: bool,
 
-    /// TODO
+    /// Parse attributes immediately following links and images.
+    /// ```rust
+    /// # use comrak::{parse_document, Arena, Options, nodes::NodeValue};
+    /// let mut options = Options::default();
+    /// options.extension.link_attributes = true;
+    /// let arena = Arena::new();
+    /// let input = "For instance:\n\n![A photo of an open-hearth furnace](zaporizhstal.jfif){data-date=2012-04-03}\n";
+    /// let root = parse_document(&arena, input, &options);
+    /// for node in root.descendants() {
+    ///   let ast = node.data();
+    ///   if let NodeValue::Image(_) = ast.value {
+    ///     assert_eq!(ast.attrs.as_ref().unwrap().pairs,
+    ///                &[("data-date".to_string(), "2012-04-03".to_string())]);
+    ///   }
+    /// }
+    /// ```
     #[cfg(feature = "attributes")]
     #[cfg_attr(feature = "bon", builder(default))]
     pub link_attributes: bool,
-
-    /// TODO
-    #[cfg(feature = "attributes")]
-    #[cfg_attr(feature = "bon", builder(default))]
-    pub attributes: bool,
 }
 
 impl Extension<'_> {

--- a/src/parser/options.rs
+++ b/src/parser/options.rs
@@ -627,6 +627,31 @@ pub struct Extension<'c> {
     /// ```
     #[cfg_attr(feature = "bon", builder(default))]
     pub block_directive: bool,
+
+    /// TODO
+    #[cfg(feature = "attributes")]
+    #[cfg_attr(feature = "bon", builder(default))]
+    pub header_attributes: bool,
+
+    /// TODO
+    #[cfg(feature = "attributes")]
+    #[cfg_attr(feature = "bon", builder(default))]
+    pub fenced_code_attributes: bool,
+
+    /// TODO
+    #[cfg(feature = "attributes")]
+    #[cfg_attr(feature = "bon", builder(default))]
+    pub inline_code_attributes: bool,
+
+    /// TODO
+    #[cfg(feature = "attributes")]
+    #[cfg_attr(feature = "bon", builder(default))]
+    pub link_attributes: bool,
+
+    /// TODO
+    #[cfg(feature = "attributes")]
+    #[cfg_attr(feature = "bon", builder(default))]
+    pub attributes: bool,
 }
 
 impl Extension<'_> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -299,7 +299,8 @@ macro_rules! ast_content {
      ($matches:ident ~ info:$info:literal $( $rest:tt )*) => {
         $matches.push($crate::tests::AstMatchContent::Info($info.to_string()));
         $crate::tests::ast_content!($matches ~ $( $rest )*);
-    };
+     };
+
     // Are you reading this comment right now?
     //
     // Can you see that the following definition forces test authors to specify
@@ -310,10 +311,7 @@ macro_rules! ast_content {
     // It's VERY possible to rewrite this to allow parsing them in any order, just
     // like the actual syntax. Feel free to try it and open a PR, and you can ask for help.
     //
-    // Hint: you'll want to feed _all_ attribute tokens (here) into a new macro,
-    // same as ast_content itself, which has three arms; one for each type,
-    // each also accepting $( $rest:tt )* at the end. Recursively call itself on the
-    // $rest each time to consume all tokens.
+    // Hint: look at how ast_content itself is implemented; recursion is the trick!
     //
     // Extra credit: at the moment, we only support x="y" syntax for pairs.
     // The above change would let us easily support both that *and* x=y syntax
@@ -327,6 +325,7 @@ macro_rules! ast_content {
         $matches.push($crate::tests::AstMatchContent::Attributes(attrs));
         $crate::tests::ast_content!($matches ~ $( $rest )*);
     };
+
     ($matches:ident ~) => {};
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -274,21 +274,32 @@ macro_rules! sourcepos {
 pub(crate) use sourcepos;
 
 macro_rules! ast {
-    (($name:tt $sp:tt $( $content:tt )*)) => {
+    (($name:tt $sp:tt $( $content:tt )*)) => ({
+        #[allow(unused_mut)]
+        let mut matches = vec![];
+        $crate::tests::ast_content!(matches ~ $( $content )*);
+
         $crate::tests::AstMatchTree {
             name: stringify!($name).to_string(),
             sourcepos: $crate::tests::sourcepos!($sp),
-            matches: vec![ $( $crate::tests::ast_content!($content), )* ],
+            matches,
         }
-    };
+    });
 }
 
 macro_rules! ast_content {
-    ($text:literal) => {$crate::tests::AstMatchContent::Text($text.to_string())};
-    ([ $( $children:tt )* ]) => {
-        $crate::tests::AstMatchContent::Children(vec![ $( $crate::tests::ast!($children), )* ])
+    ($matches:ident ~ $text:literal $( $rest:tt )*) => {
+        $matches.push($crate::tests::AstMatchContent::Text($text.to_string()));
+        $crate::tests::ast_content!($matches ~ $( $rest )*);
     };
-
+    ($matches:ident ~ [ $( $children:tt )* ] $( $rest:tt )*) => {
+        $matches.push($crate::tests::AstMatchContent::Children(vec![ $( $crate::tests::ast!($children), )* ]));
+        $crate::tests::ast_content!($matches ~ $( $rest )*);
+    };
+     ($matches:ident ~ info:$info:literal $( $rest:tt )*) => {
+        $matches.push($crate::tests::AstMatchContent::Info($info.to_string()));
+        $crate::tests::ast_content!($matches ~ $( $rest )*);
+    };
     // Are you reading this comment right now?
     //
     // Can you see that the following definition forces test authors to specify
@@ -300,20 +311,23 @@ macro_rules! ast_content {
     // like the actual syntax. Feel free to try it and open a PR, and you can ask for help.
     //
     // Hint: you'll want to feed _all_ attribute tokens (here) into a new macro,
-    // which has three arms; one for each type, each also accepting $( $rest:tt )* at
-    // the end. Recursively call itself on the $rest each time to consume all tokens.
+    // same as ast_content itself, which has three arms; one for each type,
+    // each also accepting $( $rest:tt )* at the end. Recursively call itself on the
+    // $rest each time to consume all tokens.
     //
     // Extra credit: at the moment, we only support x="y" syntax for pairs.
     // The above change would let us easily support both that *and* x=y syntax
     // (when there's no 'need' to quote the value).
-    ({ $( # $id:ident )? $( . $class:ident )* $( $key:ident = $value:literal )* }) => ({
+    ($matches:ident ~ { $( # $id:ident )? $( . $class:ident )* $( $key:ident = $value:literal )* } $( $rest:tt )*) => {
         #[allow(unused_mut)]
         let mut attrs = $crate::nodes::Attributes::default();
         $( attrs.id = Some(stringify!($id).to_string()); )?
         $( attrs.classes.push(stringify!($class).to_string()); )*
         $( attrs.pairs.push((stringify!($key).to_string(), $value.to_string())); )*
-        $crate::tests::AstMatchContent::Attributes(attrs)
-    });
+        $matches.push($crate::tests::AstMatchContent::Attributes(attrs));
+        $crate::tests::ast_content!($matches ~ $( $rest )*);
+    };
+    ($matches:ident ~) => {};
 }
 
 pub(crate) use ast;
@@ -395,6 +409,7 @@ pub(crate) use assert_ast_match;
 
 enum AstMatchContent {
     Text(String),
+    Info(String),
     Children(Vec<AstMatchTree>),
     #[cfg(feature = "attributes")]
     Attributes(Attributes),
@@ -414,6 +429,7 @@ impl AstMatchTree {
         assert_eq!(self.sourcepos, ast.sourcepos, "sourcepos are equal");
 
         let mut asserted_text = false;
+        let mut asserted_info = false;
         let mut asserted_children = false;
         #[cfg(feature = "attributes")]
         let mut asserted_attributes = false;
@@ -477,6 +493,13 @@ impl AstMatchTree {
                         ast.value
                     ),
                 },
+                AstMatchContent::Info(info) => match ast.value {
+                    NodeValue::CodeBlock(ref ncb) => {
+                        assert_eq!(info, &ncb.info, "CodeBlock info should match");
+                        asserted_info = true;
+                    }
+                    _ => panic!("no info matcher for this node type: {:?}", ast.value),
+                },
                 AstMatchContent::Children(children) => {
                     assert_eq!(
                         children.len(),
@@ -500,6 +523,14 @@ impl AstMatchTree {
         assert!(
             asserted_children || node.children().count() == 0,
             "children were not asserted"
+        );
+        assert!(
+            asserted_info
+                || match ast.value {
+                    NodeValue::CodeBlock(ref ncb) => ncb.info.is_empty(),
+                    _ => true,
+                },
+            "info string was not asserted"
         );
         #[cfg(feature = "attributes")]
         assert!(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -288,6 +288,20 @@ macro_rules! ast_content {
     ([ $( $children:tt )* ]) => {
         $crate::tests::AstMatchContent::Children(vec![ $( $crate::tests::ast!($children), )* ])
     };
+
+    // Are you reading this comment right now?
+    //
+    // Can you see that the following definition forces test authors to specify
+    // attributes in the order "id, classes, key/value pairs", even though in
+    // the actual syntax, that's not necessary? (Indeed, you could have multiple
+    // ids in real syntax; the last one wins.)
+    //
+    // It's VERY possible to rewrite this to allow parsing them in any order, just
+    // like the actual syntax. Feel free to try it and open a PR, and you can ask for help.
+    //
+    // Hint: you'll want to feed _all_ attribute tokens (here) into a new macro,
+    // which has three arms; one for each type, each also accepting $( $rest:tt )* at
+    // the end. Recursively call itself on the $rest each time to consume all tokens.
     ({ $( # $id:ident )? $( . $class:ident )* $( $key:ident = $value:literal )* }) => ({
         #[allow(unused_mut)]
         let mut attrs = $crate::nodes::Attributes::default();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -288,17 +288,9 @@ macro_rules! ast_content {
     ([ $( $children:tt )* ]) => {
         $crate::tests::AstMatchContent::Children(vec![ $( $crate::tests::ast!($children), )* ])
     };
-    ({ $( $attr:literal )* }) => ({
-        let mut attrs = $crate::nodes::Attributes::default();
-        $(
-          if $attr.starts_with("#") {
-              attrs.id = Some($attr[1..].to_string());
-          } else {
-              unreachable!()
-          }
-        )*
-        $crate::tests::AstMatchContent::Attributes(attrs)
-    });
+    ({ $( $attr:literal )* }) => {
+        $crate::tests::AstMatchContent::parse_attributes(&[$( $attr ),*])
+    };
 }
 
 pub(crate) use ast;
@@ -378,17 +370,39 @@ macro_rules! assert_ast_match {
 
 pub(crate) use assert_ast_match;
 
-struct AstMatchTree {
-    name: String,
-    sourcepos: Sourcepos,
-    matches: Vec<AstMatchContent>,
-}
-
 enum AstMatchContent {
     Text(String),
     Children(Vec<AstMatchTree>),
     #[cfg(feature = "attributes")]
     Attributes(Attributes),
+}
+
+impl AstMatchContent {
+    fn parse_attributes(literals: &[&str]) -> Self {
+        let mut attrs = Attributes::default();
+
+        for literal in literals {
+            if literal.starts_with("#") {
+                attrs.id = Some(literal[1..].to_string());
+            } else if literal.starts_with(".") {
+                attrs.classes.push(literal[1..].to_string());
+            } else if let Some(ix) = literal.find('=') {
+                attrs
+                    .pairs
+                    .push((literal[0..ix].to_string(), literal[ix + 1..].to_string()));
+            } else {
+                unreachable!()
+            }
+        }
+
+        Self::Attributes(attrs)
+    }
+}
+
+struct AstMatchTree {
+    name: String,
+    sourcepos: Sourcepos,
+    matches: Vec<AstMatchContent>,
 }
 
 impl AstMatchTree {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -503,7 +503,8 @@ impl AstMatchTree {
                     assert_eq!(
                         children.len(),
                         node.children().count(),
-                        "children count should match"
+                        "children count should match ({:?})",
+                        node
                     );
                     for (e, a) in children.iter().zip(node.children()) {
                         e.assert_match(a);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -302,6 +302,10 @@ macro_rules! ast_content {
     // Hint: you'll want to feed _all_ attribute tokens (here) into a new macro,
     // which has three arms; one for each type, each also accepting $( $rest:tt )* at
     // the end. Recursively call itself on the $rest each time to consume all tokens.
+    //
+    // Extra credit: at the moment, we only support x="y" syntax for pairs.
+    // The above change would let us easily support both that *and* x=y syntax
+    // (when there's no 'need' to quote the value).
     ({ $( # $id:ident )? $( . $class:ident )* $( $key:ident = $value:literal )* }) => ({
         #[allow(unused_mut)]
         let mut attrs = $crate::nodes::Attributes::default();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -288,9 +288,14 @@ macro_rules! ast_content {
     ([ $( $children:tt )* ]) => {
         $crate::tests::AstMatchContent::Children(vec![ $( $crate::tests::ast!($children), )* ])
     };
-    ({ $( $attr:literal )* }) => {
-        $crate::tests::AstMatchContent::parse_attributes(&[$( $attr ),*])
-    };
+    ({ $( # $id:ident )? $( . $class:ident )* $( $key:ident = $value:literal )* }) => ({
+        #[allow(unused_mut)]
+        let mut attrs = $crate::nodes::Attributes::default();
+        $( attrs.id = Some(stringify!($id).to_string()); )?
+        $( attrs.classes.push(stringify!($class).to_string()); )*
+        $( attrs.pairs.push((stringify!($key).to_string(), $value.to_string())); )*
+        $crate::tests::AstMatchContent::Attributes(attrs)
+    });
 }
 
 pub(crate) use ast;
@@ -375,28 +380,6 @@ enum AstMatchContent {
     Children(Vec<AstMatchTree>),
     #[cfg(feature = "attributes")]
     Attributes(Attributes),
-}
-
-impl AstMatchContent {
-    fn parse_attributes(literals: &[&str]) -> Self {
-        let mut attrs = Attributes::default();
-
-        for literal in literals {
-            if literal.starts_with("#") {
-                attrs.id = Some(literal[1..].to_string());
-            } else if literal.starts_with(".") {
-                attrs.classes.push(literal[1..].to_string());
-            } else if let Some(ix) = literal.find('=') {
-                attrs
-                    .pairs
-                    .push((literal[0..ix].to_string(), literal[ix + 1..].to_string()));
-            } else {
-                unreachable!()
-            }
-        }
-
-        Self::Attributes(attrs)
-    }
 }
 
 struct AstMatchTree {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,11 +2,14 @@ use pretty_assertions::assert_eq;
 use std::collections::HashMap;
 use std::panic;
 
+#[cfg(feature = "attributes")]
+use crate::nodes::Attributes;
 use crate::nodes::{Node, NodeValue, Sourcepos};
 use crate::options;
 use crate::*;
 
 mod alerts;
+mod attributes;
 mod autolink;
 mod block_directive;
 mod cjk_friendly_emphasis;
@@ -272,19 +275,30 @@ pub(crate) use sourcepos;
 
 macro_rules! ast {
     (($name:tt $sp:tt $( $content:tt )*)) => {
-        AstMatchTree {
+        $crate::tests::AstMatchTree {
             name: stringify!($name).to_string(),
-            sourcepos: sourcepos!($sp),
-            matches: vec![ $( ast_content!($content), )* ],
+            sourcepos: $crate::tests::sourcepos!($sp),
+            matches: vec![ $( $crate::tests::ast_content!($content), )* ],
         }
     };
 }
 
 macro_rules! ast_content {
-    ($text:literal) => {AstMatchContent::Text($text.to_string())};
+    ($text:literal) => {$crate::tests::AstMatchContent::Text($text.to_string())};
     ([ $( $children:tt )* ]) => {
-        AstMatchContent::Children(vec![ $( ast!($children), )* ])
+        $crate::tests::AstMatchContent::Children(vec![ $( $crate::tests::ast!($children), )* ])
     };
+    ({ $( $attr:literal )* }) => ({
+        let mut attrs = $crate::nodes::Attributes::default();
+        $(
+          if $attr.starts_with("#") {
+              attrs.id = Some($attr[1..].to_string());
+          } else {
+              unreachable!()
+          }
+        )*
+        $crate::tests::AstMatchContent::Attributes(attrs)
+    });
 }
 
 pub(crate) use ast;
@@ -333,28 +347,28 @@ pub(crate) use assert_ast_match_set_opt_single;
 
 macro_rules! assert_ast_match {
     ([ $( $optclass:ident.$optname:ident ),* ], $( $md:literal )+, $amt:tt,) => {
-        assert_ast_match!(
+        $crate::tests::assert_ast_match!(
             [ $( $optclass.$optname ),* ],
             $( $md )+,
             $amt
         )
     };
     ([ $( $optclass:ident.$optname:ident = $val:expr ),* ], $( $md:literal )+, $amt:tt) => {
-        crate::tests::assert_ast_match_i(
+        $crate::tests::assert_ast_match_i(
             concat!( $( $md ),+ ),
-            ast!($amt),
+            $crate::tests::ast!($amt),
             |#[allow(unused_variables)] opts| {$(opts.$optclass.$optname = $val;)*},
         );
     };
     ([ $( $optclass:ident.$optname:ident $(= $val:expr)? ),* ], $( $md:literal )+, $amt:tt) => {
-        crate::tests::assert_ast_match_i(
+        $crate::tests::assert_ast_match_i(
             concat!( $( $md ),+ ),
-            ast!($amt),
-            |#[allow(unused_variables)] opts| { $( assert_ast_match_set_opt_single!(opts; $optclass.$optname $(= $val)? ); )* },
+            $crate::tests::ast!($amt),
+            |#[allow(unused_variables)] opts| { $( $crate::tests::assert_ast_match_set_opt_single!(opts; $optclass.$optname $(= $val)? ); )* },
         );
     };
     ([ $( $optclass:ident.$optname:ident ),* ], $( $md:literal )+, $amt:tt) => {
-        assert_ast_match!(
+        $crate::tests::assert_ast_match!(
             [ $( $optclass.$optname  = true),* ],
             $( $md )+,
             $amt
@@ -373,6 +387,8 @@ struct AstMatchTree {
 enum AstMatchContent {
     Text(String),
     Children(Vec<AstMatchTree>),
+    #[cfg(feature = "attributes")]
+    Attributes(Attributes),
 }
 
 impl AstMatchTree {
@@ -384,6 +400,8 @@ impl AstMatchTree {
 
         let mut asserted_text = false;
         let mut asserted_children = false;
+        #[cfg(feature = "attributes")]
+        let mut asserted_attributes = false;
 
         for m in &self.matches {
             match m {
@@ -455,12 +473,23 @@ impl AstMatchTree {
                     }
                     asserted_children = true;
                 }
+                #[cfg(feature = "attributes")]
+                AstMatchContent::Attributes(attrs) => {
+                    assert!(ast.attrs.is_some());
+                    assert_eq!(attrs, &**ast.attrs.as_ref().unwrap());
+                    asserted_attributes = true;
+                }
             }
         }
 
         assert!(
             asserted_children || node.children().count() == 0,
             "children were not asserted"
+        );
+        #[cfg(feature = "attributes")]
+        assert!(
+            asserted_attributes || ast.attrs.is_none(),
+            "attributes were not asserted"
         );
         assert!(
             asserted_text

--- a/src/tests/attributes.rs
+++ b/src/tests/attributes.rs
@@ -33,4 +33,15 @@ fn heading_with_attrs() {
             ])
         ])
     );
+
+    assert_ast_match!(
+        [extension.header_attributes],
+        "Yeww {x=y x=y #a #b}\n"
+        "====================\n",
+        (document (1:1-2:20) [
+            (heading (1:1-2:20) {#b x="y" x="y"} [
+                (text (1:1-1:4) "Yeww")
+            ])
+        ])
+    );
 }

--- a/src/tests/attributes.rs
+++ b/src/tests/attributes.rs
@@ -101,3 +101,34 @@ fn inline_code_with_attrs() {
         ])
     );
 }
+
+#[test]
+fn links_and_images_with_attrs() {
+    assert_ast_match!(
+        [extension.link_attributes],
+        "Incredible [Jhin](game){lies=true}.\n",
+        (document (1:1-1:35) [
+            (paragraph (1:1-1:35) [
+                (text (1:1-1:11) "Incredible ")
+                (link (1:12-1:34) {lies="true"} "game" [
+                    (text (1:13-1:16) "Jhin")
+                ])
+                (text (1:35-1:35) ".")
+            ])
+        ])
+    );
+
+    assert_ast_match!(
+        [extension.link_attributes],
+        "Incredible ![Jhin](game){lies=true}.\n",
+        (document (1:1-1:36) [
+            (paragraph (1:1-1:36) [
+                (text (1:1-1:11) "Incredible ")
+                (image (1:12-1:35) {lies="true"} "game" [
+                    (text (1:14-1:17) "Jhin")
+                ])
+                (text (1:36-1:36) ".")
+            ])
+        ])
+    );
+}

--- a/src/tests/attributes.rs
+++ b/src/tests/attributes.rs
@@ -8,7 +8,7 @@ fn heading_with_attrs() {
         [extension.header_attributes],
         "# Hi! {#greeting}\n",
         (document (1:1-1:17) [
-            (heading (1:1-1:17) {"#greeting"} [
+            (heading (1:1-1:17) {#greeting} [
                 (text (1:3-1:5) "Hi!")
             ])
         ])
@@ -16,9 +16,9 @@ fn heading_with_attrs() {
 
     assert_ast_match!(
         [extension.header_attributes],
-        "## Yeww {yeww=\"\\\"true\\\"\"} ##\n",
-        (document (1:1-1:28) [
-            (heading (1:1-1:28) {"yeww=\"true\""} [
+        "## Yeww {.ok yeww=\"\\\"true\\\"\"} ##\n",
+        (document (1:1-1:32) [
+            (heading (1:1-1:32) {.ok yeww="\"true\""} [
                 (text (1:4-1:7) "Yeww")
             ])
         ])

--- a/src/tests/attributes.rs
+++ b/src/tests/attributes.rs
@@ -13,4 +13,14 @@ fn heading_with_attrs() {
             ])
         ])
     );
+
+    assert_ast_match!(
+        [extension.header_attributes],
+        "## Yeww {yeww=\"\\\"true\\\"\"} ##\n",
+        (document (1:1-1:28) [
+            (heading (1:1-1:28) {"yeww=\"true\""} [
+                (text (1:4-1:7) "Yeww")
+            ])
+        ])
+    );
 }

--- a/src/tests/attributes.rs
+++ b/src/tests/attributes.rs
@@ -45,3 +45,16 @@ fn heading_with_attrs() {
         ])
     );
 }
+
+#[test]
+fn fenced_code_with_attrs() {
+    assert_ast_match!(
+        [extension.header_attributes],
+        "```rust {#example}\n"
+        "const fn dogs() -> { yay }\n"
+        "```\n",
+        (document (1:1-3:3) [
+            (code_block (1:1-3:3) info:"rust" {#example} "const fn dogs() -> { yay }\n")
+        ])
+    );
+}

--- a/src/tests/attributes.rs
+++ b/src/tests/attributes.rs
@@ -49,12 +49,41 @@ fn heading_with_attrs() {
 #[test]
 fn fenced_code_with_attrs() {
     assert_ast_match!(
-        [extension.header_attributes],
+        [extension.fenced_code_attributes],
         "```rust {#example}\n"
-        "const fn dogs() -> { yay }\n"
+        "const fn dogs() -> ! { yay }\n"
         "```\n",
         (document (1:1-3:3) [
-            (code_block (1:1-3:3) info:"rust" {#example} "const fn dogs() -> { yay }\n")
+            (code_block (1:1-3:3) info:"rust" {#example} "const fn dogs() -> ! { yay }\n")
+        ])
+    );
+
+    // Pandoc does some weird language/first-class interpretative dance,
+    // but I'm not yet convinced I want to do that. Let the formatter decide.
+    assert_ast_match!(
+        [extension.fenced_code_attributes],
+        "```{.zig #truism}\n"
+        "fn cats() noreturn { yay_too }\n"
+        "```\n",
+        (document (1:1-3:3) [
+            (code_block (1:1-3:3) info:"" {#truism .zig} "fn cats() noreturn { yay_too }\n")
+        ])
+    );
+}
+
+#[test]
+fn inline_code_with_attrs() {
+    assert_ast_match!(
+        [extension.inline_code_attributes],
+        "Uhh `totally`{yea=so} hm.",
+        (document (1:1-1:25) [
+            (paragraph (1:1-1:25) [
+                (text (1:1-1:4) "Uhh ")
+                // There's probably someone out there depending on sourcepos not being this way.
+                // But then again, if they enable attributes, it's on them!
+                (code (1:5-1:21) {yea="so"} "totally")
+                (text (1:22-1:25) " hm.")
+            ])
         ])
     );
 }

--- a/src/tests/attributes.rs
+++ b/src/tests/attributes.rs
@@ -86,4 +86,18 @@ fn inline_code_with_attrs() {
             ])
         ])
     );
+
+    // "Bart, can we stop for newlines?"
+    // "I don't see why not."
+    assert_ast_match!(
+        [extension.inline_code_attributes],
+        "`T1 Faker`{role=mid\n"
+        "  kda=\"0/0/0\"\n"
+        "  cs=120}\n",
+        (document (1:1-3:9) [
+            (paragraph (1:1-3:9) [
+                (code (1:1-3:9) {role="mid" kda="0/0/0" cs="120"} "T1 Faker")
+            ])
+        ])
+    );
 }

--- a/src/tests/attributes.rs
+++ b/src/tests/attributes.rs
@@ -23,4 +23,14 @@ fn heading_with_attrs() {
             ])
         ])
     );
+
+    assert_ast_match!(
+        [extension.header_attributes],
+        "## Yeww ## {x=y x=y #a #b}\n",
+        (document (1:1-1:26) [
+            (heading (1:1-1:26) {#b x="y" x="y"} [
+                (text (1:4-1:10) "Yeww ##")
+            ])
+        ])
+    );
 }

--- a/src/tests/attributes.rs
+++ b/src/tests/attributes.rs
@@ -1,0 +1,16 @@
+#![cfg(feature = "attributes")]
+
+use crate::tests::assert_ast_match;
+
+#[test]
+fn heading_with_attrs() {
+    assert_ast_match!(
+        [extension.header_attributes],
+        "# Hi! {#greeting}\n",
+        (document (1:1-1:17) [
+            (heading (1:1-1:17) {"#greeting"} [
+                (text (1:3-1:5) "Hi!")
+            ])
+        ])
+    );
+}

--- a/src/tests/math.rs
+++ b/src/tests/math.rs
@@ -157,7 +157,7 @@ fn sourcepos() {
             (paragraph (3:1-5:2) [
                 (math (3:1-5:2) "\na^2\n")
             ])
-            (code_block (7:1-9:3) "b^2\n")
+            (code_block (7:1-9:3) info:"math" "b^2\n")
         ])
     );
 }


### PR DESCRIPTION
I'm calling full "generic attributes" [per Pandoc](https://pandoc.org/MANUAL.html#extension-attributes) out of scope for this spike, as well as adding these to any renderers (!) — there's too many possible ways one could want to do it, so for now I'm going to leave it entirely up to custom formatters.

Likewise, if anyone badly wants attributes on any particular syntax element that doesn't yet support it, well, there's a very nice and proven way to do it in this PR :)

Closes #586.

* [x] header parse
* [x] code block parse
* [x] code span parse
* [x] link/image parse
* [x] reverse parse heuristic -> state machine
* [~] generic parse
* [~] CommonMark render
* [~] HTML render
* [~] XML render