### PR TITLE
Support Obsidian wikilink embeds (`![[target]]`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ Behind the scenes:
 
 -->
 
+# [Unreleased]
+
+Parser changes:
+
+* Wikilink embeds (`![[target]]`) are now recognised when a wikilinks extension is enabled, matching Obsidian's embed syntax.
+
+Changed APIs:
+
+* `NodeWikiLink` gained an `embed` field indicating whether the wikilink was written as an embed (`![[target]]`). Embeds are rendered as images in HTML output (respecting `image_url_rewriter`) and round-trip through the CommonMark and XML formatters.
+
+
 # [v0.54.0] - 2026-07-12
 
 Changed APIs:

--- a/src/cm.rs
+++ b/src/cm.rs
@@ -1013,6 +1013,9 @@ impl<'a, 'o, 'c, 'w> CommonMarkFormatter<'a, 'o, 'c, 'w> {
 
     fn format_wikilink(&mut self, nl: &NodeWikiLink, entering: bool) -> fmt::Result {
         if entering {
+            if nl.embed {
+                write!(self, "!")?;
+            }
             write!(self, "[[")?;
             if self.options.extension.wikilinks() == Some(WikiLinksMode::UrlFirst) {
                 self.output(&nl.url, false, Escaping::Url)?;

--- a/src/html.rs
+++ b/src/html.rs
@@ -1605,6 +1605,31 @@ fn render_wiki_link<T>(
     entering: bool,
     nwl: &NodeWikiLink,
 ) -> Result<ChildRendering, fmt::Error> {
+    if nwl.embed {
+        // An embed (`![[target]]`) is rendered as an image, mirroring how
+        // Obsidian embeds image targets. The wikilink label becomes the alt
+        // text, so the children are rendered as plain text.
+        if entering {
+            context.write_str("<img")?;
+            render_sourcepos(context, node)?;
+            context.write_str(" src=\"")?;
+            let url = &nwl.url;
+            if context.options.render.r#unsafe || !dangerous_url(url) {
+                if let Some(rewriter) = &context.options.extension.image_url_rewriter {
+                    context.escape_href(&rewriter.to_html(url))?;
+                } else {
+                    context.escape_href(url)?;
+                }
+            }
+            context.write_str("\" data-wikilink=\"true\" alt=\"")?;
+            return Ok(ChildRendering::Plain);
+        } else {
+            context.write_str("\" />")?;
+        }
+
+        return Ok(ChildRendering::HTML);
+    }
+
     if entering {
         context.write_str("<a")?;
         render_sourcepos(context, node)?;

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -352,6 +352,12 @@ pub struct NodeLink {
 pub struct NodeWikiLink {
     /// The URL for the link destination.
     pub url: String,
+
+    /// Whether the wikilink is an embed, i.e. it was written with a leading
+    /// `!` (`![[target]]`) as used by Obsidian to embed the target rather than
+    /// link to it. Consumers can inspect this flag to decide how the target
+    /// should be rendered (for example, an image, a transcluded note, and so on).
+    pub embed: bool,
 }
 
 /// The metadata of a list; the kind of list, the delimiter used and so on.

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -291,7 +291,7 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
                     && !self.within_brackets
                     && self.peek_byte() == Some(b'[')
                 {
-                    wikilink_inl = self.handle_wikilink();
+                    wikilink_inl = self.handle_wikilink(false);
                 }
 
                 if wikilink_inl.is_none() {
@@ -314,7 +314,25 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
             }
             b'!' => {
                 self.scanner.pos += 1;
-                if self.peek_byte() == Some(b'[') && self.peek_byte_n(1) != Some(b'^') {
+                let after_bang = self.scanner.pos;
+
+                let mut wikilink_inl = None;
+
+                if self.options.extension.wikilinks().is_some()
+                    && !self.within_brackets
+                    && self.peek_byte() == Some(b'[')
+                    && self.peek_byte_n(1) == Some(b'[')
+                {
+                    self.scanner.pos += 1;
+                    wikilink_inl = self.handle_wikilink(true);
+                    if wikilink_inl.is_none() {
+                        self.scanner.pos = after_bang;
+                    }
+                }
+
+                if wikilink_inl.is_some() {
+                    wikilink_inl
+                } else if self.peek_byte() == Some(b'[') && self.peek_byte_n(1) != Some(b'^') {
                     self.scanner.pos += 1;
                     let inl = self.make_inline(
                         NodeValue::Text("![".into()),
@@ -931,7 +949,9 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
     // Handles wikilink syntax
     //   [[link text|url]]
     //   [[url|link text]]
-    fn handle_wikilink(&mut self) -> Option<Node<'a>> {
+    // When `embed` is true the wikilink was preceded by a `!` (`![[target]]`),
+    // and the opening bang is included in the resulting node's source position.
+    fn handle_wikilink(&mut self, embed: bool) -> Option<Node<'a>> {
         let startpos = self.scanner.pos;
         let component = self.wikilink_url_link_label()?;
         let url_clean = strings::clean_url(&component.url);
@@ -947,8 +967,15 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
 
         let nl = NodeWikiLink {
             url: url_clean.into(),
+            embed,
         };
-        let inl = self.make_inline(NodeValue::WikiLink(nl), startpos - 1, self.scanner.pos - 1);
+        // For an embed the node starts one byte earlier, at the leading `!`.
+        let start_offset = if embed { 2 } else { 1 };
+        let inl = self.make_inline(
+            NodeValue::WikiLink(nl),
+            startpos - start_offset,
+            self.scanner.pos - 1,
+        );
 
         self.label_backslash_escapes(inl, &link_label, link_label_start_column);
 

--- a/src/parser/options.rs
+++ b/src/parser/options.rs
@@ -384,12 +384,20 @@ pub struct Extension<'c> {
     ///
     /// [0]: Self::wikilinks_title_before_pipe
     ///
+    /// A wikilink prefixed with `!` is treated as an embed (`![[url]]`), as used
+    /// by Obsidian. Embeds set [`NodeWikiLink::embed`][1] and are rendered as
+    /// images in HTML output.
+    ///
+    /// [1]: crate::nodes::NodeWikiLink::embed
+    ///
     /// ```rust
     /// # use comrak::{markdown_to_html, Options};
     /// let mut options = Options::default();
     /// options.extension.wikilinks_title_after_pipe = true;
     /// assert_eq!(markdown_to_html("[[url|link label]]", &options),
     ///            "<p><a href=\"url\" data-wikilink=\"true\">link label</a></p>\n");
+    /// assert_eq!(markdown_to_html("![[image.jpg]]", &options),
+    ///            "<p><img src=\"image.jpg\" data-wikilink=\"true\" alt=\"image.jpg\" /></p>\n");
     /// ```
     #[cfg_attr(feature = "bon", builder(default))]
     pub wikilinks_title_after_pipe: bool,

--- a/src/tests/wikilinks.rs
+++ b/src/tests/wikilinks.rs
@@ -248,3 +248,102 @@ fn sourcepos() {
         ])
     );
 }
+
+#[test]
+fn wikilinks_embed_renders_as_image() {
+    // An embed (`![[...]]`) becomes an image, with the label used as alt text.
+    html_opts!(
+        [extension.wikilinks_title_after_pipe],
+        "an ![[fido.jpg]] here",
+        "<p>an <img src=\"fido.jpg\" data-wikilink=\"true\" alt=\"fido.jpg\" /> here</p>\n",
+    );
+
+    html_opts!(
+        [extension.wikilinks_title_after_pipe],
+        "![[fido.jpg|a good dog]]",
+        "<p><img src=\"fido.jpg\" data-wikilink=\"true\" alt=\"a good dog\" /></p>\n",
+    );
+
+    html_opts!(
+        [extension.wikilinks_title_before_pipe],
+        "![[a good dog|fido.jpg]]",
+        "<p><img src=\"fido.jpg\" data-wikilink=\"true\" alt=\"a good dog\" /></p>\n",
+    );
+}
+
+#[test]
+fn wikilinks_without_bang_is_still_a_link() {
+    // Regression: an ordinary wikilink (no leading `!`) keeps rendering as a link.
+    html_opts!(
+        [extension.wikilinks_title_after_pipe],
+        "[[fido.jpg]]",
+        "<p><a href=\"fido.jpg\" data-wikilink=\"true\">fido.jpg</a></p>\n",
+    );
+}
+
+#[test]
+fn wikilinks_embed_needs_the_extension() {
+    // Regression: without the extension, `![[...]]` is not treated as an embed.
+    html("![[fido.jpg]]", "<p>![[fido.jpg]]</p>\n");
+}
+
+#[test]
+fn wikilinks_embed_uses_image_url_rewriter() {
+    html_opts_i(
+        "![[bad.png]]",
+        "<p><img src=\"https://safe.example.com?url=bad.png\" data-wikilink=\"true\" alt=\"bad.png\" /></p>\n",
+        true,
+        |opts| {
+            opts.extension.wikilinks_title_after_pipe = true;
+            opts.extension.image_url_rewriter = Some(std::sync::Arc::new(|url: &str| {
+                format!("{}{}", "https://safe.example.com?url=", url)
+            }));
+        },
+    );
+}
+
+#[test]
+fn wikilinks_embed_sanitizes_the_src_attribute() {
+    html_opts!(
+        [extension.wikilinks_title_after_pipe],
+        "![[javascript:alert(0)]]",
+        "<p><img src=\"\" data-wikilink=\"true\" alt=\"javascript:alert(0)\" /></p>\n",
+        no_roundtrip,
+    );
+}
+
+#[test]
+fn wikilinks_embed_xml_has_embed_attribute() {
+    xml_opts(
+        "![[fido.jpg|a good dog]]\n",
+        concat!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+            "<!DOCTYPE document SYSTEM \"CommonMark.dtd\">\n",
+            "<document xmlns=\"http://commonmark.org/xml/1.0\">\n",
+            "  <paragraph>\n",
+            "    <wikilink destination=\"fido.jpg\" embed=\"true\">\n",
+            "      <text xml:space=\"preserve\">a good dog</text>\n",
+            "    </wikilink>\n",
+            "  </paragraph>\n",
+            "</document>\n",
+        ),
+        |opts| opts.extension.wikilinks_title_after_pipe = true,
+    );
+}
+
+#[test]
+fn wikilinks_embed_sourcepos_includes_bang() {
+    assert_ast_match!(
+        [extension.wikilinks_title_after_pipe],
+        "a ![[fido.jpg]] b\n",
+        (document (1:1-1:17) [
+            (paragraph (1:1-1:17) [
+                (text (1:1-1:2) "a ")
+                (wikilink (1:3-1:15) [
+                    (text (1:6-1:13) "fido.jpg")
+                ])
+                (text (1:16-1:17) " b")
+            ])
+        ])
+    );
+}

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -309,6 +309,9 @@ impl<'o, 'c> XmlFormatter<'o, 'c> {
                     self.output.write_str(" destination=\"")?;
                     self.escape(&nl.url)?;
                     self.output.write_str("\"")?;
+                    if nl.embed {
+                        self.output.write_str(" embed=\"true\"")?;
+                    }
                 }
                 NodeValue::Underline => {}
                 NodeValue::Subscript => {}


### PR DESCRIPTION
Closes #535.

Wikilinks written with a leading `!` (Obsidian's embed syntax, `![[target]]`) previously weren't recognised: the `!` was consumed as an ordinary image marker, so no wikilink node was produced. This adds support for parsing them as embeds when a wikilinks extension is enabled.

Following the discussion on #535, the parsing surface is the important part — `NodeWikiLink` now carries an `embed: bool` so downstream consumers can tell embeds apart and decide how to handle the target (image, transcluded note, canvas, etc.). Since the issue is specifically about image embeds and you pointed at `image_url_rewriter`, embeds also render as images out of the box.

### What's included

- **Parsing:** `![[target]]` is parsed as a wikilink with `embed = true` (both `wikilinks_title_after_pipe` and `wikilinks_title_before_pipe` modes). Plain `[[target]]` keeps `embed = false`. The source position includes the leading `!`. If the `![[…` doesn't form a valid wikilink, it falls back to the previous image-marker behaviour.
- **`NodeWikiLink::embed`:** new field, defaults to `false`.
- **HTML:** embeds render as `<img src="…" data-wikilink="true" alt="…" />`, with the label as alt text and `image_url_rewriter` applied to the URL (mirroring `render_image`). Dangerous URLs are sanitised just like images. Non-embed wikilinks are byte-for-byte unchanged.
- **XML:** embeds get an `embed="true"` attribute.
- **CommonMark round-trip:** embeds are re-emitted with the leading `!`.
- **Docs:** the `wikilinks_title_after_pipe` option gains a note + doctest for embeds.

### Tests

Added to `src/tests/wikilinks.rs`: HTML rendering for both pipe modes, `image_url_rewriter` interaction, URL sanitisation, the XML `embed` attribute, source positions, and regressions confirming that `[[target]]` still renders as a link and that `![[…]]` is inert without the extension. Full suite (`cargo test`) and `cargo fmt --check` pass; no new clippy warnings.