### PR TITLE
autolink: three cmark-gfm parity fixes

### DIFF
--- a/src/parser/autolink.rs
+++ b/src/parser/autolink.rs
@@ -427,13 +427,29 @@ pub fn url_match<'a>(
 
     if !relaxed_autolinks {
         let scheme = &subject.input[i - rewind..i];
-        let cond = |s: &&str| size - i + rewind >= s.len() && &scheme == s;
+        // As in cmark-gfm's `sd_autolink_issafe`, the scheme is compared
+        // case-insensitively.
+        let cond = |s: &&str| size - i + rewind >= s.len() && scheme.eq_ignore_ascii_case(s);
         if !SCHEMES.iter().any(cond) {
+            return None;
+        }
+
+        // `sd_autolink_issafe` additionally requires the first character after
+        // the scheme to be a valid host character. Without this, a bare scheme
+        // such as `http://` would be autolinked now that `check_domain` allows
+        // a dot-less domain at this call site.
+        if !subject.input[i + 3..]
+            .chars()
+            .next()
+            .is_some_and(is_valid_hostchar)
+        {
             return None;
         }
     }
 
-    let mut link_end = check_domain(&subject.input[i + 3..], relaxed_autolinks)? + 3;
+    // Unlike `www_match`, a domain without a dot is allowed here; cmark-gfm
+    // calls `check_domain` with `allow_short = 1` from `url_match`.
+    let mut link_end = check_domain(&subject.input[i + 3..], true)? + 3;
 
     while link_end < size - i && !isspace(bytes[i + link_end]) {
         // basic test to detect whether we're in a normal markdown link - not exhaustive

--- a/src/parser/inlines.rs
+++ b/src/parser/inlines.rs
@@ -46,7 +46,6 @@ pub struct Subject<'a: 'd, 'r, 'o, 'd, 'c, 'p> {
     delimiter_arena: &'d typed_arena::Arena<Delimiter<'a, 'd>>,
     last_delimiter: Option<&'d Delimiter<'a, 'd>>,
     brackets: SmallVec<[Bracket<'a>; 8]>,
-    within_brackets: bool,
     pub backticks: [usize; MAXBACKTICKS + 1],
     pub scanned_for_backticks: bool,
     no_link_openers: bool,
@@ -89,7 +88,6 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
             delimiter_arena,
             last_delimiter: None,
             brackets: SmallVec::new(),
-            within_brackets: false,
             backticks: [0; MAXBACKTICKS + 1],
             scanned_for_backticks: false,
             no_link_openers: true,
@@ -288,7 +286,7 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
                 let mut wikilink_inl = None;
 
                 if self.options.extension.wikilinks().is_some()
-                    && !self.within_brackets
+                    && self.brackets.is_empty()
                     && self.peek_byte() == Some(b'[')
                 {
                     wikilink_inl = self.handle_wikilink();
@@ -301,17 +299,13 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
                         self.scanner.pos - 1,
                     );
                     self.push_bracket(false, inl);
-                    self.within_brackets = true;
 
                     Some(inl)
                 } else {
                     wikilink_inl
                 }
             }
