### PR TITLE
cm: correct ol marker when exiting.

### DIFF
--- a/src/cm.rs
+++ b/src/cm.rs
@@ -584,8 +584,10 @@ impl<'a, 'o, 'c, 'w> CommonMarkFormatter<'a, 'o, 'c, 'w> {
                 let list_number = *last_stack;
                 if entering {
                     *last_stack += 1;
-                };
-                list_number
+                    list_number
+                } else {
+                    list_number - 1
+                }
             } else {
                 match node.data().value {
                     NodeValue::Item(ref ni) => ni.start,

--- a/src/tests/commonmark.rs
+++ b/src/tests/commonmark.rs
@@ -158,3 +158,8 @@ fn dont_wrap_table_cell() {
     options.render.width = 80;
     commonmark(input, input, Some(&options));
 }
+
+#[test]
+fn ol_marker_wonk() {
+    commonmark(">9)\r\u{b}", "> 9) \n\n&#11;\n", None);
+}


### PR DESCRIPTION
Should be based on previous; over-truncates from prefix when going from 9 to 10.