-            b']' => {
-                self.within_brackets = false;
-                self.handle_close_bracket(&ast.line_offsets)
-            }
+            b']' => self.handle_close_bracket(&ast.line_offsets),
             b'!' => {
                 self.scanner.pos += 1;
                 if self.peek_byte() == Some(b'[') && self.peek_byte_n(1) != Some(b'^') {
@@ -322,7 +316,6 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
                         self.scanner.pos - 1,
                     );
                     self.push_bracket(true, inl);
-                    self.within_brackets = true;
                     Some(inl)
                 } else {
                     Some(self.make_inline(
@@ -343,7 +336,7 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
                     && self.peek_byte_n(1) == Some(b'[')
                 {
                     self.handle_inline_footnote()
-                } else if self.options.extension.superscript && !self.within_brackets {
+                } else if self.options.extension.superscript && self.brackets.is_empty() {
                     Some(self.handle_delim(b'^'))
                 } else {
                     // Just regular text
@@ -695,7 +688,11 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
         node: Node<'a>,
         f: fn(&mut Subject<'a, '_, '_, '_, '_, '_>) -> Option<(Node<'a>, usize, usize)>,
     ) -> Option<Node<'a>> {
-        if !self.options.parse.relaxed_autolinks && self.within_brackets {
+        // As in cmark-gfm, the autolink extension refuses to match anywhere
+        // inside an open bracket. Consult the bracket stack itself: a flag
+        // cleared on any `]` would allow an autolink to run through an
+        // enclosing link when an inner `]` appears first.
+        if !self.options.parse.relaxed_autolinks && !self.brackets.is_empty() {
             return None;
         }
         let startpos = self.scanner.pos;
@@ -2089,7 +2086,7 @@ impl<'a, 'r, 'o, 'd, 'c, 'p> Subject<'a, 'r, 'o, 'd, 'c, 'p> {
     }
 
     fn is_special_char(&self, value: u8) -> bool {
-        if value == b'^' && self.within_brackets {
+        if value == b'^' && !self.brackets.is_empty() {
             return false;
         }
 

--- a/src/tests/autolink.rs
+++ b/src/tests/autolink.rs
@@ -598,3 +598,88 @@ fn autolink_with_unicode_isolation() {
         "<p>\u{2068}<a href=\"https://www.example.com/\">https://www.example.com/</a>\u{2069}</p>\n",
     );
 }
+
+// As in cmark-gfm, `url_match` allows a domain without a dot; only `www_match`
+// asks for one. See <https://github.com/kivikakk/comrak/issues/832>.
+#[test]
+fn autolink_short_domain() {
+    html_opts!(
+        [extension.autolink],
+        "see http://localhost/x now",
+        "<p>see <a href=\"http://localhost/x\">http://localhost/x</a> now</p>\n",
+    );
+
+    html_opts!(
+        [extension.autolink],
+        "see http://localhost:3000/admin now",
+        "<p>see <a href=\"http://localhost:3000/admin\">http://localhost:3000/admin</a> now</p>\n",
+    );
+
+    // The URL is matched as a whole instead of falling through to the email
+    // matcher partway through.
+    html_opts!(
+        [extension.autolink],
+        "see http://user:pass@www.example.com/ now",
+        "<p>see <a href=\"http://user:pass@www.example.com/\">http://user:pass@www.example.com/</a> now</p>\n",
+    );
+
+    // A bare scheme is still not autolinked.
+    html_opts!(
+        [extension.autolink],
+        "see http:// and http://. now",
+        "<p>see http:// and http://. now</p>\n",
+    );
+}
+
+// As in cmark-gfm's `sd_autolink_issafe`, the scheme is compared
+// case-insensitively. `www.` matching stays case-sensitive. See
+// <https://github.com/kivikakk/comrak/issues/832>.
+#[test]
+fn autolink_scheme_case_insensitive() {
+    html_opts!(
+        [extension.autolink],
+        "see HTTP://www.example.com/ now",
+        "<p>see <a href=\"HTTP://www.example.com/\">HTTP://www.example.com/</a> now</p>\n",
+    );
+
+    html_opts!(
+        [extension.autolink],
+        "see Http://www.example.com/ now",
+        "<p>see <a href=\"Http://www.example.com/\">Http://www.example.com/</a> now</p>\n",
+    );
+
+    html_opts!(
+        [extension.autolink],
+        "Www.example.com",
+        "<p>Www.example.com</p>\n",
+    );
+}
+
+// cmark-gfm refuses an autolink anywhere inside an open bracket, so an inner
+// `]` no longer lets an autolink run through an enclosing link. See
+// <https://github.com/kivikakk/comrak/issues/832>.
+#[test]
+fn autolink_nested_brackets() {
+    html_opts!(
+        [extension.autolink],
+        "see [a [b] http://x.example.com/](y) now",
+        "<p>see <a href=\"y\">a [b] http://x.example.com/</a> now</p>\n",
+        no_roundtrip,
+    );
+
+    // The autolink no longer produces an `<a>` nested inside an `<a>`.
+    html_opts!(
+        [extension.autolink],
+        "see [a [b] http://x.example.com/ ](y) now",
+        "<p>see <a href=\"y\">a [b] http://x.example.com/ </a> now</p>\n",
+        no_roundtrip,
+    );
+
+    // An image in link text (e.g. a README badge) does not break the link.
+    html_opts!(
+        [extension.autolink],
+        "[![badge](b.svg) http://example.com/](http://example.com/)",
+        "<p><a href=\"http://example.com/\"><img src=\"b.svg\" alt=\"badge\" /> http://example.com/</a></p>\n",
+        no_roundtrip,
+    );
+}


### PR DESCRIPTION
With `extension.autolink` enabled, comrak diverged from cmark-gfm in three cases (#832).

`url_match` now calls `check_domain` with `allow_short = 1` as cmark-gfm does, so dot-less hosts such as `http://localhost/x` autolink again (they did through 0.43.0; the requirement of a dot dates to #618), while a new check mirroring the host-character test in `sd_autolink_issafe` keeps bare `http://` from linking; `http://user:pass@host/` is likewise matched whole instead of falling through to the email matcher.

The scheme is now compared case-insensitively, matching `sd_autolink_issafe`, so `HTTP://www.example.com/` autolinks while `www.` matching stays case-sensitive.

Finally, the autolink matchers consult the bracket stack rather than a flag cleared by any `]`, mirroring `cmark_inline_parser_in_bracket`, so an inner `]` no longer lets an autolink run through an enclosing link or produce an `<a>` nested inside an `<a>`. Fixture tests are added for each case.
